### PR TITLE
M2-5512: adds a PR template for use in GitHub pull requests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,60 @@
+<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
+<!-- Include information that helps your peers review your updates and understand this    -->
+<!-- repository's history of changes over time.                                           -->
+
+<!-- Delete any options that are not relevant -->
+
+- [ ] Tests for the changes have been added
+- [ ] Related documentation has been added / updated
+- [ ] OSS packages added to MindLogger [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)
+
+### 📝 Description
+
+<!-- Contributions are welcome! If there is a corresponding      -->
+<!-- JIRA ticket, link to it by replacing `#` with ticket number -->
+
+🔗 [Jira Ticket M2-#](https://mindlogger.atlassian.net/browse/M2-#)
+
+<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->
+
+Changes include:
+
+- [Thing]
+- [Other thing]
+- [More things]
+
+### 📸 Screenshots
+
+<!--
+If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.
+
+If not, then delete this section
+-->
+
+| Before (Optional)                      | After                                 |
+| -------------------------------------- | ------------------------------------- |
+| <!-- Paste before image/video here --> | <!-- Paste after image/video here --> |
+
+### 🪤 Peer Testing
+
+<!-- If peer testing is not needed, then delete this section -->
+<!-- Uncomment out any of the following as needed:           -->
+<!-- **Requires `npm install`**     -->
+
+<!--
+Replace this with a series of test steps & expected outcomes.
+
+Example test step:
+
+- This is a test step.  Highlight actions **in bold**.
+
+    **Expected outcome:** This is what to expect after the step
+-->
+
+### ✏️ Notes
+
+<!--
+Replace this line with anything else you think may be relevant or related PRs
+
+If there are no notes, then delete this section.
+-->


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-5512](https://mindlogger.atlassian.net/browse/M2-5512)

This PR defines a [GitHub pull request description template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates#pull-request-templates) to act as a guide for developers to use when opening pull requests on the `mindlogger-admin` repository.  GitHub will start using this as this repository's pull request template once this is merged to the default branch (`main`).

Changes include:

- a new [GitHub pull request template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository)