### PR TITLE
M2-5309: change Banner `data-testid`s

### DIFF
--- a/src/modules/Builder/features/ReportConfigSetting/ReportConfigSetting.test.tsx
+++ b/src/modules/Builder/features/ReportConfigSetting/ReportConfigSetting.test.tsx
@@ -279,9 +279,7 @@ describe('ReportConfigSetting', () => {
       );
       fireEvent.click(screen.getByTestId('report-config-password-popup-submit-button'));
 
-      await waitFor(() => {
-        expectBanner(store, 'builder-applet-settings-report-config-setting-success-banner');
-      });
+      await waitFor(() => expectBanner(store, 'SaveSuccessBanner'));
     });
 
     test('Validations', async () => {

--- a/src/modules/Builder/features/ReportConfigSetting/ReportConfigSetting.tsx
+++ b/src/modules/Builder/features/ReportConfigSetting/ReportConfigSetting.tsx
@@ -108,10 +108,7 @@ export const ReportConfigSetting = ({
     dispatch(
       banners.actions.addBanner({
         key: 'SaveSuccessBanner',
-        bannerProps: {
-          onClose: confirmNavigation,
-          'data-testid': 'builder-applet-settings-report-config-setting-success-banner',
-        },
+        bannerProps: { onClose: confirmNavigation },
       }),
     );
   };

--- a/src/modules/Builder/features/SaveAndPublish/SaveAndPublish.hooks.test.tsx
+++ b/src/modules/Builder/features/SaveAndPublish/SaveAndPublish.hooks.test.tsx
@@ -46,9 +46,7 @@ describe('useSaveAndPublishSetup hook', () => {
 
       await (result.current as SaveAndPublishSetup).handleSaveAndPublishFirstClick();
 
-      await waitFor(() => {
-        expectBanner(store, 'dashboard-applets-save-success-banner');
-      });
+      await waitFor(() => expectBanner(store, 'SaveSuccessBanner'));
     });
 
     test('should not show a success banner if call to save fails', async () => {
@@ -68,14 +66,7 @@ describe('useSaveAndPublishSetup hook', () => {
         SaveAndPublishSteps.Failed,
       );
 
-      expect(
-        store
-          .getState()
-          .banners.data.banners.find(
-            ({ bannerProps }) =>
-              bannerProps?.['data-testid'] === 'dashboard-applets-save-success-banner',
-          ),
-      ).not.toBeDefined();
+      expectBanner(store, 'SaveSuccessBanner', false);
     });
   });
 });

--- a/src/modules/Dashboard/features/Applet/Popups/DeletePopup/DeletePopup.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/DeletePopup/DeletePopup.test.tsx
@@ -56,8 +56,6 @@ describe('DeletePopup', () => {
       target: { value: mockedPassword },
     });
     fireEvent.click(screen.getByText('Delete'));
-    await waitFor(() => {
-      expectBanner(store, `${testId}-success-banner`);
-    });
+    await waitFor(() => expectBanner(store, 'SaveSuccessBanner'));
   });
 });

--- a/src/modules/Dashboard/features/Applet/Popups/DeletePopup/DeletePopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/DeletePopup/DeletePopup.tsx
@@ -38,10 +38,7 @@ export const DeletePopup = ({ onCloseCallback, 'data-testid': dataTestid }: Dele
       dispatch(
         banners.actions.addBanner({
           key: 'SaveSuccessBanner',
-          bannerProps: {
-            children: t('appletDeletedSuccessfully'),
-            'data-testid': `${dataTestid}-success-banner`,
-          },
+          bannerProps: { children: t('appletDeletedSuccessfully') },
         }),
       );
       dispatch(alerts.actions.resetAlerts());

--- a/src/modules/Dashboard/features/Applet/Popups/DuplicatePopups/DuplicatePopups.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/DuplicatePopups/DuplicatePopups.test.tsx
@@ -84,9 +84,7 @@ describe('DuplicatePopups', () => {
       fireEvent.click(getByText('Submit'));
     });
 
-    await waitFor(() => {
-      expectBanner(store, 'dashboard-applets-duplicate-popup-success-popup');
-    });
+    await waitFor(() => expectBanner(store, 'SaveSuccessBanner'));
   });
 
   // TODO uncomment after useasync changes

--- a/src/modules/Dashboard/features/Applet/Popups/DuplicatePopups/DuplicatePopups.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/DuplicatePopups/DuplicatePopups.tsx
@@ -136,10 +136,7 @@ export const DuplicatePopups = ({ onCloseCallback }: { onCloseCallback?: () => v
       banners.actions.addBanner({
         key: 'SaveSuccessBanner',
         bannerProps: {
-          children: t('successDuplication', {
-            appletName: currentAppletName,
-          }),
-          'data-testid': 'dashboard-applets-duplicate-popup-success-popup',
+          children: t('successDuplication', { appletName: currentAppletName }),
         },
       }),
     );

--- a/src/modules/Dashboard/features/Applet/Popups/PublishConcealAppletPopup/PublishConcealAppletPopup.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/PublishConcealAppletPopup/PublishConcealAppletPopup.test.tsx
@@ -44,9 +44,7 @@ describe('PublishConcealAppletPopup', () => {
     });
 
     fireEvent.click(screen.getByText('Yes'));
-    await waitFor(() => {
-      expectBanner(store, 'dashboard-applets-publish-success-banner');
-    });
+    await waitFor(() => expectBanner(store, 'SaveSuccessBanner'));
   });
 
   test('should show conceal success banner', async () => {
@@ -57,8 +55,6 @@ describe('PublishConcealAppletPopup', () => {
     });
 
     fireEvent.click(screen.getByText('Yes'));
-    await waitFor(() => {
-      expectBanner(store, 'dashboard-applets-conceal-success-banner');
-    });
+    await waitFor(() => expectBanner(store, 'SaveSuccessBanner'));
   });
 });

--- a/src/modules/Dashboard/features/Applet/Popups/PublishConcealAppletPopup/PublishConcealAppletPopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/PublishConcealAppletPopup/PublishConcealAppletPopup.tsx
@@ -53,9 +53,6 @@ export const PublishConcealAppletPopup = () => {
             </Trans>
           ),
           duration: null,
-          'data-testid': `dashboard-applets-${
-            appletData?.isPublished ? 'publish' : 'conceal'
-          }-success-banner`,
         },
       }),
     );

--- a/src/modules/Dashboard/features/Applet/Popups/TransferOwnershipPopup/TransferOwnershipPopup.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/TransferOwnershipPopup/TransferOwnershipPopup.test.tsx
@@ -37,8 +37,6 @@ describe('TransferOwnershipPopup component tests', () => {
     });
     fireEvent.click(screen.getByText('Confirm'));
 
-    await waitFor(() => {
-      expectBanner(store, 'dashboard-applets-transfer-success-banner');
-    });
+    await waitFor(() => expectBanner(store, 'TransferOwnershipSuccessBanner'));
   });
 });

--- a/src/modules/Dashboard/features/Applet/Popups/TransferOwnershipPopup/TransferOwnershipPopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/TransferOwnershipPopup/TransferOwnershipPopup.tsx
@@ -26,10 +26,7 @@ export const TransferOwnershipPopup = () => {
     );
   };
 
-  const handleEmailTransferred = handleSendInvitation({
-    callback: transferOwnershipPopupClose,
-    bannerTestId: 'dashboard-applets-transfer-success-banner',
-  });
+  const handleEmailTransferred = handleSendInvitation(transferOwnershipPopupClose);
 
   return (
     <>

--- a/src/modules/Dashboard/features/Managers/Managers.tsx
+++ b/src/modules/Dashboard/features/Managers/Managers.tsx
@@ -107,14 +107,7 @@ export const Managers = () => {
   const editManagerAccessOnClose = (shouldRefetch?: boolean) => {
     setEditAccessPopupVisible(false);
     if (shouldRefetch) {
-      dispatch(
-        banners.actions.addBanner({
-          key: 'SaveSuccessBanner',
-          bannerProps: {
-            'data-testid': 'dashboard-managers-edit-access-popup-success-banner',
-          },
-        }),
-      );
+      dispatch(banners.actions.addBanner({ key: 'SaveSuccessBanner' }));
       handleReload();
     }
   };

--- a/src/modules/Dashboard/features/Respondents/Popups/EditRespondentPopup/EditRespondentPopup.test.tsx
+++ b/src/modules/Dashboard/features/Respondents/Popups/EditRespondentPopup/EditRespondentPopup.test.tsx
@@ -45,8 +45,6 @@ describe('EditRespondentPopup component tests', () => {
 
     fireEvent.change(screen.getByLabelText(/Nickname/i), { target: { value: '00000' } });
     fireEvent.click(screen.getByText('Save'));
-    await waitFor(() => {
-      expectBanner(store, 'dashboard-respondents-edit-popup-success-banner');
-    });
+    await waitFor(() => expectBanner(store, 'SaveSuccessBanner'));
   });
 });

--- a/src/modules/Dashboard/features/Respondents/Popups/EditRespondentPopup/EditRespondentPopup.tsx
+++ b/src/modules/Dashboard/features/Respondents/Popups/EditRespondentPopup/EditRespondentPopup.tsx
@@ -43,14 +43,7 @@ export const EditRespondentPopup = ({
     editRespondentApi,
     () => {
       onCloseHandler(true);
-      dispatch(
-        banners.actions.addBanner({
-          key: 'SaveSuccessBanner',
-          bannerProps: {
-            'data-testid': `${dataTestid}-success-banner`,
-          },
-        }),
-      );
+      dispatch(banners.actions.addBanner({ key: 'SaveSuccessBanner' }));
     },
     falseReturnFunc,
     () => {

--- a/src/shared/components/Banners/Banner/Banner.test.tsx
+++ b/src/shared/components/Banners/Banner/Banner.test.tsx
@@ -58,11 +58,11 @@ describe('Banner', () => {
   });
 
   test.each`
-    severity      | testId
-    ${'success'}  | ${'success-banner'}
-    ${'info'}     | ${'info-banner'}
-    ${'warning'}  | ${'warning-banner'}
-    ${'error'}    | ${'error-banner'}
+    severity     | testId
+    ${'success'} | ${'success-banner'}
+    ${'info'}    | ${'info-banner'}
+    ${'warning'} | ${'warning-banner'}
+    ${'error'}   | ${'error-banner'}
   `('has test ID that matches severity $severity', ({ severity, testId }) => {
     render(<Banner {...props} severity={severity} />);
 

--- a/src/shared/components/Banners/Banner/Banner.test.tsx
+++ b/src/shared/components/Banners/Banner/Banner.test.tsx
@@ -56,4 +56,16 @@ describe('Banner', () => {
     jest.advanceTimersByTime(props.duration + 1000);
     expect(mockOnClose).not.toHaveBeenCalled();
   });
+
+  test.each`
+    severity      | testId
+    ${'success'}  | ${'success-banner'}
+    ${'info'}     | ${'info-banner'}
+    ${'warning'}  | ${'warning-banner'}
+    ${'error'}    | ${'error-banner'}
+  `('has test ID that matches severity $severity', ({ severity, testId }) => {
+    render(<Banner {...props} severity={severity} />);
+
+    expect(screen.getByTestId(testId)).toBeInTheDocument();
+  });
 });

--- a/src/shared/components/Banners/Banner/Banner.tsx
+++ b/src/shared/components/Banners/Banner/Banner.tsx
@@ -14,7 +14,6 @@ export const Banner = ({
   onClose,
   hasCloseButton = !!onClose,
   severity = 'success',
-  'data-testid': dataTestid = `${severity}-banner`,
 }: BannerProps) => {
   let timeoutId: NodeJS.Timeout | undefined;
   const [isHovering, setIsHovering] = useState(false);
@@ -47,7 +46,7 @@ export const Banner = ({
       onMouseEnter={() => setIsHovering(true)}
       onMouseLeave={() => setIsHovering(false)}
       severity={severity}
-      data-testid={dataTestid}
+      data-testid={`${severity}-banner`}
     >
       {children}
     </Alert>

--- a/src/shared/components/Banners/Banner/Banner.tsx
+++ b/src/shared/components/Banners/Banner/Banner.tsx
@@ -13,8 +13,8 @@ export const Banner = ({
   duration = 5000,
   onClose,
   hasCloseButton = !!onClose,
-  severity,
-  'data-testid': dataTestid,
+  severity = 'success',
+  'data-testid': dataTestid = `${severity}-banner`,
 }: BannerProps) => {
   let timeoutId: NodeJS.Timeout | undefined;
   const [isHovering, setIsHovering] = useState(false);

--- a/src/shared/components/Banners/Banner/Banner.types.ts
+++ b/src/shared/components/Banners/Banner/Banner.types.ts
@@ -6,6 +6,5 @@ export type BannerProps = {
   /** @default !!onClose */
   hasCloseButton?: boolean;
   onClose?: () => void;
-  'data-testid'?: string;
 } & Pick<AlertProps, 'severity' | 'children'> &
   Record<string, unknown>; // Custom banner props

--- a/src/shared/components/Banners/FileSizeExceededBanner/FileSizeExceededBanner.test.tsx
+++ b/src/shared/components/Banners/FileSizeExceededBanner/FileSizeExceededBanner.test.tsx
@@ -13,7 +13,7 @@ describe('FileSizeExceededBanner', () => {
   test('should render', () => {
     renderWithProviders(<FileSizeExceededBanner {...props} />);
 
-    expect(screen.getByTestId('file-size-exceeded-banner')).toBeInTheDocument();
+    expect(screen.getByTestId('error-banner')).toBeInTheDocument();
     expect(
       screen.getByText(`File is too big. Please upload a file less than ${props.size} B.`),
     ).toBeInTheDocument();

--- a/src/shared/components/Banners/FileSizeExceededBanner/FileSizeExceededBanner.tsx
+++ b/src/shared/components/Banners/FileSizeExceededBanner/FileSizeExceededBanner.tsx
@@ -8,7 +8,7 @@ export const FileSizeExceededBanner = ({ size, ...props }: BannerProps) => {
   const { t } = useTranslation('app');
 
   return (
-    <Banner severity="error" data-testid="file-size-exceeded-banner" {...props}>
+    <Banner severity="error" {...props}>
       {t('fileSizeExceed', { size: byteFormatter(size as number) })}
     </Banner>
   );

--- a/src/shared/components/Banners/IncorrectFileBanner/IncorrectFileBanner.test.tsx
+++ b/src/shared/components/Banners/IncorrectFileBanner/IncorrectFileBanner.test.tsx
@@ -11,13 +11,11 @@ const props = {
   onClose: jest.fn(),
 };
 
-const dataTestid = 'incorrect-file-popup';
-
 describe('IncorrectFileBanner', () => {
   test('should render size error', () => {
-    renderWithProviders(<IncorrectFileBanner {...props} data-testid={dataTestid} />);
+    renderWithProviders(<IncorrectFileBanner {...props} />);
 
-    expect(screen.getByTestId(dataTestid)).toBeInTheDocument();
+    expect(screen.getByTestId('error-banner')).toBeInTheDocument();
     expect(screen.getByText('Image is more than 25 MB.')).toBeInTheDocument();
   });
 

--- a/src/shared/components/Banners/IncorrectFileBanner/IncorrectFileBanner.tsx
+++ b/src/shared/components/Banners/IncorrectFileBanner/IncorrectFileBanner.tsx
@@ -12,11 +12,7 @@ export const IncorrectFileBanner = ({ errorType, fileType, ...props }: BannerPro
   const isFormatError = errorType === UploadFileError.Format;
 
   return (
-    <Banner
-      severity="error"
-      data-testid={`incorrect-file-${isFormatError ? 'format' : 'size'}-banner`}
-      {...props}
-    >
+    <Banner severity="error" {...props}>
       {isFormatError ? (
         t(formatError[fileType as MediaType])
       ) : (

--- a/src/shared/components/Banners/SaveSuccessBanner/SaveSuccessBanner.test.tsx
+++ b/src/shared/components/Banners/SaveSuccessBanner/SaveSuccessBanner.test.tsx
@@ -10,7 +10,7 @@ describe('SaveSuccessBanner', () => {
   test('should render', () => {
     renderWithProviders(<SaveSuccessBanner />);
 
-    expect(screen.getByTestId('save-success-banner')).toBeInTheDocument();
+    expect(screen.getByTestId('success-banner')).toBeInTheDocument();
     expect(screen.getByText('Changes saved')).toBeInTheDocument();
   });
 

--- a/src/shared/components/Banners/SaveSuccessBanner/SaveSuccessBanner.tsx
+++ b/src/shared/components/Banners/SaveSuccessBanner/SaveSuccessBanner.tsx
@@ -10,7 +10,6 @@ export const SaveSuccessBanner = ({ children, ...props }: BannerProps) => {
     <Banner
       duration={SAVE_SUCCESS_BANNER_DURATION}
       severity="success"
-      data-testid="save-success-banner"
       {...props}
     >
       {children ?? t('saveSuccess')}

--- a/src/shared/components/Banners/SaveSuccessBanner/SaveSuccessBanner.tsx
+++ b/src/shared/components/Banners/SaveSuccessBanner/SaveSuccessBanner.tsx
@@ -7,11 +7,7 @@ export const SaveSuccessBanner = ({ children, ...props }: BannerProps) => {
   const { t } = useTranslation('app');
 
   return (
-    <Banner
-      duration={SAVE_SUCCESS_BANNER_DURATION}
-      severity="success"
-      {...props}
-    >
+    <Banner duration={SAVE_SUCCESS_BANNER_DURATION} severity="success" {...props}>
       {children ?? t('saveSuccess')}
     </Banner>
   );

--- a/src/shared/components/Banners/TransferOwnershipSuccessBanner/TransferOwnershipSuccessBanner.test.tsx
+++ b/src/shared/components/Banners/TransferOwnershipSuccessBanner/TransferOwnershipSuccessBanner.test.tsx
@@ -15,7 +15,7 @@ describe('TransferOwnershipSuccessBanner', () => {
   test('should render', () => {
     renderWithProviders(<TransferOwnershipSuccessBanner {...props} />);
 
-    expect(screen.getByTestId('transfer-ownership-success-banner')).toBeInTheDocument();
+    expect(screen.getByTestId('success-banner')).toBeInTheDocument();
     expect(
       screen.getByText(
         'Your request has been successfully sent to . Please wait for receiver to accept your request.',

--- a/src/shared/components/Banners/TransferOwnershipSuccessBanner/TransferOwnershipSuccessBanner.tsx
+++ b/src/shared/components/Banners/TransferOwnershipSuccessBanner/TransferOwnershipSuccessBanner.tsx
@@ -3,12 +3,8 @@ import { Trans } from 'react-i18next';
 import { Banner, BannerProps } from '../Banner';
 import { TRANSFER_OWNERSHIP_SUCCESS_BANNER_DURATION } from './TransferOwnershipSuccessBanner.const';
 
-export const TransferOwnershipSuccessBanner = ({ children, email, ...props }: BannerProps) => (
-  <Banner
-    duration={TRANSFER_OWNERSHIP_SUCCESS_BANNER_DURATION}
-    severity="success"
-    {...props}
-  >
+export const TransferOwnershipSuccessBanner = ({ email, ...props }: BannerProps) => (
+  <Banner duration={TRANSFER_OWNERSHIP_SUCCESS_BANNER_DURATION} severity="success" {...props}>
     <Trans i18nKey="requestTransferOwnershipSuccess">
       <>
         Your request has been successfully sent to

--- a/src/shared/components/Banners/TransferOwnershipSuccessBanner/TransferOwnershipSuccessBanner.tsx
+++ b/src/shared/components/Banners/TransferOwnershipSuccessBanner/TransferOwnershipSuccessBanner.tsx
@@ -7,7 +7,6 @@ export const TransferOwnershipSuccessBanner = ({ children, email, ...props }: Ba
   <Banner
     duration={TRANSFER_OWNERSHIP_SUCCESS_BANNER_DURATION}
     severity="success"
-    data-testid="transfer-ownership-success-banner"
     {...props}
   >
     <Trans i18nKey="requestTransferOwnershipSuccess">

--- a/src/shared/components/Banners/VersionWarningBanner/VersionWarningBanner.test.tsx
+++ b/src/shared/components/Banners/VersionWarningBanner/VersionWarningBanner.test.tsx
@@ -11,7 +11,7 @@ describe('VersionWarningBanner', () => {
   test('should render', () => {
     renderWithProviders(<VersionWarningBanner />);
 
-    expect(screen.getByTestId('version-warning-banner')).toBeInTheDocument();
+    expect(screen.getByTestId('warning-banner')).toBeInTheDocument();
     expect(screen.getByText('You are using the new version of MindLogger!')).toBeInTheDocument();
   });
 

--- a/src/shared/components/Banners/VersionWarningBanner/VersionWarningBanner.tsx
+++ b/src/shared/components/Banners/VersionWarningBanner/VersionWarningBanner.tsx
@@ -5,7 +5,7 @@ import { Banner, BannerProps } from '../Banner';
 import { VERSION_WARNING_BANNER_LINK } from './VersionWarningBanner.const';
 
 export const VersionWarningBanner = (props: BannerProps) => (
-  <Banner duration={null} severity="warning" data-testid="version-warning-banner" {...props}>
+  <Banner duration={null} severity="warning" {...props}>
     <Trans i18nKey="versionWarningBanner">
       <strong>You are using the new version of MindLogger!</strong>
       <>End users must update to the new app.</>

--- a/src/shared/components/FormComponents/EditorController/EditorController.tsx
+++ b/src/shared/components/FormComponents/EditorController/EditorController.tsx
@@ -3,7 +3,6 @@ import { FieldValues, Controller } from 'react-hook-form';
 import { ExposeParam, InsertContentGenerator } from 'md-editor-rt';
 
 import { MediaType, UploadFileError } from 'shared/consts';
-import { concatIf } from 'shared/utils/concatIf';
 import { useAppDispatch } from 'redux/store';
 import { banners } from 'redux/modules';
 

--- a/src/shared/components/FormComponents/EditorController/EditorController.tsx
+++ b/src/shared/components/FormComponents/EditorController/EditorController.tsx
@@ -29,10 +29,7 @@ export const EditorController = <T extends FieldValues>({
       dispatch(
         banners.actions.addBanner({
           key: 'FileSizeExceededBanner',
-          bannerProps: {
-            size,
-            'data-testid': concatIf(dataTestid, '-incorrect-file-size-banner'),
-          },
+          bannerProps: { size },
         }),
       );
     },
@@ -49,7 +46,6 @@ export const EditorController = <T extends FieldValues>({
           bannerProps: {
             errorType: UploadFileError.Format,
             fileType,
-            'data-testid': concatIf(dataTestid, '-incorrect-file-format-banner'),
           },
         }),
       );

--- a/src/shared/components/Uploader/Uploader.tsx
+++ b/src/shared/components/Uploader/Uploader.tsx
@@ -115,7 +115,6 @@ export const Uploader = ({
             bannerProps: {
               errorType: UploadFileError.Size,
               fileType: MediaType.Image,
-              'data-testid': concatIf(dataTestid, '-incorrect-file-size-banner'),
               onClose: () => setError(null),
             },
           }),
@@ -133,7 +132,6 @@ export const Uploader = ({
             bannerProps: {
               errorType: UploadFileError.Format,
               fileType: MediaType.Image,
-              'data-testid': concatIf(dataTestid, '-incorrect-file-format-banner'),
               onClose: () => setError(null),
             },
           }),

--- a/src/shared/features/AppletSettings/DataRetentionSetting/DataRetention.test.tsx
+++ b/src/shared/features/AppletSettings/DataRetentionSetting/DataRetention.test.tsx
@@ -108,8 +108,6 @@ describe('DataRetention component tests', () => {
       );
     });
 
-    await waitFor(() => {
-      expectBanner(store, `${dataTestid}-success-popup`);
-    });
+    await waitFor(() => expectBanner(store, 'SaveSuccessBanner'));
   });
 });

--- a/src/shared/features/AppletSettings/DataRetentionSetting/DataRetention.tsx
+++ b/src/shared/features/AppletSettings/DataRetentionSetting/DataRetention.tsx
@@ -61,10 +61,7 @@ export const DataRetention = ({ isDashboard }: { isDashboard?: boolean }) => {
       dispatch(
         banners.actions.addBanner({
           key: 'SaveSuccessBanner',
-          bannerProps: {
-            'data-testid': `${dataTestid}-success-popup`,
-            onClose: confirmNavigation,
-          },
+          bannerProps: { onClose: confirmNavigation },
         }),
       );
     },

--- a/src/shared/features/AppletSettings/DeleteAppletSetting/DeleteAppletSetting.test.tsx
+++ b/src/shared/features/AppletSettings/DeleteAppletSetting/DeleteAppletSetting.test.tsx
@@ -77,9 +77,7 @@ describe('DeleteAppletSetting', () => {
 
     fireEvent.click(screen.getByText('Delete'));
 
-    await waitFor(() => {
-      expectBanner(store, 'applet-settings-delete-applet-delete-success-banner');
-    });
+    await waitFor(() => expectBanner(store, 'SaveSuccessBanner'));
 
     expect(mockedUseNavigate).toBeCalledWith('/dashboard/applets');
   });

--- a/src/shared/features/AppletSettings/DuplicateAppletSettings/DuplicateAppletSettings.test.tsx
+++ b/src/shared/features/AppletSettings/DuplicateAppletSettings/DuplicateAppletSettings.test.tsx
@@ -106,9 +106,7 @@ describe('DuplicateAppletSettings', () => {
         'Submit',
       ),
     );
-    await waitFor(() => {
-      expectBanner(store, 'dashboard-applets-duplicate-popup-success-popup');
-    });
+    await waitFor(() => expectBanner(store, 'SaveSuccessBanner'));
 
     expect(mockedUseNavigate).toBeCalledWith('/dashboard/applets');
   });

--- a/src/shared/features/AppletSettings/TransferOwnershipSetting/TransferOwnershipSetting.test.tsx
+++ b/src/shared/features/AppletSettings/TransferOwnershipSetting/TransferOwnershipSetting.test.tsx
@@ -65,7 +65,7 @@ describe('TransferOwnershipSetting', () => {
 
       userEvent.click(screen.getByTestId(`${dataTestid}-confirm`));
 
-      expectBanner(store, `${dataTestid}-success-banner`);
+      expectBanner(store, 'TransferOwnershipSuccessBanner');
     });
   });
 });

--- a/src/shared/features/AppletSettings/TransferOwnershipSetting/TransferOwnershipSetting.tsx
+++ b/src/shared/features/AppletSettings/TransferOwnershipSetting/TransferOwnershipSetting.tsx
@@ -19,10 +19,7 @@ export const TransferOwnershipSetting = () => {
 
   const dataTestid = 'applet-settings-transfer-ownership';
 
-  const handleEmailTransferred = handleSendInvitation({
-    callback: transferOwnershipRef.current?.resetEmail,
-    bannerTestId: `${dataTestid}-success-banner`,
-  });
+  const handleEmailTransferred = handleSendInvitation(transferOwnershipRef.current?.resetEmail);
 
   return (
     <>

--- a/src/shared/hooks/useTransferOwnership.test.ts
+++ b/src/shared/hooks/useTransferOwnership.test.ts
@@ -18,17 +18,13 @@ const emptyState: PreloadedState<RootState> = {
   },
 };
 const email = 'test@email.com';
-const bannerTestId = 'testId';
 const populatedState: PreloadedState<RootState> = {
   banners: {
     data: {
       banners: [
         {
           key: 'TransferOwnershipSuccessBanner',
-          bannerProps: {
-            email,
-            'data-testid': bannerTestId,
-          },
+          bannerProps: { email },
         },
       ],
     },
@@ -62,7 +58,7 @@ describe('useTransferOwnership', () => {
     );
   });
 
-  test('should change transferOwnershipSuccessVisible accorging to emailTransfered updates', async () => {
+  test('should show success banner when transferring ownership succeeds', async () => {
     const mixpanelTrack = jest.spyOn(MixpanelFunc.Mixpanel, 'track');
     const { result, rerender, store } = renderHookWithProviders(useTransferOwnership, {
       preloadedState: emptyState,
@@ -72,10 +68,7 @@ describe('useTransferOwnership', () => {
     expect(store.getState().banners).toEqual(emptyState.banners);
     expect(screen.queryByTestId('testId')).toBeNull();
 
-    result.current.handleSendInvitation({
-      callback: mockedCallback,
-      bannerTestId,
-    })(email);
+    result.current.handleSendInvitation(mockedCallback)(email);
 
     rerender();
 

--- a/src/shared/hooks/useTransferOwnership.ts
+++ b/src/shared/hooks/useTransferOwnership.ts
@@ -12,23 +12,18 @@ export const useTransferOwnership = () => {
     setIsSubmitted(true);
   };
 
-  const handleSendInvitation =
-    ({ callback, bannerTestId }: { callback?: () => void; bannerTestId: string }) =>
-    (email: string) => {
-      callback?.();
+  const handleSendInvitation = (callback?: () => void) => (email: string) => {
+    callback?.();
 
-      dispatch(
-        banners.actions.addBanner({
-          key: 'TransferOwnershipSuccessBanner',
-          bannerProps: {
-            email,
-            'data-testid': bannerTestId,
-          },
-        }),
-      );
+    dispatch(
+      banners.actions.addBanner({
+        key: 'TransferOwnershipSuccessBanner',
+        bannerProps: { email },
+      }),
+    );
 
-      Mixpanel.track('Invitation sent successfully');
-    };
+    Mixpanel.track('Invitation sent successfully');
+  };
 
   return {
     isSubmitted,

--- a/src/shared/utils/expectBanner.ts
+++ b/src/shared/utils/expectBanner.ts
@@ -1,13 +1,12 @@
+import { BannerType } from 'redux/modules';
 import { AppStore } from 'redux/store';
 
 /**
- * Jest utility to determine if the banner having the given testId has been rendered
+ * Jest utility to determine if the banner having the given key has been rendered
  * based on the current state of Redux store.
  */
-export const expectBanner = (store: AppStore, testId: string) => {
+export const expectBanner = (store: AppStore, key: keyof typeof BannerType) => {
   expect(
-    store
-      .getState()
-      .banners.data.banners.find(({ bannerProps }) => bannerProps?.['data-testid'] === testId),
+    store.getState().banners.data.banners.find((payload) => payload.key === key),
   ).toBeDefined();
 };

--- a/src/shared/utils/expectBanner.ts
+++ b/src/shared/utils/expectBanner.ts
@@ -5,8 +5,15 @@ import { AppStore } from 'redux/store';
  * Jest utility to determine if the banner having the given key has been rendered
  * based on the current state of Redux store.
  */
-export const expectBanner = (store: AppStore, key: keyof typeof BannerType) => {
-  expect(
+export const expectBanner = (
+  store: AppStore,
+  key: keyof typeof BannerType,
+  expectPresence = true,
+) => {
+  const expectation = expect(
     store.getState().banners.data.banners.find((payload) => payload.key === key),
-  ).toBeDefined();
+  );
+
+  const matcher = expectPresence ? expectation : expectation.not;
+  matcher.toBeDefined();
 };


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-5309](https://mindlogger.atlassian.net/browse/M2-5309)


<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

To make Selenium tests easier, it was requested to standardize banners' `data-testid` prop, following this pattern:

| Severity                      | `data-testid`                                 |
| -------------------------------------- | ------------------------------------- |
| `success` | `success-banner` |
| `info` | `info-banner` |
| `warning` | `warning-banner` |
| `error` | `error-banner` |

In making this change, I had to adjust the `expectBanner` unit testing utility as well, since the customized `data-testid` prop would no longer be available to compare specific banners against. Instead, unit tests now use the banner's `key` for comparison.

### 🪤 Peer Testing

Test existing banner functionality and ensure there is no regressive behaviour.