### PR TITLE
M2-4626: disabling state/value selects when no item is selected in item flow condition

### DIFF
--- a/src/modules/Builder/components/ConditionRow/Condition/Condition.tsx
+++ b/src/modules/Builder/components/ConditionRow/Condition/Condition.tsx
@@ -96,6 +96,7 @@ export const Condition = ({
         customChange={onStateChange}
         isLabelNeedTranslation={false}
         data-testid={`${dataTestid}-type`}
+        disabled={!selectedItem?.type}
       />
       {isValueSelectShown && (
         <StyledSelectController
@@ -105,6 +106,7 @@ export const Condition = ({
           placeholder={t('value')}
           isLabelNeedTranslation={false}
           data-testid={`${dataTestid}-selection-value`}
+          disabled={!isItemScoreCondition && !valueOptions.length}
         />
       )}
       {isNumberValueShown && (


### PR DESCRIPTION
[M2-4626](https://mindlogger.atlassian.net/jira/software/c/projects/M2/issues/M2-4626):  disabling state/value selects when no item is selected in item flow condition

[M2-4626]: https://mindlogger.atlassian.net/browse/M2-4626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ