### PR TITLE
Fix: M2-1162 - Builder - Items: Single/Multiple Selection Per Row Item: Error message overlaps the Option/Row field

### DIFF
--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/SelectionRows/CharactersCounter/CharactersCounter.styles.ts
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/SelectionRows/CharactersCounter/CharactersCounter.styles.ts
@@ -1,0 +1,27 @@
+import { styled } from '@mui/material';
+
+import { theme } from 'shared/styles';
+import { shouldForwardProp } from 'shared/utils';
+import { StyledCounter as Counter } from 'shared/components/FormComponents/InputController/InputController.styles';
+
+export const StyledCounter = styled(Counter, shouldForwardProp)`
+  white-space: nowrap;
+
+  .shortened-counter {
+    display: none;
+  }
+
+  ${({ isShortenedVisible }: { isShortenedVisible?: boolean }) =>
+    isShortenedVisible &&
+    `
+    ${theme.breakpoints.down('xl')} {
+      .shortened-counter {
+        display: inline;
+       }
+    
+      .primary-counter {
+        display: none;
+      }
+    }
+  `}
+`;

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/SelectionRows/CharactersCounter/CharactersCounter.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/SelectionRows/CharactersCounter/CharactersCounter.tsx
@@ -1,0 +1,22 @@
+import { PropsWithChildren } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { StyledCounter } from './CharactersCounter.styles';
+import { CharactersCounterProps } from './CharactersCounter.types';
+
+export const CharactersCounter = ({
+  value,
+  maxLength,
+  counterProps,
+  children,
+}: PropsWithChildren<CharactersCounterProps>) => {
+  const { t } = useTranslation('app');
+  const shortenedText = `${value}/${maxLength} ${t('chars')}`;
+
+  return (
+    <StyledCounter isShortenedVisible={counterProps?.isShortenedVisible}>
+      <span className="primary-counter">{children}</span>
+      <span className="shortened-counter">{shortenedText}</span>
+    </StyledCounter>
+  );
+};

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/SelectionRows/CharactersCounter/CharactersCounter.types.ts
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/SelectionRows/CharactersCounter/CharactersCounter.types.ts
@@ -1,0 +1,5 @@
+export type CharactersCounterProps = {
+  value: number;
+  maxLength?: number;
+  counterProps?: { isShortenedVisible?: boolean };
+};

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/SelectionRows/CharactersCounter/index.ts
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/SelectionRows/CharactersCounter/index.ts
@@ -1,0 +1,1 @@
+export * from './CharactersCounter';

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/SelectionRows/Items/Items.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/SelectionRows/Items/Items.tsx
@@ -20,6 +20,7 @@ import {
   StyledRemoveItemButton,
 } from './Items.styles';
 import { ItemsProps } from './Items.types';
+import { CharactersCounter } from '../CharactersCounter';
 import { StyledSelectionBox } from '../SelectionRows.styles';
 import { ItemConfigurationSettings } from '../../../ItemConfiguration.types';
 import { SELECTION_ROW_OPTION_LABEL_MAX_LENGTH } from '../../../ItemConfiguration.const';
@@ -46,6 +47,7 @@ export const Items = ({ name, isSingle }: ItemsProps) => {
   const hasScores = get(settings, ItemConfigurationSettings.HasScores);
   const hasAlerts = get(settings, ItemConfigurationSettings.HasAlerts);
   const hasRemoveButton = rows?.length > 1;
+  const hasShortenedHelper = options?.length === 3;
 
   const handleRemoveItem = (index: number) => {
     if (hasAlerts) {
@@ -78,7 +80,7 @@ export const Items = ({ name, isSingle }: ItemsProps) => {
 
     return (
       <StyledSelectionRowItem key={`row-${row.id}`} hasTooltips={hasTooltips}>
-        <StyledSelectionBox>
+        <StyledSelectionBox isErrorShortened={hasShortenedHelper}>
           <StyledFlexTopStart sx={{ gap: '1.2rem' }}>
             <Uploader
               {...commonUploaderProps}
@@ -91,6 +93,8 @@ export const Items = ({ name, isSingle }: ItemsProps) => {
               label={t('selectionRowsItemLabel', { index: index + 1 })}
               maxLength={SELECTION_ROW_OPTION_LABEL_MAX_LENGTH}
               restrictExceededValueLength
+              Counter={CharactersCounter}
+              counterProps={{ isShortenedVisible: hasShortenedHelper }}
             />
           </StyledFlexTopStart>
           {hasTooltips && (

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/SelectionRows/Options/Options.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/SelectionRows/Options/Options.tsx
@@ -10,6 +10,7 @@ import { SingleAndMultipleSelectOption } from 'shared/state';
 import { StyledSelectionRow, StyledSelectionBox } from '../SelectionRows.styles';
 import { ItemConfigurationSettings } from '../../../ItemConfiguration.types';
 import { SELECTION_ROW_OPTION_LABEL_MAX_LENGTH } from '../../../ItemConfiguration.const';
+import { CharactersCounter } from '../CharactersCounter';
 
 const commonUploaderProps = {
   width: 5.6,
@@ -27,6 +28,7 @@ export const Options = ({ name }: { name: string }) => {
   const settings = watch(`${name}.config`);
 
   const hasTooltips = get(settings, ItemConfigurationSettings.HasTooltips);
+  const hasShortenedHelper = options?.length === 3;
 
   return (
     <StyledSelectionRow hasTooltips={hasTooltips}>
@@ -35,7 +37,7 @@ export const Options = ({ name }: { name: string }) => {
         const optionName = `${optionsName}.${index}`;
 
         return (
-          <StyledSelectionBox key={`option-${option.id}`}>
+          <StyledSelectionBox key={`option-${option.id}`} isErrorShortened={hasShortenedHelper}>
             <StyledFlexTopStart sx={{ gap: '1.2rem' }}>
               <Uploader
                 {...commonUploaderProps}
@@ -48,6 +50,8 @@ export const Options = ({ name }: { name: string }) => {
                 label={t('selectionRowsOptionLabel', { index: index + 1 })}
                 maxLength={SELECTION_ROW_OPTION_LABEL_MAX_LENGTH}
                 restrictExceededValueLength
+                Counter={CharactersCounter}
+                counterProps={{ isShortenedVisible: hasShortenedHelper }}
               />
             </StyledFlexTopStart>
             {hasTooltips && (

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/SelectionRows/SelectionRows.styles.ts
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/SelectionRows/SelectionRows.styles.ts
@@ -18,7 +18,7 @@ export const StyledSelectionRow = styled(StyledFlexTopCenter, shouldForwardProp)
   align-items: stretch;
 `;
 
-export const StyledSelectionBox = styled(StyledFlexColumn)`
+export const StyledSelectionBox = styled(StyledFlexColumn, shouldForwardProp)`
   position: relative;
   flex: 1 1;
   justify-content: space-between;
@@ -43,6 +43,15 @@ export const StyledSelectionBox = styled(StyledFlexColumn)`
     bottom: unset;
     white-space: normal;
     font-size: ${variables.font.size.md};
+
+    ${({ isErrorShortened }: { isErrorShortened?: boolean }) =>
+      isErrorShortened &&
+      `
+        ${theme.breakpoints.down('xl')} {
+          white-space: nowrap;
+          right: 0;
+        }
+    `}
   }
 `;
 

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -411,6 +411,7 @@
   "appletImg": "Applet Image",
   "appletWatermark": "Applet Watermark",
   "characters": "characters",
+  "chars": "chars.",
   "default": "Default",
   "dropImage": "Drop Image here or <1>click to browse</1>.",
   "dropError": "Image is more than <br /> {{size}}.",

--- a/src/shared/components/FormComponents/InputController/InputController.tsx
+++ b/src/shared/components/FormComponents/InputController/InputController.tsx
@@ -34,6 +34,8 @@ export const InputController = <T extends FieldValues>({
   isEmptyStringAllowed = false,
   isErrorVisible = true,
   restrictExceededValueLength = false,
+  Counter = StyledCounter,
+  counterProps,
   ...textFieldProps
 }: InputControllerProps<T>) => {
   const { t } = useTranslation('app');
@@ -115,9 +117,13 @@ export const InputController = <T extends FieldValues>({
                 }
               />
               {maxLength && !error && (
-                <StyledCounter>
+                <Counter
+                  value={value?.length || 0}
+                  maxLength={maxLength}
+                  counterProps={counterProps}
+                >
                   {value?.length || 0}/{maxLength} {t('characters')}
-                </StyledCounter>
+                </Counter>
               )}
             </StyledTextFieldContainer>
           </Tooltip>

--- a/src/shared/components/FormComponents/InputController/InputController.types.ts
+++ b/src/shared/components/FormComponents/InputController/InputController.types.ts
@@ -1,5 +1,12 @@
+import { FC, ReactNode, PropsWithChildren } from 'react';
 import { TextFieldProps } from '@mui/material/TextField';
 import { FieldValues, UseControllerProps } from 'react-hook-form';
+
+type CounterProps = {
+  value: number;
+  maxLength?: number;
+  counterProps?: Record<string, unknown>;
+};
 
 type FormInputProps = {
   textAdornment?: string;
@@ -12,6 +19,8 @@ type FormInputProps = {
   restrictExceededValueLength?: boolean;
   onAddNumber?: (value: number) => void;
   onDistractNumber?: (value: number) => void;
+  Counter?: FC<PropsWithChildren<CounterProps>>;
+  counterProps?: Record<string, unknown>;
 } & TextFieldProps;
 
 export type InputControllerProps<T extends FieldValues> = FormInputProps & UseControllerProps<T>;


### PR DESCRIPTION
![image](https://github.com/ChildMindInstitute/mindlogger-admin/assets/4319881/ced4617e-60d6-48e8-936c-d45785165447)
