### PR TITLE
Fix/M2-1981 always available event edit fix

### DIFF
--- a/src/modules/Dashboard/features/Applet/Schedule/Calendar/Calendar.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/Calendar/Calendar.tsx
@@ -74,7 +74,11 @@ export const Calendar = () => {
 
   const onSelectEvent = (calendarEvent: CalendarEvent) => {
     setEditEventPopupVisible(true);
-    setDefaultStartDate(getDefaultStartDate(calendarEvent.start));
+    setDefaultStartDate(
+      getDefaultStartDate(
+        calendarEvent.alwaysAvailable ? calendarEvent.eventStart : calendarEvent.start,
+      ),
+    );
     setEditedEvent(calendarEvent);
   };
 


### PR DESCRIPTION
Start date of always available event after editing must correspond start date before editing.