### PR TITLE
M2-4626: disabling state/value selects when no item is selected in item flow condition

### DIFF
--- a/src/modules/Builder/components/ConditionRow/Condition/Condition.styles.ts
+++ b/src/modules/Builder/components/ConditionRow/Condition/Condition.styles.ts
@@ -38,6 +38,7 @@ export const StyledCondition = styled(StyledFlexTopCenter)`
 
 export const StyledSelectController = styled(SelectController)`
   min-width: 10rem;
+  width: 100%;
 
   .MuiInputBase-root {
     border-radius: ${variables.borderRadius.md};

--- a/src/modules/Builder/components/ConditionRow/Condition/Condition.tsx
+++ b/src/modules/Builder/components/ConditionRow/Condition/Condition.tsx
@@ -57,6 +57,8 @@ export const Condition = ({
     state,
   });
   const [minValue, maxValue] = useWatch({ name: [minValueName, maxValueName] });
+  const isValueSelectDisabled = !isItemScoreCondition && !valueOptions.length;
+  const isStateSelectDisabled = !selectedItem?.type;
 
   const { leftRange, rightRange } = getConditionMinMaxRangeValues({
     item: selectedItem,
@@ -92,21 +94,23 @@ export const Condition = ({
         control={control}
         name={stateName}
         options={getStateOptions(selectedItem?.type)}
-        placeholder={t('conditionTypePlaceholder')}
+        placeholder={
+          isStateSelectDisabled ? t('conditionDisabledPlaceholder') : t('conditionTypePlaceholder')
+        }
         customChange={onStateChange}
         isLabelNeedTranslation={false}
         data-testid={`${dataTestid}-type`}
-        disabled={!selectedItem?.type}
+        disabled={isStateSelectDisabled}
       />
       {isValueSelectShown && (
         <StyledSelectController
           control={control}
           name={isItemScoreCondition ? numberValueName : optionValueName}
           options={isItemScoreCondition ? getScoreConditionOptions() : valueOptions}
-          placeholder={t('value')}
+          placeholder={isValueSelectDisabled ? t('conditionDisabledPlaceholder') : t('value')}
           isLabelNeedTranslation={false}
           data-testid={`${dataTestid}-selection-value`}
-          disabled={!isItemScoreCondition && !valueOptions.length}
+          disabled={isValueSelectDisabled}
         />
       )}
       {isNumberValueShown && (

--- a/src/modules/Builder/components/ConditionRow/Condition/Condition.tsx
+++ b/src/modules/Builder/components/ConditionRow/Condition/Condition.tsx
@@ -96,6 +96,7 @@ export const Condition = ({
         customChange={onStateChange}
         isLabelNeedTranslation={false}
         data-testid={`${dataTestid}-type`}
+        disabled={!selectedItem?.type}
       />
       {isValueSelectShown && (
         <StyledSelectController
@@ -105,6 +106,7 @@ export const Condition = ({
           placeholder={t('value')}
           isLabelNeedTranslation={false}
           data-testid={`${dataTestid}-selection-value`}
+          disabled={!isItemScoreCondition && !valueOptions.length}
         />
       )}
       {isNumberValueShown && (

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -256,6 +256,7 @@
   "conditionTarget": "Item",
   "conditionType": "State",
   "conditionTypePlaceholder": "State",
+  "conditionDisabledPlaceholder": "Select Item First",
   "conditionValue": "Value",
   "configure": "Configure",
   "configureServer": "Please configure the report server to download the report.",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -256,6 +256,7 @@
   "conditionTarget": "Élément",
   "conditionType": "État",
   "conditionTypePlaceholder": "État",
+  "conditionDisabledPlaceholder": "Sélectionnez d'abord un élément",
   "conditionValue": "Valeur",
   "configure": "Configurer",
   "configureServer": "Veuillez configurer le serveur de rapports pour télécharger le rapport.",

--- a/src/shared/components/FormComponents/SelectController/SelectController.styles.ts
+++ b/src/shared/components/FormComponents/SelectController/SelectController.styles.ts
@@ -29,6 +29,14 @@ export const StyledPlaceholder = styled(StyledBodyLarge)`
   left: 1.65rem;
   top: 1.4rem;
   color: ${variables.palette.outline};
+  white-space: nowrap;
+`;
+
+export const StyledPlaceholderMask = styled(StyledBodyLarge)`
+  white-space: nowrap;
+  margin-right: 5rem;
+  height: 0rem;
+  opacity: 0;
 `;
 
 export const StyledItem = styled(StyledFlexTopCenter, shouldForwardProp)`

--- a/src/shared/components/FormComponents/SelectController/SelectController.tsx
+++ b/src/shared/components/FormComponents/SelectController/SelectController.tsx
@@ -21,6 +21,7 @@ import {
   StyledMenuItem,
   selectDropdownStyles,
   StyledTextField,
+  StyledPlaceholderMask,
 } from './SelectController.styles';
 import {
   SelectControllerProps,
@@ -141,7 +142,13 @@ export const SelectController = <T extends FieldValues>({
     error?: FieldError,
   ) => (
     <Box sx={{ position: 'relative', width: '100%', ...sx }}>
-      {placeholder && !selectValue && <StyledPlaceholder>{placeholder}</StyledPlaceholder>}
+      {placeholder && !selectValue && (
+        <>
+          <StyledPlaceholderMask>{placeholder}</StyledPlaceholderMask>
+          <StyledPlaceholder>{placeholder}</StyledPlaceholder>
+        </>
+      )}
+
       <StyledTextField
         {...props}
         select


### PR DESCRIPTION
[M2-4626](https://mindlogger.atlassian.net/browse/M2-4626): disabling state/value selects when no item is selected in item flow condition

Added translations, improved SelectController component ui, as it was breaking when using longer text for placeholder

<img width="1417" alt="image" src="https://github.com/ChildMindInstitute/mindlogger-admin/assets/120190555/54d3abcf-b148-4c39-a48a-fc133fb9bece">


[M2-4626]: https://mindlogger.atlassian.net/browse/M2-4626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ