### PR TITLE
M2-6038: [MI Applet Dashboard] Render Outlet for non-top-level tabs

### DIFF
--- a/src/modules/Dashboard/pages/Applet/AppletMultiInformant.tsx
+++ b/src/modules/Dashboard/pages/Applet/AppletMultiInformant.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, generatePath, useLocation, useParams } from 'react-router-dom';
+import { Link, Outlet, generatePath, useLocation, useParams } from 'react-router-dom';
 import { Button, Tooltip } from '@mui/material';
 
 import { LinkedTabs, Spinner, Svg } from 'shared/components';
@@ -21,7 +21,6 @@ import { palette } from 'shared/styles/variables/palette';
 import { page } from 'resources';
 import { Mixpanel } from 'shared/utils';
 import { ExportDataSetting } from 'shared/features/AppletSettings';
-import DashboardAppletSettings from 'modules/Dashboard/features/Applet/DashboardAppletSettings';
 import { StyledPanel } from 'shared/components/Tabs/TabPanel/TabPanel.style';
 
 import { useMultiInformantAppletTabs } from './Applet.hooks';
@@ -53,6 +52,8 @@ export const AppletMultiInformant = () => {
   if (isForbidden) return noPermissionsComponent;
 
   const isLoading = appletLoadingStatus === 'loading' || appletLoadingStatus === 'idle';
+
+  const isTopLevelTab = appletTabs.map((tabConfig) => tabConfig.path).includes(location.pathname);
   const isSettingsSelected = location.pathname.includes('settings');
 
   return (
@@ -112,6 +113,7 @@ export const AppletMultiInformant = () => {
           )}
 
           <LinkedTabs
+            deepPathCompare
             animateTabIndicator={false}
             defaultToFirstTab={false}
             hiddenHeader={hiddenHeader}
@@ -119,9 +121,22 @@ export const AppletMultiInformant = () => {
             tabs={appletTabs}
           />
 
-          {isSettingsSelected && (
+          {/*
+            The main `<Outlet />` for this page lives in LinkedTabs above. The outlet appears when
+            the current url matches the path config described in useMultiInformantAppletTabs.
+            This is an issue for routes like /settings and /add-user which are not top-level tabs.
+
+            Use of this extra `<Outlet />` is a temporary workaround for those routes. Both /settings
+            and /add-user are becoming modals that will NOT change the url. When that happens, we
+            should remove this.
+
+            See:
+              - https://mindlogger.atlassian.net/browse/M2-5987
+              - https://mindlogger.atlassian.net/browse/M2-5436
+          */}
+          {!isTopLevelTab && (
             <StyledPanel hiddenHeader={hiddenHeader}>
-              <DashboardAppletSettings />
+              <Outlet />
             </StyledPanel>
           )}
 


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-6038](https://mindlogger.atlassian.net/browse/M2-6038)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

This fixes an issue where certain pages (`/dashboard/[applet_id]/add-user`, `/dashboard/[applet_id]/respondents/[resopndent_id]/dataviz/summary`) were showing as blank.

The main `<Outlet />` for this page lives in `LinkedTabs`. The outlet appears when the current url matches the path config described in `useMultiInformantAppletTabs`. This is an issue for routes like /settings and /add-user which are not top-level tabs.

Use of an extra `<Outlet />` is a temporary workaround for those routes. Both /settings and /add-user are becoming modals that will NOT change the url. When that happens, we should be sure to modify this code.

### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| <!-- Paste before image/video here --> | <!-- Paste after image/video here --> |

### 🪤 Peer Testing

<!-- If peer testing is not needed, then delete this section -->
<!-- Uncomment out any of the following as needed:           -->
<!-- **Requires `npm install`**     -->

<!--
Replace this with a series of test steps & expected outcomes.

Example test step:

- This is a test step.  Highlight actions **in bold**.

    **Expected outcome:** This is what to expect after the step
-->

1. Ensure the `enable-multi-informant` feature flag is **ON**.
2. Navigate to the applet dashboard and click "Participants"
3. Click the "Add Participant" button

**Expected outcome:** Add user UI appears

4. Navigate back to the applet dashboard/Participants tab
5. Hover over a participant and click `...` to reveal menu. Click "View Data"

**Expected outcome:** Participants activity summary appears

### ✏️ Notes

<!--
Replace this line with anything else you think may be relevant or related PRs

If there are no notes, then delete this section.
-->
