### PR TITLE
M2-6056: [Admin Panel - Phase 1] - Allow to divide the space 50/50 between Drawing Example and Drawing Area

### DIFF
--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/Drawing/DrawingContent/DrawingContent.test.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/Drawing/DrawingContent/DrawingContent.test.tsx
@@ -1,0 +1,74 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+import { screen } from '@testing-library/react';
+
+import { mockedAppletId, mockedActivityId, mockedAppletFormData } from 'shared/mock';
+import { renderWithAppletFormData } from 'shared/utils/renderWithAppletFormData';
+import { page } from 'resources';
+
+import { DrawingContent } from './DrawingContent';
+
+const mockedDrawingItem = {
+  question: {
+    en: 'drawing\n',
+  },
+  responseType: 'drawing',
+  responseValues: {
+    drawingExample: 'https://some_media_example.jpg',
+    drawingBackground: 'https://some_media_background.jpg',
+  },
+  config: {
+    removeBackButton: false,
+    skippableItem: false,
+    additionalResponseOption: {
+      textInputOption: false,
+      textInputRequired: false,
+    },
+    timer: 0,
+    removeUndoButton: false,
+    navigationToTop: false,
+  },
+  name: 'drawing',
+  isHidden: false,
+  conditionalLogic: null,
+  allowEdit: true,
+  id: 'e2e611df-02d5-4316-8406-c5d685b94090',
+  order: 1,
+};
+const appletFormData = {
+  ...mockedAppletFormData,
+  activities: [
+    {
+      ...mockedAppletFormData.activities[0],
+      items: [mockedDrawingItem],
+    },
+  ],
+};
+const route = `/builder/${mockedAppletId}/activities/${mockedActivityId}/items/c17b7b59-8074-4c69-b787-88ea9ea3df5d`;
+const routePath = page.builderAppletActivityItem;
+const name = 'activities.0.itemws.0';
+
+describe('DrawingContent', () => {
+  test('render component with content', () => {
+    renderWithAppletFormData({
+      children: <DrawingContent name={name} />,
+      appletFormData,
+      options: { route, routePath },
+    });
+
+    expect(
+      screen.getByTestId('builder-activity-items-item-configuration-drawing-example'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('builder-activity-items-item-configuration-drawing-background'),
+    ).toBeInTheDocument();
+
+    const divideFlag = screen.getByTestId(
+      'builder-activity-items-item-configuration-drawing-divide-content-flag',
+    );
+    expect(divideFlag).toBeInTheDocument();
+    expect(divideFlag).toHaveTextContent(
+      'Divide the screen equally between the Drawing Example and the Drawing area',
+    );
+  });
+});

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/Drawing/DrawingContent/DrawingContent.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/Drawing/DrawingContent/DrawingContent.tsx
@@ -1,22 +1,27 @@
 import { useTranslation } from 'react-i18next';
+import { Box } from '@mui/material';
+import { useWatch } from 'react-hook-form';
 
 import { Uploader } from 'shared/components';
 import { MAX_FILE_SIZE_25MB } from 'shared/consts';
-import { theme } from 'shared/styles';
+import { StyledBodyMedium, theme } from 'shared/styles';
 import { byteFormatter } from 'shared/utils';
 import { Uploads } from 'modules/Builder/components';
 import { useCustomFormContext } from 'modules/Builder/hooks';
+import { CheckboxController } from 'shared/components/FormComponents/CheckboxController/CheckboxController';
 
 import { DrawingContentProps } from './DrawingContent.types';
 
 export const DrawingContent = ({ name }: DrawingContentProps) => {
   const { t } = useTranslation('app');
-  const { watch, setValue } = useCustomFormContext();
+  const { control, setValue } = useCustomFormContext();
 
   const drawingExampleName = `${name}.responseValues.drawingExample`;
   const drawingBackgroundName = `${name}.responseValues.drawingBackground`;
-  const drawingExample = watch(drawingExampleName);
-  const drawingBackground = watch(drawingBackgroundName);
+  const divideSpaceFlagName = `${name}.responseValues.proportion.enabled`;
+  const [drawingExample, drawingBackground] = useWatch({
+    name: [drawingExampleName, drawingBackgroundName],
+  });
   const dataTestid = 'builder-activity-items-item-configuration-drawing';
 
   const commonUploaderProps = {
@@ -55,13 +60,26 @@ export const DrawingContent = ({ name }: DrawingContentProps) => {
   ];
 
   return (
-    <Uploads
-      uploads={uploads}
-      wrapperStyles={{
-        mt: theme.spacing(2),
-        ml: theme.spacing(-4.8),
-        justifyContent: 'flex-start',
-      }}
-    />
+    <Box>
+      <Uploads
+        uploads={uploads}
+        wrapperStyles={{
+          mt: theme.spacing(2),
+          ml: theme.spacing(-4.8),
+          justifyContent: 'flex-start',
+          flexWrap: 'wrap',
+          width: 'unset',
+        }}
+      />
+      <CheckboxController
+        name={divideSpaceFlagName}
+        control={control}
+        label={<StyledBodyMedium>{t('drawingDivideFlagDescription')}</StyledBodyMedium>}
+        sxLabelProps={{
+          mt: theme.spacing(3),
+        }}
+        data-testid={`${dataTestid}-divide-content-flag`}
+      />
+    </Box>
   );
 };

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/Drawing/DrawingContent/DrawingContent.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/Drawing/DrawingContent/DrawingContent.tsx
@@ -64,8 +64,7 @@ export const DrawingContent = ({ name }: DrawingContentProps) => {
       <Uploads
         uploads={uploads}
         wrapperStyles={{
-          mt: theme.spacing(2),
-          ml: theme.spacing(-4.8),
+          m: theme.spacing(2, 0, 0, -4.8),
           justifyContent: 'flex-start',
           flexWrap: 'wrap',
           width: 'unset',

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/__mocks__/mock.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/__mocks__/mock.tsx
@@ -466,7 +466,11 @@ export const mockedEmptyDrawing = {
   isHidden: false,
   allowEdit: true,
   alerts: [],
-  responseValues: {},
+  responseValues: {
+    proportion: {
+      enabled: undefined,
+    },
+  },
 };
 export const mockedEmptyPhoto = {
   responseType: 'photo',

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -364,6 +364,7 @@
   "drawingBackgroundDescription": "This image is optional will serve as the background for the drawing. The respondent will be able to draw on it.",
   "drawingExample": "Drawing Example",
   "drawingExampleDescription": "This image is optional and will serve as an example for the drawing. The respondent will not be able to draw on it.",
+  "drawingDivideFlagDescription": "Divide the screen equally between the Drawing Example and the Drawing area",
   "drawingHint": "Drawing task",
   "dropAudio": "Please upload file in one of the following formats: <1>.mp3, .wav</1>.",
   "dropCsvFile": "Drop <1>.csv</1> here <br/>or <3>click to browse.</3>",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -364,6 +364,7 @@
   "drawingBackgroundDescription": "Cette image est facultative et servira d'arrière-plan pour le dessin. Le participant pourra dessiner dessus.",
   "drawingExample": "Exemple de dessin",
   "drawingExampleDescription": "Cette image est facultative et servira d'exemple pour le dessin. Le participant ne pourra pas dessiner dessus.",
+  "drawingDivideFlagDescription": "Divisez l'écran également entre l'exemple de dessin et la zone de dessin",
   "drawingHint": "Tâche de dessin",
   "dropAudio": "Veuillez uploader le fichier dans l'un des formats suivants : <1>.mp3 .wav</1>.",
   "dropCsvFile": "Déposez le fichier <1>.csv</1> ici <br/>ou <3>cliquez pour parcourir.</3>",

--- a/src/shared/components/FormComponents/CheckboxController/CheckboxController.tsx
+++ b/src/shared/components/FormComponents/CheckboxController/CheckboxController.tsx
@@ -14,6 +14,7 @@ export const CheckboxController = <T extends FieldValues>({
   isInversed,
   onCustomChange,
   'data-testid': dataTestid,
+  sxLabelProps = {},
   ...checkboxProps
 }: InputControllerProps<T>) => {
   const handleCheckboxChange = (
@@ -33,7 +34,7 @@ export const CheckboxController = <T extends FieldValues>({
         <>
           <FormControlLabel
             disabled={disabled}
-            sx={{ opacity: disabled ? variables.opacity.disabled : 1 }}
+            sx={{ opacity: disabled ? variables.opacity.disabled : 1, ...sxLabelProps }}
             label={label}
             control={
               <Checkbox

--- a/src/shared/components/FormComponents/CheckboxController/CheckboxController.types.ts
+++ b/src/shared/components/FormComponents/CheckboxController/CheckboxController.types.ts
@@ -1,5 +1,5 @@
 import { ChangeEvent } from 'react';
-import { CheckboxProps } from '@mui/material';
+import { CheckboxProps, SxProps } from '@mui/material';
 import { FieldValues, UseControllerProps } from 'react-hook-form';
 
 type FormCheckboxProps = {
@@ -7,6 +7,7 @@ type FormCheckboxProps = {
   isInversed?: boolean;
   onCustomChange?: (event: ChangeEvent<HTMLInputElement>) => void;
   'data-testid'?: string;
+  sxLabelProps?: SxProps;
 } & CheckboxProps;
 
 export type InputControllerProps<T extends FieldValues> = FormCheckboxProps & UseControllerProps<T>;

--- a/src/shared/mock.ts
+++ b/src/shared/mock.ts
@@ -545,6 +545,9 @@ export const mockedDrawingFormValues = {
   responseValues: {
     drawingExample: null,
     drawingBackground: null,
+    proportion: {
+      enabled: null,
+    },
   },
   config: {
     removeUndoButton: false,

--- a/src/shared/state/Applet/Applet.schema.ts
+++ b/src/shared/state/Applet/Applet.schema.ts
@@ -323,6 +323,9 @@ export type NumberItemResponseValues = {
 export type DrawingResponseValues = {
   drawingExample: string;
   drawingBackground: string;
+  proportion: {
+    enabled: boolean;
+  } | null;
 };
 
 export type GyroscopeConfig = {


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [X] Tests for the changes have been added
- [ ] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-6056](https://mindlogger.atlassian.net/browse/M2-6056)

### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| ![image](https://github.com/ChildMindInstitute/mindlogger-admin/assets/16320432/b8fa9a24-4467-4f42-bd39-f781cdfe6fcc) |  ![image](https://github.com/ChildMindInstitute/mindlogger-admin/assets/16320432/8273a880-5f08-4ec2-99b8-85b866848aac) |

### ✏️ Notes

<!--
Replace this line with anything else you think may be relevant or related PRs

If there are no notes, then delete this section.
-->
