### PR TITLE
M2-4705: It is possible to set Activity description with 150+ characters length

### DIFF
--- a/src/modules/Builder/features/ActivityAbout/ActivityAbout.tsx
+++ b/src/modules/Builder/features/ActivityAbout/ActivityAbout.tsx
@@ -158,6 +158,7 @@ export const ActivityAbout = () => {
               key={`${fieldName}.name`}
               name={`${fieldName}.name`}
               maxLength={MAX_NAME_LENGTH}
+              restrictExceededValueLength
               label={t('activityName')}
               data-testid="builder-activity-about-name"
             />
@@ -167,6 +168,7 @@ export const ActivityAbout = () => {
             key={`${fieldName}.description`}
             name={`${fieldName}.description`}
             maxLength={MAX_DESCRIPTION_LENGTH}
+            restrictExceededValueLength
             label={t('activityDescription')}
             multiline
             rows={TEXTAREA_ROWS_COUNT_SM}


### PR DESCRIPTION
(https://mindlogger.atlassian.net/jira/software/c/projects/M2/issues/M2-4705): restricting user to input more characters , than permitted in activity description and name fields