### PR TITLE
M2-4710: The ‘Upload FileBody: File is too big’ is sometimes missing after an attempt to upload audio .mp3 with 150Mb+ size

### DIFF
--- a/src/shared/components/MarkDownEditor/extensions/Extensions.hooks.ts
+++ b/src/shared/components/MarkDownEditor/extensions/Extensions.hooks.ts
@@ -83,6 +83,7 @@ export const useUploadMethods = ({
 
   useEffect(() => {
     setIsLoading(isLoading);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoading]);
 
   return {

--- a/src/shared/components/MarkDownEditor/extensions/Extensions.hooks.ts
+++ b/src/shared/components/MarkDownEditor/extensions/Extensions.hooks.ts
@@ -67,7 +67,7 @@ export const useUploadMethods = ({
     if (!inputRef.current?.files?.length) return;
 
     const file = inputRef.current.files[0];
-    if (file.size > fileSizeExceeded) {
+    if (file.size >= fileSizeExceeded) {
       return setFileSizeExceeded(fileSizeExceeded);
     }
 


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-4710](https://mindlogger.atlassian.net/browse/M2-4710)