### PR TITLE
M2-5556: DataViz: Make the feedback panel a split screen instead of an overlay

### DIFF
--- a/src/modules/Dashboard/features/RespondentData/RespondentData.styles.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentData.styles.ts
@@ -9,6 +9,13 @@ export const StyledMenu = styled(StyledFlexColumn)`
   border-right: ${variables.borderWidth.md} solid ${variables.palette.surface_variant};
   padding: ${theme.spacing(4.8, 1.6)};
   overflow-y: auto;
+
+  ${theme.breakpoints.down('xl')} {
+    width: 35rem;
+  }
+  ${theme.breakpoints.down('lg')} {
+    width: 30rem;
+  }
 `;
 
 export const StyledTextBtn = styled(Button)`

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/Feedback.styles.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/Feedback.styles.ts
@@ -5,10 +5,15 @@ import { StyledClearedButton, StyledFlexColumn, theme, variables } from 'shared/
 export const StyledContainer = styled(StyledFlexColumn)`
   width: 44rem;
   height: 100%;
-  position: absolute;
-  right: 0;
-  z-index: ${theme.zIndex.drawer};
   background-color: ${variables.palette.surface1};
+  flex-shrink: 0;
+
+  ${theme.breakpoints.down('xl')} {
+    width: 40rem;
+  }
+  ${theme.breakpoints.down('lg')} {
+    width: 35rem;
+  }
 `;
 
 export const StyledButton = styled(StyledClearedButton)`

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/Feedback.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/Feedback.tsx
@@ -10,8 +10,8 @@ import {
   theme,
 } from 'shared/styles';
 import { UiType } from 'shared/components/Tabs/Tabs.types';
-import { RespondentDataReviewContext } from 'modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.context';
 
+import { RespondentDataReviewContext } from '../RespondentDataReview.context';
 import { StyledButton, StyledContainer } from './Feedback.styles';
 import { getTabs } from './Feedback.const';
 import { FeedbackForm, FeedbackProps } from './Feedback.types';

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/FeedbackAssessment/FeedbackAssessment.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/FeedbackAssessment/FeedbackAssessment.tsx
@@ -5,8 +5,8 @@ import { useFormContext } from 'react-hook-form';
 import { auth } from 'redux/modules';
 import { useEncryptedAnswers } from 'modules/Dashboard/hooks';
 import { createAssessmentApi } from 'api';
-import { RespondentDataReviewContext } from 'modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.context';
 
+import { RespondentDataReviewContext } from '../../RespondentDataReview.context';
 import { AssessmentFormItem, FeedbackForm } from '../Feedback.types';
 import { FeedbackTabs } from './FeedbackAssessment.const';
 import { StyledContainer } from './FeedbackAssessment.styles';

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/FeedbackNotes/FeedbackNotes.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/FeedbackNotes/FeedbackNotes.tsx
@@ -16,8 +16,8 @@ import {
   getAnswersNotesApi,
 } from 'api';
 import { FeedbackForm } from 'modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback';
-import { RespondentDataReviewContext } from 'modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.context';
 
+import { RespondentDataReviewContext } from '../../RespondentDataReview.context';
 import { FeedbackNote } from './FeedbackNote';
 import { NOTE_ROWS_COUNT } from './FeedbackNotes.const';
 import { StyledContainer, StyledForm, StyledNoteListContainer } from './FeedbackNotes.styles';

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.styles.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.styles.ts
@@ -1,14 +1,8 @@
 import { Box, styled } from '@mui/material';
 
-export const StyledContentContainer = styled(Box)`
-  position: relative;
-  width: calc(100% - 40rem);
-  height: 100%;
-`;
-
 export const StyledReviewContainer = styled(Box)`
-  width: 100%;
   height: 100%;
   position: relative;
   overflow-y: auto;
+  flex-grow: 1;
 `;

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.tsx
@@ -30,7 +30,7 @@ import { ReviewMenu } from './ReviewMenu';
 import { ReviewHeader } from './ReviewHeader';
 import { RespondentDataReviewContext } from './RespondentDataReview.context';
 import { Answer, AssessmentActivityItem } from './RespondentDataReview.types';
-import { StyledContentContainer, StyledReviewContainer } from './RespondentDataReview.styles';
+import { StyledReviewContainer } from './RespondentDataReview.styles';
 
 export const RespondentDataReview = () => {
   const { appletId, respondentId } = useParams();
@@ -172,6 +172,7 @@ export const RespondentDataReview = () => {
         setIsLoading(false);
       }
     })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [appletId, answerId, selectedActivity, selectedAnswer]);
 
   useEffect(() => {
@@ -195,6 +196,7 @@ export const RespondentDataReview = () => {
     }
 
     handleSetInitialDate(new Date());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [lastActivityCompleted]);
 
   return (
@@ -228,24 +230,22 @@ export const RespondentDataReview = () => {
           setItemIds,
         }}
       >
-        <StyledContentContainer>
+        <StyledReviewContainer ref={containerRef} data-testid={`${dataTestid}-container`}>
           {isLoading && <Spinner />}
-          <StyledReviewContainer ref={containerRef} data-testid={`${dataTestid}-container`}>
-            <ReviewHeader
-              containerRef={containerRef}
-              isAnswerSelected={!!selectedAnswer}
-              activityName={selectedActivity?.name ?? ''}
-              onButtonClick={() => setIsFeedbackOpen(true)}
-              data-testid={dataTestid}
-            />
-            <Review
-              isLoading={isLoading}
-              selectedAnswer={selectedAnswer}
-              activityItemAnswers={activityItemAnswers}
-              data-testid={`${dataTestid}-activity-items`}
-            />
-          </StyledReviewContainer>
-        </StyledContentContainer>
+          <ReviewHeader
+            containerRef={containerRef}
+            isAnswerSelected={!!selectedAnswer}
+            activityName={selectedActivity?.name ?? ''}
+            onButtonClick={() => setIsFeedbackOpen(true)}
+            data-testid={dataTestid}
+          />
+          <Review
+            isLoading={isLoading}
+            selectedAnswer={selectedAnswer}
+            activityItemAnswers={activityItemAnswers}
+            data-testid={`${dataTestid}-activity-items`}
+          />
+        </StyledReviewContainer>
         {selectedActivity && selectedAnswer && !isLoading && (
           <Feedback selectedActivity={selectedActivity} onClose={() => setIsFeedbackOpen(false)} />
         )}

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewHeader/ReviewHeader.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewHeader/ReviewHeader.test.tsx
@@ -2,6 +2,7 @@ import userEvent from '@testing-library/user-event';
 
 import { renderWithProviders } from 'shared/utils';
 
+import { RespondentDataReviewContext } from '../RespondentDataReview.context';
 import { ReviewHeader } from './ReviewHeader';
 import { ReviewHeaderProps } from './ReviewHeader.types';
 
@@ -14,6 +15,7 @@ const defaultProps = {
   onButtonClick: mockOnButtonClick,
   'data-testid': dataTestId,
 };
+
 const renderReviewHeader = (props: ReviewHeaderProps) =>
   renderWithProviders(<ReviewHeader {...props} />);
 
@@ -51,5 +53,18 @@ describe('ReviewHeader', () => {
     expect(getComputedStyle(stickyHeader).justifyContent).toBe('flex-end');
     expect(queryByText('Activity Name')).not.toBeInTheDocument();
     expect(getByTestId(`${dataTestId}-feedback-button`)).toBeDisabled();
+  });
+
+  test('does not render the Feedback button if the Feedback Panel is open', async () => {
+    const { queryByTestId, queryByText } = renderWithProviders(
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      <RespondentDataReviewContext.Provider value={{ isFeedbackOpen: true }}>
+        <ReviewHeader {...defaultProps} isAnswerSelected />,
+      </RespondentDataReviewContext.Provider>,
+    );
+
+    expect(queryByText('Feedback')).not.toBeInTheDocument();
+    expect(queryByTestId(`${dataTestId}-feedback-button`)).not.toBeInTheDocument();
   });
 });

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewHeader/ReviewHeader.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewHeader/ReviewHeader.tsx
@@ -1,3 +1,4 @@
+import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Svg } from 'shared/components';
@@ -5,6 +6,7 @@ import { useHeaderSticky } from 'shared/hooks';
 import { StyledStickyHeader, StyledStickyHeadline } from 'shared/styles';
 
 import { StyledTextBtn } from '../../RespondentData.styles';
+import { RespondentDataReviewContext } from '../RespondentDataReview.context';
 import { ReviewHeaderProps } from './ReviewHeader.types';
 
 export const ReviewHeader = ({
@@ -16,6 +18,7 @@ export const ReviewHeader = ({
 }: ReviewHeaderProps) => {
   const { t } = useTranslation();
   const isHeaderSticky = useHeaderSticky(containerRef);
+  const { isFeedbackOpen } = useContext(RespondentDataReviewContext);
 
   return (
     <StyledStickyHeader
@@ -26,15 +29,17 @@ export const ReviewHeader = ({
       {isAnswerSelected && (
         <StyledStickyHeadline isSticky={isHeaderSticky}>{activityName}</StyledStickyHeadline>
       )}
-      <StyledTextBtn
-        variant="text"
-        onClick={onButtonClick}
-        disabled={!isAnswerSelected}
-        startIcon={<Svg id="item-outlined" width="18" height="18" />}
-        data-testid={`${dataTestid}-feedback-button`}
-      >
-        {t('feedback')}
-      </StyledTextBtn>
+      {!isFeedbackOpen && (
+        <StyledTextBtn
+          variant="text"
+          onClick={onButtonClick}
+          disabled={!isAnswerSelected}
+          startIcon={<Svg id="item-outlined" width="18" height="18" />}
+          data-testid={`${dataTestid}-feedback-button`}
+        >
+          {t('feedback')}
+        </StyledTextBtn>
+      )}
     </StyledStickyHeader>
   );
 };


### PR DESCRIPTION
- [x] Tests for the changes have been added
- [x] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

🔗 [Jira Ticket M2-5556](https://mindlogger.atlassian.net/browse/M2-5556)

### 📸 Screenshots

| Before                   | After                                 |
| -------------------------------------- | ------------------------------------- |
| ![image](https://github.com/ChildMindInstitute/mindlogger-admin/assets/116339462/9f11a730-e1ae-4a43-a4ca-4782cff20cd8) | ![image](https://github.com/ChildMindInstitute/mindlogger-admin/assets/116339462/360e5c8a-2fe4-4db3-bb78-f175849cc5ec) |
