### PR TITLE
M2-5427: Fix applet displayName in duplicate success message

### DIFF
--- a/src/modules/Dashboard/features/Applet/Popups/DuplicatePopups/DuplicatePopups.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/DuplicatePopups/DuplicatePopups.test.tsx
@@ -54,7 +54,7 @@ describe('DuplicatePopups', () => {
   test('should duplicate and open success modal', async () => {
     mockAxios.post.mockResolvedValueOnce({ data: { result: { name: 'name' } } });
     mockAxios.post.mockResolvedValueOnce({ data: { result: { name: 'name' } } });
-    mockAxios.post.mockResolvedValueOnce({ data: mockedAppletData });
+    mockAxios.post.mockResolvedValueOnce({ data: { result: mockedAppletData } });
     jest
       .spyOn(encryptionFunctions, 'getEncryptionToServer')
       .mockReturnValue(Promise.resolve(mockedEncryption));

--- a/src/modules/Dashboard/features/Applet/Popups/DuplicatePopups/DuplicatePopups.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/DuplicatePopups/DuplicatePopups.tsx
@@ -83,14 +83,14 @@ export const DuplicatePopups = ({ onCloseCallback }: { onCloseCallback?: () => v
 
   const { execute: executeDuplicate, isLoading: isDuplicateLoading } = useAsync(
     duplicateAppletApi,
-    async (result) => {
+    async (res) => {
       await setAppletPrivateKey({
         appletPassword: encryptionDataRef.current.password ?? '',
         encryption: encryptionDataRef.current.encryption!,
         appletId: currentAppletId,
       });
 
-      handleDuplicateSuccess(result);
+      handleDuplicateSuccess(res);
     },
     (error) => {
       setPasswordModalVisible(false);
@@ -127,7 +127,7 @@ export const DuplicatePopups = ({ onCloseCallback }: { onCloseCallback?: () => v
     duplicatePopupsClose();
   };
 
-  const handleDuplicateSuccess = (result: AxiosResponse) => {
+  const handleDuplicateSuccess = (res: AxiosResponse) => {
     setPasswordModalVisible(false);
 
     onCloseCallback?.();
@@ -140,7 +140,7 @@ export const DuplicatePopups = ({ onCloseCallback }: { onCloseCallback?: () => v
         key: 'SaveSuccessBanner',
         bannerProps: {
           children: t('successDuplication', {
-            appletName: result?.data?.displayName ?? '',
+            appletName: res?.data?.result?.displayName ?? '',
           }),
         },
       }),


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-5427](https://mindlogger.atlassian.net/browse/M2-5427)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

🤦🏻‍♀️ Last time, I swear.

Duplicate success message was pulling applet `displayName` from the wrong place. Update, and also update test that was masking this mistake

### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

### 🪤 Peer Testing

<!--
Replace this with a series of test steps & expected outcomes.

Example test step:

- This is a test step.  Highlight actions **in bold**.

    **Expected outcome:** This is what to expect after the step
-->

Case | Testing Steps | Expected
-- | -- | --
Applet duplicate success | 1. Go to dashboard<br />2. Hover over a created applet and click the "Duplicate" icon<br />3. Enter a password and submit | 1. Banner should appear that says "Your applet <applet name> was successfully created!"

### ✏️ Notes

<!--
Replace this line with anything else you think may be relevant or related PRs

If there are no notes, then delete this section.
-->