### PR TITLE
Fix: M2-844 

### DIFF
--- a/src/modules/Dashboard/features/Applet/Schedule/Calendar/YearView/YearView.styles.ts
+++ b/src/modules/Dashboard/features/Applet/Schedule/Calendar/YearView/YearView.styles.ts
@@ -3,8 +3,11 @@ import { styled } from '@mui/material';
 import { variables, theme, StyledFlexWrap } from 'shared/styles';
 
 export const StyledYear = styled(StyledFlexWrap)`
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+
   justify-content: space-between;
   border-top: ${variables.borderWidth.md} solid ${variables.palette.surface_variant};
-  padding-top: ${theme.spacing(2.6)};
+  padding-top: ${theme.spacing(1.6)};
   overflow: auto;
 `;


### PR DESCRIPTION
Fix the "Calendar" component:
- Vertical scroll (disappear for screen sizes 1080 and 900)
- 3 columns of calendar (Since now calendar built-in 4 columns on all screens)
<img width="1393" alt="Screenshot 2023-06-28 at 20 12 00" src="https://github.com/ChildMindInstitute/mindlogger-admin/assets/45964820/ffbfa104-bdfe-4876-a3cc-76896a19dd77">
<img width="1360" alt="Screenshot 2023-06-28 at 20 11 46" src="https://github.com/ChildMindInstitute/mindlogger-admin/assets/45964820/3e73c6ec-4744-4bd4-a87c-37c4d31d8c4e">
<img width="1184" alt="Screenshot 2023-06-28 at 20 11 34" src="https://github.com/ChildMindInstitute/mindlogger-admin/assets/45964820/f0a43915-6829-49d7-ad1d-47c12585f40e">
