### PR TITLE
M2-5259: [Data Export] NKI RS2 Daily Activities (New) export is failing for migrated data

### DIFF
--- a/src/modules/Dashboard/hooks/useDecryptedActivityData.ts
+++ b/src/modules/Dashboard/hooks/useDecryptedActivityData.ts
@@ -83,7 +83,9 @@ export const useDecryptedActivityData = (
       }
     }
 
-    const getAnswer = (activityItem: Item, answer: AnswerDTO): AnswerDTO => {
+    const getAnswer = (activityItem: Item, index: number): AnswerDTO => {
+      const answer = answersDecrypted[index];
+
       if (!migratedUrls) {
         return answer;
       }
@@ -112,17 +114,33 @@ export const useDecryptedActivityData = (
       return answer;
     };
 
-    const itemsObject = getObjectFromList(rest.items);
-    const answerDataDecrypted = answersDecrypted.map((answer, index) => {
-      const itemId = itemIds[index];
-      const item = itemsObject[itemId];
+    /*
+    Mapping should go through all list of items since the decrypted items MUST have the same length,
+    that means we do identify the decrypted answer with the according item and respective item type and item config.
 
-      return {
-        activityItem: item,
-        answer: getAnswer(item, answer),
-        ...rest,
-      };
-    });
+    So if a hidden item have no an answer on Mobile App or Web App
+    then Mobile/Web app should prepare `null` value for such reponses to support
+    the LEGACY/migrated responses from all respondents.
+
+    For ex.,
+    if activity items = [
+      { ...text item data },
+      { ...single selection item data },
+      { ...multi selection item data }
+    ],
+    and fist item was HIDDEN and third item was SKIPPED on Mobile/Web platform during the activity,
+    then Admin Panel expect to receive decrypted answers in this form:
+    responses = [
+      null, // index = 0, answer for text item = null;
+      { "value": 0 }, // index = 1, answer for single selection item = { "value": 0 };
+      null // index = 2, answer for multi selection item = null;
+    ]
+    */
+    const answerDataDecrypted = rest.items.map((activityItem, index) => ({
+      activityItem,
+      answer: getAnswer(activityItem, index),
+      ...rest,
+    }));
 
     return {
       decryptedAnswers: answerDataDecrypted as DecryptedActivityData<T>['decryptedAnswers'],


### PR DESCRIPTION
🔗 [M2-5259](https://mindlogger.atlassian.net/browse/M2-5259)

### 📝 Description
This changes reverts logic introduced by fixing [M2-5126](https://mindlogger.atlassian.net/browse/M2-5126). Incorrect answers were received on Admin Panel from errors in preparing and submitting answers on Web 2.5. That should be fixed in Web 2.5  [M2-5260](https://mindlogger.atlassian.net/browse/M2-5260)


**This PR changes:**
Mapping should go through all list of items since the decrypted items MUST have the same length,
that means we do identify the decrypted answer with the according item and respective item type and item config.

So if a hidden item have no an answer on Mobile App or Web App
then Mobile/Web app should prepare `null` value for such responses to support
the LEGACY/migrated responses from all respondents.

### ✏️ Notes
For ex.,
```
if activity items = [
  { ...text item data },
  { ...single selection item data },
  { ...multi selection item data }
],
```
and fist item was HIDDEN and third item was SKIPPED on Mobile/Web platform during the activity,
then Admin Panel expect to receive decrypted answers in this form:
```
responses = [
  null, // index = 0, answer for text item = null;
  { "value": 0 }, // index = 1, answer for single selection item = { "value": 0 };
  null // index = 2, answer for multi selection item = null;
]
```


[M2-5259]: https://mindlogger.atlassian.net/browse/M2-5259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[M2-5126]: https://mindlogger.atlassian.net/browse/M2-5126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[M2-5260]: https://mindlogger.atlassian.net/browse/M2-5260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ