### PR TITLE
M2-5427: Use new applet name in success message

### DIFF
--- a/src/modules/Dashboard/features/Applet/Popups/DuplicatePopups/DuplicatePopups.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/DuplicatePopups/DuplicatePopups.test.tsx
@@ -90,13 +90,13 @@ describe('DuplicatePopups', () => {
         store.getState().banners.data.banners.find((payload) => {
           const bannerContent = payload.bannerProps?.children;
           if (bannerContent) {
-            return bannerContent.toString().includes(mockedAppletData.displayName)
+            return bannerContent.toString().includes(mockedAppletData.displayName);
           }
 
           return false;
-        })
-      ).toBeDefined()
-    })
+        }),
+      ).toBeDefined();
+    });
   });
 
   // TODO uncomment after useasync changes

--- a/src/modules/Dashboard/features/Applet/Popups/DuplicatePopups/DuplicatePopups.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/DuplicatePopups/DuplicatePopups.test.tsx
@@ -52,7 +52,7 @@ describe('DuplicatePopups', () => {
   test('should duplicate and open success modal', async () => {
     mockAxios.post.mockResolvedValueOnce({ data: { result: { name: 'name' } } });
     mockAxios.post.mockResolvedValueOnce({ data: { result: { name: 'name' } } });
-    mockAxios.post.mockResolvedValueOnce({ data: { result: mockedAppletData } });
+    mockAxios.post.mockResolvedValueOnce({ data: mockedAppletData });
     jest
       .spyOn(encryptionFunctions, 'getEncryptionToServer')
       .mockReturnValue(Promise.resolve(mockedEncryption));
@@ -85,6 +85,18 @@ describe('DuplicatePopups', () => {
     });
 
     await waitFor(() => expectBanner(store, 'SaveSuccessBanner'));
+    await waitFor(() => {
+      expect(
+        store.getState().banners.data.banners.find((payload) => {
+          const bannerContent = payload.bannerProps?.children;
+          if (bannerContent) {
+            return bannerContent.toString().includes(mockedAppletData.displayName)
+          }
+
+          return false;
+        })
+      ).toBeDefined()
+    })
   });
 
   // TODO uncomment after useasync changes

--- a/src/modules/Dashboard/features/Applet/Popups/DuplicatePopups/DuplicatePopups.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/DuplicatePopups/DuplicatePopups.tsx
@@ -1,3 +1,4 @@
+import { type AxiosResponse } from 'axios';
 import { ChangeEvent, useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -82,14 +83,14 @@ export const DuplicatePopups = ({ onCloseCallback }: { onCloseCallback?: () => v
 
   const { execute: executeDuplicate, isLoading: isDuplicateLoading } = useAsync(
     duplicateAppletApi,
-    async () => {
+    async (result) => {
       await setAppletPrivateKey({
         appletPassword: encryptionDataRef.current.password ?? '',
         encryption: encryptionDataRef.current.encryption!,
         appletId: currentAppletId,
       });
 
-      handleDuplicateSuccess();
+      handleDuplicateSuccess(result);
     },
     () => {
       setPasswordModalVisible(false);
@@ -124,7 +125,7 @@ export const DuplicatePopups = ({ onCloseCallback }: { onCloseCallback?: () => v
     duplicatePopupsClose();
   };
 
-  const handleDuplicateSuccess = () => {
+  const handleDuplicateSuccess = (result: AxiosResponse) => {
     setPasswordModalVisible(false);
 
     onCloseCallback?.();
@@ -136,7 +137,9 @@ export const DuplicatePopups = ({ onCloseCallback }: { onCloseCallback?: () => v
       banners.actions.addBanner({
         key: 'SaveSuccessBanner',
         bannerProps: {
-          children: t('successDuplication', { appletName: currentAppletName }),
+          children: t('successDuplication', {
+            appletName: result?.data?.displayName
+          }),
         },
       }),
     );

--- a/src/modules/Dashboard/features/Applet/Popups/DuplicatePopups/DuplicatePopups.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/DuplicatePopups/DuplicatePopups.tsx
@@ -138,7 +138,7 @@ export const DuplicatePopups = ({ onCloseCallback }: { onCloseCallback?: () => v
         key: 'SaveSuccessBanner',
         bannerProps: {
           children: t('successDuplication', {
-            appletName: result?.data?.displayName
+            appletName: result?.data?.displayName,
           }),
         },
       }),

--- a/src/modules/Dashboard/features/Applet/Popups/DuplicatePopups/DuplicatePopups.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/DuplicatePopups/DuplicatePopups.tsx
@@ -138,7 +138,7 @@ export const DuplicatePopups = ({ onCloseCallback }: { onCloseCallback?: () => v
         key: 'SaveSuccessBanner',
         bannerProps: {
           children: t('successDuplication', {
-            appletName: result?.data?.displayName,
+            appletName: result?.data?.displayName ?? '',
           }),
         },
       }),

--- a/src/shared/features/AppletSettings/DuplicateAppletSettings/DuplicateAppletSettings.test.tsx
+++ b/src/shared/features/AppletSettings/DuplicateAppletSettings/DuplicateAppletSettings.test.tsx
@@ -71,7 +71,7 @@ describe('DuplicateAppletSettings', () => {
   test('should render and navigate to builder', async () => {
     mockAxios.post.mockResolvedValueOnce({ data: { result: { name: 'name' } } });
     mockAxios.post.mockResolvedValueOnce({ data: { result: { name: 'name' } } });
-    mockAxios.post.mockResolvedValueOnce({ data: { result: mockedAppletData } });
+    mockAxios.post.mockResolvedValueOnce({ data: mockedAppletData });
     jest
       .spyOn(encryptionFunctions, 'getEncryptionToServer')
       .mockReturnValue(Promise.resolve(mockedEncryption));


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-5427](https://mindlogger.atlassian.net/browse/M2-5427)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

This fixes a bug where upon successful applet duplication, the name of the original source applet appears in the success message rather than the newly created applet. It updates the name to the name from the successful creation response.

### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->



### 🪤 Peer Testing

<!--
Replace this with a series of test steps & expected outcomes.

Example test step:

- This is a test step.  Highlight actions **in bold**.

    **Expected outcome:** This is what to expect after the step
-->

https://github.com/ChildMindInstitute/mindlogger-admin/assets/1165936/ac515aaa-9732-44cf-bd8c-bf8aeeeaa0b7


Case | Testing Steps | Expected
-- | -- | --
Successful applet duplication | 1. Go to dashboard<br />2. Hover over an existing applet and click duplicate icon<br />3. Enter a new name for the applet, give the applet and password, and submit | 1. Verify that the success message uses the new name that you input

### ✏️ Notes

<!--
Replace this line with anything else you think may be relevant or related PRs

If there are no notes, then delete this section.
-->