### PR TITLE
M2-4966: Fix `tsc` errors

### DIFF
--- a/src/modules/Builder/pages/BuilderApplet/BuilderApplet.schema.ts
+++ b/src/modules/Builder/pages/BuilderApplet/BuilderApplet.schema.ts
@@ -235,13 +235,13 @@ export const ItemSchema = () =>
           ItemTestFunctions.ExistingNameInSystemItem,
           ({ value: itemName }) => t('validationMessages.nameExistsInSystemItems', { itemName }),
           (_, context) =>
-            testFunctionForSystemItems(context.parent, get(context, 'from.1.value.items')),
+            testFunctionForSystemItems(context.parent, get(context, 'from.1.value.items') ?? []),
         )
         .test(
           ItemTestFunctions.UniqueItemName,
           t('validationMessages.unique', { field: t('itemName') }) as string,
           (itemName, context) =>
-            testFunctionForUniqueness(itemName ?? '', get(context, 'from.1.value.items')),
+            testFunctionForUniqueness(itemName ?? '', get(context, 'from.1.value.items') ?? []),
         ),
       responseType: yup.string().required(getIsRequiredValidateMessage('itemType')),
       question: yup
@@ -487,7 +487,10 @@ export const SubscaleSchema = () =>
           'unique-subscale-name',
           t('validationMessages.unique', { field: t('subscaleName') }) as string,
           (subscaleName, context) =>
-            testFunctionForUniqueness(subscaleName ?? '', get(context, 'from.1.value.subscales')),
+            testFunctionForUniqueness(
+              subscaleName ?? '',
+              get(context, 'from.1.value.subscales') ?? [],
+            ),
         ),
       items: yup.array().min(1, t('validationMessages.atLeastOne') as string),
       scoring: yup.string(),
@@ -519,7 +522,7 @@ export const ConditionalLogicSchema = () =>
         'item-flow-contradiction',
         t('appletHasItemFlowContradictions') as string,
         (itemKey, context) => {
-          const items = get(context, 'from.1.value.items');
+          const items = get(context, 'from.1.value.items') ?? [];
           const conditions = get(context, 'parent.conditions');
           const itemIds = items?.map((item: Item) => getEntityKey(item));
           const itemIndex = itemIds?.findIndex((id: string) => id === itemKey);
@@ -570,7 +573,7 @@ export const ScoreConditionalLogic = () =>
         (scoreConditionName, context) =>
           testFunctionForUniqueness(
             scoreConditionName ?? '',
-            get(context, 'from.1.value.conditionalLogic'),
+            get(context, 'from.1.value.conditionalLogic') ?? [],
           ),
       ),
     conditions: yup
@@ -590,7 +593,7 @@ export const ScoreSchema = () => ({
       'unique-score-name',
       t('validationMessages.unique', { field: t('scoreName') }) as string,
       (scoreName, context) => {
-        const reports = get(context, 'from.1.value.reports');
+        const reports = get(context, 'from.1.value.reports') ?? [];
         const scores = reports?.filter(
           ({ type }: ScoreOrSection) => type === ScoreReportType.Score,
         );
@@ -628,7 +631,7 @@ export const SectionSchema = () => ({
       'unique-section-name',
       t('validationMessages.unique', { field: t('sectionName') }) as string,
       (sectionName, context) => {
-        const reports = get(context, 'from.1.value.reports');
+        const reports = get(context, 'from.1.value.reports') ?? [];
         const sections = reports?.filter(
           ({ type }: ScoreOrSection) => type === ScoreReportType.Section,
         );
@@ -707,7 +710,10 @@ export const ActivitySchema = () =>
         'unique-activity-name',
         t('validationMessages.unique', { field: t('activityName') }) as string,
         (activityName, context) =>
-          testFunctionForUniqueness(activityName ?? '', get(context, 'from.1.value.activities')),
+          testFunctionForUniqueness(
+            activityName ?? '',
+            get(context, 'from.1.value.activities') ?? [],
+          ),
       ),
     description: yup.string(),
     image: yup.string(),
@@ -772,7 +778,7 @@ export const ActivityFlowSchema = () =>
           (activityFlowName, context) =>
             testFunctionForUniqueness(
               activityFlowName ?? '',
-              get(context, 'from.1.value.activityFlows'),
+              get(context, 'from.1.value.activityFlows') ?? [],
             ),
         ),
       description: yup

--- a/src/modules/Builder/pages/BuilderApplet/BuilderApplet.utils.tsx
+++ b/src/modules/Builder/pages/BuilderApplet/BuilderApplet.utils.tsx
@@ -1036,7 +1036,7 @@ export const testIsReportCommonFieldsRequired = (
   context: unknown,
 ) => {
   if (isScoreReport) {
-    const conditionalLogicLength = get(context, 'from.0.value.conditionalLogic')?.length;
+    const conditionalLogicLength = (get(context, 'from.0.value.conditionalLogic') ?? [])?.length;
 
     return !!conditionalLogicLength || printItemsValue;
   }
@@ -1074,7 +1074,7 @@ export const testFunctionForTheSameVariable = (
 };
 
 export const testFunctionForNotSupportedItems = (value: string, context: yup.TestContext) => {
-  const items: Item[] = get(context, 'from.1.value.items');
+  const items: Item[] = get(context, 'from.1.value.items') ?? [];
   const variableNames = getTextBetweenBrackets(value);
   const itemsFromVariables = items.filter((item) => variableNames.includes(item.name));
 
@@ -1082,14 +1082,14 @@ export const testFunctionForNotSupportedItems = (value: string, context: yup.Tes
 };
 
 export const testFunctionForSkippedItems = (value: string, context: yup.TestContext) => {
-  const items: Item[] = get(context, 'from.1.value.items');
+  const items: Item[] = get(context, 'from.1.value.items') ?? [];
   const variableNames = getTextBetweenBrackets(value);
 
   return !items.some((item) => variableNames.includes(item.name) && item.config.skippableItem);
 };
 
 export const testFunctionForNotExistedItems = (value: string, context: yup.TestContext) => {
-  const items: Item[] = get(context, 'from.1.value.items');
+  const items: Item[] = get(context, 'from.1.value.items') ?? [];
   const variableNames = getTextBetweenBrackets(value);
 
   if (!variableNames.length) return true;
@@ -1158,7 +1158,11 @@ export const getCommonSliderValidationProps = (type: 'slider' | 'sliderRows') =>
         if (!value && value !== 0) return;
         const { maxValue } = this.parent;
 
-        return value < maxValue && value >= minNumber && value < DEFAULT_SLIDER_MAX_NUMBER;
+        return (
+          value < maxValue &&
+          (value as number) >= minNumber &&
+          (value as number) < DEFAULT_SLIDER_MAX_NUMBER
+        );
       }),
     maxValue: yup
       .mixed()
@@ -1167,7 +1171,11 @@ export const getCommonSliderValidationProps = (type: 'slider' | 'sliderRows') =>
         if (!value && value !== 0) return;
         const { minValue } = this.parent;
 
-        return value > minValue && value > minNumber && value <= DEFAULT_SLIDER_MAX_NUMBER;
+        return (
+          value > minValue &&
+          (value as number) > minNumber &&
+          (value as number) <= DEFAULT_SLIDER_MAX_NUMBER
+        );
       }),
     ...(isSlider && {
       scores: yup

--- a/src/shared/components/Uploader/Uploader.test.tsx
+++ b/src/shared/components/Uploader/Uploader.test.tsx
@@ -33,7 +33,7 @@ const uploaderProps = {
 
 describe('Uploader component', () => {
   beforeAll(() => {
-    global.URL.createObjectURL = jest.fn((file: Blob) => `mocked-url://${file.name}`);
+    global.URL.createObjectURL = jest.fn(() => 'mocked-url://mocked-url');
   });
 
   afterAll(() => {


### PR DESCRIPTION
Resolves: [M2-4966](https://mindlogger.atlassian.net/browse/M2-4966)

### Objective
In starting work on another JIRA task, I found that there were a handful of `tsc` compilation errors that were obstructing the app when running the dev server:

<img width="600" alt="Jan 25 Screenshot from M2 board" src="https://github.com/ChildMindInstitute/mindlogger-admin/assets/1282772/6a8853a6-bf94-461c-9084-d4361b29311d">

This PR cleans up those typing errors.

### Notes
One of the fixes required modifying the `createObjectURL` mock defined in the Uploader component tests, as `Blob`s do not have a `name` prop. Confirmed that tests in Uploader component still pass with a static mock URL.

### Acceptance Criteria

1. Run `yarn tsc` from the root of the project.
    **Expected result:** no errors are reported.

2. Run `yarn start` and open http://localhost:3000.
    **Expected result:** app runs without a “Compiled with problems” overlay obstructing the page.

3. Run `yarn test:nowatch src/shared/components/Uploader`.
    **Expected result:** tests pass.

[M2-4966]: https://mindlogger.atlassian.net/browse/M2-4966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ