### PR TITLE
M2-4790: Transfer Applet Ownership functionality update

### DIFF
--- a/src/modules/Dashboard/features/Applet/TransferOwnership/TransferOwnership.tsx
+++ b/src/modules/Dashboard/features/Applet/TransferOwnership/TransferOwnership.tsx
@@ -84,8 +84,16 @@ export const TransferOwnership = forwardRef<TransferOwnershipRef, TransferOwners
             to another user?
           </StyledBodyLarge>
           <StyledBodyLarge marginTop={theme.spacing(2.4)}>
-            This will only transfer the Applet. No user data will be transferred. After the new
-            Owner confirms transfer, you will no longer have access to this Applet or its data.
+            This action will transfer all Applet settings, created Schedules, the list of
+            Respondents and Managers, as well as the data collected during the study.
+          </StyledBodyLarge>
+          <StyledBodyLarge marginTop={theme.spacing(0.4)}>
+            Once the new owner confirms the transfer, you will no longer have access to this Applet
+            or its data.
+          </StyledBodyLarge>
+          <StyledBodyLarge marginTop={theme.spacing(0.4)}>
+            However, be assured that the transfer of Applet ownership will not impact Respondents.
+            They will still be able to submit new responses.
           </StyledBodyLarge>
         </Trans>
         <StyledInputWrapper>

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -1136,7 +1136,7 @@
   "toTime": "To time",
   "touch": "CST Touch",
   "transferOwnership": "Transfer Ownership",
-  "transferOwnershipConfirmation": "<0>Are you sure you want to transfer ownership of Applet <1>{{appletName}}</1> to another user?</0><1>This will only transfer the Applet. No user data will be transferred. After the new Owner confirms transfer, you will no longer have access to this Applet or its data.</1>",
+  "transferOwnershipConfirmation": "<0>Are you sure you want to transfer ownership of Applet <1>{{appletName}}</1> to another user?</0><1>This action will transfer all Applet settings, created Schedules, the list of Respondents and Managers, as well as the data collected during the study. </1><2>Once the new owner confirms the transfer, you will no longer have access to this Applet or its data.</2> <3>However, be assured that the transfer of Applet ownership will not impact Respondents. They will still be able to submit new responses.</3>",
   "transferOwnershipHelperText": "Enter the new Owner's email address",
   "trash": "Trash",
   "true": "True",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -1136,7 +1136,7 @@
   "toTime": "À l'heure",
   "touch": "CST Touch",
   "transferOwnership": "Transférer la propriété",
-  "transferOwnershipConfirmation": "<0>Êtes-vous sûr de vouloir transférer la propriété de l'applet <1>{{appletName}}</1> à un autre utilisateur?</0><1>Cela ne transférera que l'applet. Aucune donnée utilisateur ne sera transférée. Une fois que le nouveau propriétaire aura confirmé le transfert, vous n'aurez plus accès à cette applet ni à ses données.</1>",
+  "transferOwnershipConfirmation": "<0>Êtes-vous sûr de vouloir transférer la propriété de l'applet <1>{{appletName}}</1> à un autre utilisateur ?</0><1>Cette action transférera tous les paramètres de l'Applet, les horaires créés, la liste des répondants et des gestionnaires, ainsi que les données collectées pendant l'étude. </1><2>Une fois que le nouveau propriétaire confirme le transfert, vous n'aurez plus accès à cet Applet ni à ses données.</2> <3>Cependant, soyez assuré que le transfert de la propriété de l'Applet n'aura aucun impact sur les répondants. Ils pourront toujours soumettre de nouvelles réponses.</3>",
   "transferOwnershipHelperText": "Entrez l'adresse e-mail du nouveau propriétaire",
   "trash": "Corbeille",
   "true": "Vrai",


### PR DESCRIPTION
[M2-4790](https://mindlogger.atlassian.net/jira/software/c/projects/M2/issues/M2-4790): 

Updated transfer applet ownership confirmation text and translations as per 

https://mindlogger.atlassian.net/wiki/spaces/MINDLOGGER1/pages/385777665/Transfer+Applet+Ownership+functionality+update#:~:text=1-,Wording%20Updates,-Transfer%20Ownership%20pop


<img width="601" alt="image" src="https://github.com/ChildMindInstitute/mindlogger-admin/assets/120190555/54b2f4aa-903d-4452-b0a2-b27c5b32216d">
<img width="601" alt="image" src="https://github.com/ChildMindInstitute/mindlogger-admin/assets/120190555/673c958d-f9c9-4ad3-8932-ba249dada419">
<img width="601" alt="image" src="https://github.com/ChildMindInstitute/mindlogger-admin/assets/120190555/76bd495c-2b70-4c7e-8c9f-4a46b30cf0f1">


[M2-4790]: https://mindlogger.atlassian.net/browse/M2-4790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ