### PR TITLE
M2-5743: Ensure DataExportPopup gets to/from dates

### DIFF
--- a/src/shared/features/AppletSettings/ExportDataSetting/ExportDataSetting.test.tsx
+++ b/src/shared/features/AppletSettings/ExportDataSetting/ExportDataSetting.test.tsx
@@ -1,8 +1,10 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 
+import { ExportData } from 'api';
 import { initialStateData } from 'redux/modules';
-import { mockedApplet } from 'shared/mock';
+import { mockedApplet, mockedPassword } from 'shared/mock';
 import { renderWithProviders } from 'shared/utils';
+import * as encryptionFunctions from 'shared/utils/encryption';
 
 import { ExportDataSetting } from './ExportDataSetting';
 import {
@@ -10,14 +12,24 @@ import {
   DATA_TESTID_EXPORT_DATA_SETTINGS_POPUP,
 } from './ExportDataSetting.const';
 
+const createdDate = '2023-11-14T14:43:33';
+
 const preloadedState = {
   applet: {
     applet: {
       ...initialStateData,
-      data: { result: { ...mockedApplet, createdAt: '2023-11-14T14:43:33.369902' } },
+      data: { result: { ...mockedApplet, createdAt: createdDate } },
     },
   },
 };
+
+const getPublicKeyMock = () => Buffer.from(JSON.parse(mockedApplet?.encryption?.publicKey || ''));
+
+const mockedExportDataApi = jest.fn();
+
+jest.mock('modules/Dashboard/api', () => ({
+  getExportDataApi: (body: ExportData) => mockedExportDataApi(body),
+}));
 
 describe('ExportDataSetting', () => {
   it('should not render export settings model if isExportSettingsOpen is false', async () => {
@@ -57,5 +69,53 @@ describe('ExportDataSetting', () => {
     );
 
     expect(mockOnClose).toHaveBeenCalled();
+  });
+
+  describe('date options', () => {
+    it('should pass settings specified in settings popup to the export popup', async () => {
+      const mockOnClose = jest.fn();
+
+      jest.spyOn(encryptionFunctions, 'getAppletEncryptionInfo').mockImplementation(() =>
+        Promise.resolve({
+          getPublicKey: getPublicKeyMock,
+        }),
+      );
+
+      renderWithProviders(
+        <ExportDataSetting isExportSettingsOpen onExportSettingsClose={mockOnClose} />,
+        {
+          preloadedState,
+        },
+      );
+
+      await waitFor(() =>
+        expect(screen.queryByTestId(DATA_TESTID_EXPORT_DATA_SETTINGS_POPUP)).toBeInTheDocument(),
+      );
+
+      fireEvent.click(screen.getByText('Download CSV'));
+
+      expect(screen.getByTestId(`${DATA_TESTID_EXPORT_DATA_EXPORT_POPUP}-password`)).toBeVisible();
+
+      fireEvent.change(await screen.findByLabelText('Password'), {
+        target: { value: mockedPassword },
+      });
+
+      fireEvent.click(
+        within(screen.getByTestId(`${DATA_TESTID_EXPORT_DATA_EXPORT_POPUP}-password`)).getByText(
+          'Submit',
+        ),
+      );
+
+      await waitFor(() => {
+        const requestBody = mockedExportDataApi.mock.calls[0][0];
+
+        expect(requestBody).toHaveProperty('appletId', mockedApplet.id);
+        expect(requestBody).toHaveProperty('fromDate', createdDate);
+
+        // We don't check an explicit value here because the `toDate` uses `new Date()`
+        // which will be different everytime the test runs
+        expect(requestBody).toHaveProperty('toDate');
+      });
+    });
   });
 });

--- a/src/shared/features/AppletSettings/ExportDataSetting/ExportDataSetting.tsx
+++ b/src/shared/features/AppletSettings/ExportDataSetting/ExportDataSetting.tsx
@@ -1,11 +1,20 @@
 import { useState } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { ObjectSchema } from 'yup';
+import { yupResolver } from '@hookform/resolvers/yup';
 
 import { DataExportPopup } from 'modules/Dashboard/features/Respondents/Popups';
 import { applet } from 'shared/state';
+import { getNormalizedTimezoneDate } from 'shared/utils';
 
-import { ExportDataSettingProps } from './ExportDataSetting.types';
-import { ExportSettingsPopup } from './Popups/ExportSettingsPopup/ExportSettingsPopup';
+import {
+  ExportDataFormValues,
+  ExportDataSettingProps,
+  ExportDateType,
+} from './ExportDataSetting.types';
 import { DATA_TESTID_EXPORT_DATA_EXPORT_POPUP } from './ExportDataSetting.const';
+import { exportDataSettingSchema } from './ExportDataSetting.schema';
+import { ExportSettingsPopup } from './Popups/ExportSettingsPopup/ExportSettingsPopup';
 
 export const ExportDataSetting = ({
   isExportSettingsOpen,
@@ -14,8 +23,20 @@ export const ExportDataSetting = ({
   const { result: appletData } = applet.useAppletData() ?? {};
   const [dataIsExporting, setDataIsExporting] = useState(false);
 
+  const minDate = new Date(appletData?.createdAt ?? '');
+  const getMaxDate = () => getNormalizedTimezoneDate(new Date().toString());
+  const methods = useForm<ExportDataFormValues>({
+    resolver: yupResolver(exportDataSettingSchema() as ObjectSchema<ExportDataFormValues>),
+    defaultValues: {
+      dateType: ExportDateType.AllTime,
+      fromDate: minDate,
+      toDate: getMaxDate(),
+    },
+    mode: 'onSubmit',
+  });
+
   return (
-    <>
+    <FormProvider {...methods}>
       {isExportSettingsOpen && (
         <ExportSettingsPopup
           isOpen
@@ -35,6 +56,6 @@ export const ExportDataSetting = ({
           data-testid={DATA_TESTID_EXPORT_DATA_EXPORT_POPUP}
         />
       )}
-    </>
+    </FormProvider>
   );
 };

--- a/src/shared/features/AppletSettings/ExportDataSetting/ExportDataSetting.tsx
+++ b/src/shared/features/AppletSettings/ExportDataSetting/ExportDataSetting.tsx
@@ -45,6 +45,8 @@ export const ExportDataSetting = ({
             setDataIsExporting(true);
             onExportSettingsClose();
           }}
+          minDate={minDate}
+          getMaxDate={getMaxDate}
         />
       )}
       {dataIsExporting && (

--- a/src/shared/features/AppletSettings/ExportDataSetting/Popups/ExportSettingsPopup/ExportSettingsPopup.test.tsx
+++ b/src/shared/features/AppletSettings/ExportDataSetting/Popups/ExportSettingsPopup/ExportSettingsPopup.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { addDays, format } from 'date-fns';
+import { FormProvider, useForm } from 'react-hook-form';
 
 import { initialStateData } from 'redux/modules';
 import { page } from 'resources';
@@ -9,7 +10,7 @@ import { SettingParam, renderWithProviders } from 'shared/utils';
 
 import { ExportSettingsPopup } from './ExportSettingsPopup';
 import { DATA_TESTID_EXPORT_DATA_SETTINGS_POPUP } from '../../ExportDataSetting.const';
-import { ExportDateType } from '../../ExportDataSetting.types';
+import { ExportDataFormValues, ExportDateType } from '../../ExportDataSetting.types';
 
 const dateString = '2023-11-14T14:43:33.369902';
 const date = new Date(dateString);
@@ -25,12 +26,27 @@ const preloadedState = {
 
 const mockOnClose = jest.fn();
 
+const FormComponent = ({ children }: { children: React.ReactNode }) => {
+  const methods = useForm<ExportDataFormValues>({
+    defaultValues: {
+      dateType: ExportDateType.AllTime,
+      fromDate: new Date(),
+      toDate: new Date(),
+    },
+    mode: 'onSubmit',
+  });
+
+  return <FormProvider {...methods}>{children}</FormProvider>;
+};
+
 describe('ExportSettingsPopup', () => {
   it('should appear if isOpen is true', async () => {
     const mockOnExport = jest.fn();
 
     renderWithProviders(
-      <ExportSettingsPopup isOpen onClose={mockOnClose} onExport={mockOnExport} />,
+      <FormComponent>
+        <ExportSettingsPopup isOpen onClose={mockOnClose} onExport={mockOnExport} />
+      </FormComponent>,
       {
         preloadedState,
       },
@@ -45,7 +61,9 @@ describe('ExportSettingsPopup', () => {
     const mockOnExport = jest.fn();
 
     renderWithProviders(
-      <ExportSettingsPopup isOpen={false} onClose={mockOnClose} onExport={mockOnExport} />,
+      <FormComponent>
+        <ExportSettingsPopup isOpen={false} onClose={mockOnClose} onExport={mockOnExport} />
+      </FormComponent>,
       {
         preloadedState,
       },
@@ -58,7 +76,9 @@ describe('ExportSettingsPopup', () => {
     const mockOnExport = jest.fn();
 
     renderWithProviders(
-      <ExportSettingsPopup isOpen onClose={mockOnClose} onExport={mockOnExport} />,
+      <FormComponent>
+        <ExportSettingsPopup isOpen onClose={mockOnClose} onExport={mockOnExport} />
+      </FormComponent>,
       {
         preloadedState,
       },
@@ -80,7 +100,9 @@ describe('ExportSettingsPopup', () => {
       const mockOnExport = jest.fn();
 
       renderWithProviders(
-        <ExportSettingsPopup isOpen onClose={mockOnClose} onExport={mockOnExport} />,
+        <FormComponent>
+          <ExportSettingsPopup isOpen onClose={mockOnClose} onExport={mockOnExport} />
+        </FormComponent>,
         {
           preloadedState,
         },
@@ -103,7 +125,9 @@ describe('ExportSettingsPopup', () => {
       const mockOnExport = jest.fn();
 
       renderWithProviders(
-        <ExportSettingsPopup isOpen onClose={mockOnClose} onExport={mockOnExport} />,
+        <FormComponent>
+          <ExportSettingsPopup isOpen onClose={mockOnClose} onExport={mockOnExport} />
+        </FormComponent>,
         { preloadedState, route, routePath },
       );
       const dateType = screen.getByTestId(`${DATA_TESTID_EXPORT_DATA_SETTINGS_POPUP}-dateType`);

--- a/src/shared/features/AppletSettings/ExportDataSetting/Popups/ExportSettingsPopup/ExportSettingsPopup.tsx
+++ b/src/shared/features/AppletSettings/ExportDataSetting/Popups/ExportSettingsPopup/ExportSettingsPopup.tsx
@@ -10,7 +10,6 @@ import { DatePicker, Modal } from 'shared/components';
 import { theme, StyledBodyLarge, StyledFlexTopCenter, StyledModalWrapper } from 'shared/styles';
 import { SelectEvent } from 'shared/types';
 import { DateType } from 'shared/components/DatePicker/DatePicker.types';
-import { getNormalizedTimezoneDate } from 'shared/utils';
 import { StyledAppletSettingsButton } from 'shared/features/AppletSettings/AppletSettings.styles';
 
 import { ExportSettingsPopupProps } from './ExportSettingsPopup.types';
@@ -19,7 +18,13 @@ import { DATA_TESTID_EXPORT_DATA_SETTINGS_POPUP } from '../../ExportDataSetting.
 import { ExportDataFormValues, ExportDateType } from '../../ExportDataSetting.types';
 import { StyledExportSettingsDescription } from './ExportSettingsPopup.styles';
 
-export const ExportSettingsPopup = ({ isOpen, onClose, onExport }: ExportSettingsPopupProps) => {
+export const ExportSettingsPopup = ({
+  isOpen,
+  onClose,
+  onExport,
+  minDate,
+  getMaxDate,
+}: ExportSettingsPopupProps) => {
   const { t } = useTranslation('app');
   const { result: appletData } = applet.useAppletData() ?? {};
 
@@ -28,9 +33,6 @@ export const ExportSettingsPopup = ({ isOpen, onClose, onExport }: ExportSetting
   const fromDate = watch('fromDate');
   const toDate = watch('toDate');
   const hasCustomDate = dateType === ExportDateType.ChooseDates;
-
-  const minDate = new Date(appletData?.createdAt ?? '');
-  const getMaxDate = () => getNormalizedTimezoneDate(new Date().toString());
 
   const commonProps = {
     maxDate: getMaxDate(),

--- a/src/shared/features/AppletSettings/ExportDataSetting/Popups/ExportSettingsPopup/ExportSettingsPopup.tsx
+++ b/src/shared/features/AppletSettings/ExportDataSetting/Popups/ExportSettingsPopup/ExportSettingsPopup.tsx
@@ -1,9 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { Box } from '@mui/material';
 import { addDays, endOfDay, startOfDay } from 'date-fns';
-import { ObjectSchema } from 'yup';
-import { yupResolver } from '@hookform/resolvers/yup';
-import { FormProvider, useForm } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 
 import { Svg } from 'shared/components/Svg';
 import { applet } from 'shared/state';
@@ -16,7 +14,6 @@ import { getNormalizedTimezoneDate } from 'shared/utils';
 import { StyledAppletSettingsButton } from 'shared/features/AppletSettings/AppletSettings.styles';
 
 import { ExportSettingsPopupProps } from './ExportSettingsPopup.types';
-import { exportDataSettingSchema } from '../../ExportDataSetting.schema';
 import { getDateTypeOptions } from './ExportSettingsPopup.utils';
 import { DATA_TESTID_EXPORT_DATA_SETTINGS_POPUP } from '../../ExportDataSetting.const';
 import { ExportDataFormValues, ExportDateType } from '../../ExportDataSetting.types';
@@ -26,22 +23,15 @@ export const ExportSettingsPopup = ({ isOpen, onClose, onExport }: ExportSetting
   const { t } = useTranslation('app');
   const { result: appletData } = applet.useAppletData() ?? {};
 
-  const minDate = new Date(appletData?.createdAt ?? '');
-  const getMaxDate = () => getNormalizedTimezoneDate(new Date().toString());
-  const methods = useForm<ExportDataFormValues>({
-    resolver: yupResolver(exportDataSettingSchema() as ObjectSchema<ExportDataFormValues>),
-    defaultValues: {
-      dateType: ExportDateType.AllTime,
-      fromDate: minDate,
-      toDate: getMaxDate(),
-    },
-    mode: 'onSubmit',
-  });
-  const { control, setValue, watch } = methods;
+  const { control, setValue, watch } = useFormContext<ExportDataFormValues>() ?? {};
   const dateType = watch('dateType');
   const fromDate = watch('fromDate');
   const toDate = watch('toDate');
   const hasCustomDate = dateType === ExportDateType.ChooseDates;
+
+  const minDate = new Date(appletData?.createdAt ?? '');
+  const getMaxDate = () => getNormalizedTimezoneDate(new Date().toString());
+
   const commonProps = {
     maxDate: getMaxDate(),
     control,
@@ -104,68 +94,66 @@ export const ExportSettingsPopup = ({ isOpen, onClose, onExport }: ExportSetting
       data-testid={DATA_TESTID_EXPORT_DATA_SETTINGS_POPUP}
     >
       <StyledModalWrapper>
-        <FormProvider {...methods}>
-          <form noValidate autoComplete="off">
-            <StyledExportSettingsDescription>
-              {t('exportDescription')}
-            </StyledExportSettingsDescription>
-            <SelectController
-              name={'dateType'}
-              control={control}
-              options={getDateTypeOptions()}
-              label={t('dateRange')}
-              data-testid={`${DATA_TESTID_EXPORT_DATA_SETTINGS_POPUP}-dateType`}
-              dropdownStyles={{
-                width: '30rem',
+        <form noValidate autoComplete="off">
+          <StyledExportSettingsDescription>
+            {t('exportDescription')}
+          </StyledExportSettingsDescription>
+          <SelectController
+            name={'dateType'}
+            control={control}
+            options={getDateTypeOptions()}
+            label={t('dateRange')}
+            data-testid={`${DATA_TESTID_EXPORT_DATA_SETTINGS_POPUP}-dateType`}
+            dropdownStyles={{
+              width: '30rem',
+            }}
+            SelectProps={{
+              autoWidth: true,
+            }}
+            customChange={onDateTypeChange}
+            style={{ width: '100%' }}
+          />
+          {hasCustomDate && (
+            <StyledFlexTopCenter
+              sx={{
+                mt: theme.spacing(2.4),
               }}
-              SelectProps={{
-                autoWidth: true,
-              }}
-              customChange={onDateTypeChange}
-              style={{ width: '100%' }}
-            />
-            {hasCustomDate && (
-              <StyledFlexTopCenter
-                sx={{
-                  mt: theme.spacing(2.4),
-                }}
-              >
-                <DatePicker
-                  {...commonProps}
-                  name="fromDate"
-                  onCloseCallback={onDatePickerClose}
-                  onSubmitCallback={onFromDateSubmit}
-                  label={t('startDate')}
-                  minDate={minDate}
-                  data-testid={`${DATA_TESTID_EXPORT_DATA_SETTINGS_POPUP}-from-date`}
-                  inputSx={{ width: '100%' }}
-                />
-                <StyledBodyLarge sx={{ margin: theme.spacing(0, 0.8) }}>
-                  {t('smallTo')}
-                </StyledBodyLarge>
-                <DatePicker
-                  {...commonProps}
-                  name="toDate"
-                  onSubmitCallback={onToDateSubmit}
-                  minDate={fromDate}
-                  label={t('endDate')}
-                  data-testid={`${DATA_TESTID_EXPORT_DATA_SETTINGS_POPUP}-to-date`}
-                  inputSx={{ width: '100%' }}
-                />
-              </StyledFlexTopCenter>
-            )}
-            <Box sx={{ textAlign: 'center' }}>
-              <StyledAppletSettingsButton
-                onClick={onExport}
-                variant="contained"
-                startIcon={<Svg width="18" height="18" id="export" />}
-                data-testid={`${DATA_TESTID_EXPORT_DATA_SETTINGS_POPUP}-button`}
-              >
-                {t('downloadCSV')}
-              </StyledAppletSettingsButton>
-            </Box>
-          </form>
-        </FormProvider>
+            >
+              <DatePicker
+                {...commonProps}
+                name="fromDate"
+                onCloseCallback={onDatePickerClose}
+                onSubmitCallback={onFromDateSubmit}
+                label={t('startDate')}
+                minDate={minDate}
+                data-testid={`${DATA_TESTID_EXPORT_DATA_SETTINGS_POPUP}-from-date`}
+                inputSx={{ width: '100%' }}
+              />
+              <StyledBodyLarge sx={{ margin: theme.spacing(0, 0.8) }}>
+                {t('smallTo')}
+              </StyledBodyLarge>
+              <DatePicker
+                {...commonProps}
+                name="toDate"
+                onSubmitCallback={onToDateSubmit}
+                minDate={fromDate}
+                label={t('endDate')}
+                data-testid={`${DATA_TESTID_EXPORT_DATA_SETTINGS_POPUP}-to-date`}
+                inputSx={{ width: '100%' }}
+              />
+            </StyledFlexTopCenter>
+          )}
+          <Box sx={{ textAlign: 'center' }}>
+            <StyledAppletSettingsButton
+              onClick={onExport}
+              variant="contained"
+              startIcon={<Svg width="18" height="18" id="export" />}
+              data-testid={`${DATA_TESTID_EXPORT_DATA_SETTINGS_POPUP}-button`}
+            >
+              {t('downloadCSV')}
+            </StyledAppletSettingsButton>
+          </Box>
+        </form>
       </StyledModalWrapper>
     </Modal>
   );

--- a/src/shared/features/AppletSettings/ExportDataSetting/Popups/ExportSettingsPopup/ExportSettingsPopup.types.ts
+++ b/src/shared/features/AppletSettings/ExportDataSetting/Popups/ExportSettingsPopup/ExportSettingsPopup.types.ts
@@ -2,4 +2,6 @@ export type ExportSettingsPopupProps = {
   isOpen: boolean;
   onClose: () => void;
   onExport: () => void;
+  minDate: Date;
+  getMaxDate: () => Date;
 };


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-5743](https://mindlogger.atlassian.net/browse/M2-5743)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

We moved export data settings into a popup in this PR: https://github.com/ChildMindInstitute/mindlogger-admin/pull/1496 and in the process moved the settings form into its own popup. In doing so I forgot to ensure that the popups were sharing a form context, resulting in `DataExportPopup` not getting the from and to date values from the settings.

This moves the `FormProvider` a level up to `ExportDataSettings` which is a parent to both `ExportSettingsPopup` and `DataExportPopup` so they both have access.

### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

<img width="1308" alt="Screenshot 2024-03-11 at 10 43 44 PM" src="https://github.com/ChildMindInstitute/mindlogger-admin/assets/1165936/e9c3d649-b8ce-40c3-a7ac-569833053e7d">
<img width="1314" alt="Screenshot 2024-03-11 at 10 43 29 PM" src="https://github.com/ChildMindInstitute/mindlogger-admin/assets/1165936/84dc8e4f-923b-4448-ae3d-dd920d7c7c44">

### 🪤 Peer Testing

<!--
Replace this with a series of test steps & expected outcomes.

Example test step:

- This is a test step.  Highlight actions **in bold**.

    **Expected outcome:** This is what to expect after the step
-->

Case | Testing Steps | Expected
-- | -- | --
Export should use correct `fromDate` and `toDate` for All Time | 1. Go to dashboard and click on applet<br />2. Click on applet settings and click "Export Data"<br />3. Select "All Time" for range and click "Download CSV"<br />4. Enter applet password if asked | 1. Network tab should show that `fromDate` uses applet create date and `toDate` uses now
Export should use correct `fromDate` and `toDate` for Last 24 hours | 1. Go to dashboard and click on applet<br />2. Click on applet settings and click "Export Data"<br />3. Select "Last 24 hours" for range and click "Download CSV"<br />4. Enter applet password if asked | 1. Network tab should show that `fromDate` uses 24 hours before now and `toDate` uses now
Export should use correct `fromDate` and `toDate` for Choose dates | 1. Go to dashboard and click on applet<br />2. Click on applet settings and click "Export Data"<br />3. Select "Choose dates" for range and click "Download CSV"<br />4. Enter applet password if asked | 1. Network tab should show that `fromDate` uses the first date you chose and `toDate` uses the second date

### ✏️ Notes

<!--
Replace this line with anything else you think may be relevant or related PRs

If there are no notes, then delete this section.
-->