### PR TITLE
M2-6108: Add refresh token renewal after refreshing (when access token has expired)

### DIFF
--- a/src/shared/api/api.ts
+++ b/src/shared/api/api.ts
@@ -1,5 +1,5 @@
 import { SingleApplet } from 'shared/state/Applet';
-import { AlertListParams, FileUploadUrlResult } from 'shared/api/api.types';
+import { AlertListParams, FileUploadUrlResult, RefreshResponse } from 'shared/api/api.types';
 import { OwnerId } from 'modules/Dashboard/api/api.types';
 
 import { apiClient, authApiClient } from './api.client';
@@ -15,7 +15,7 @@ export const signInRefreshTokenApi = (
   { refreshToken }: SignInRefreshTokenArgs,
   signal?: AbortSignal,
 ) =>
-  apiClient.post(
+  apiClient.post<ResponseWithObject<RefreshResponse>>(
     '/auth/token/refresh',
     { refreshToken },
     {

--- a/src/shared/api/api.types.ts
+++ b/src/shared/api/api.types.ts
@@ -53,3 +53,9 @@ export type FileUploadUrlResult = {
   uploadUrl: string;
   url: string;
 };
+
+export type RefreshResponse = {
+  accessToken: string;
+  refreshToken: string;
+  tokenType: string | null;
+};


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-6108](https://mindlogger.atlassian.net/browse/M2-6108)

This task involves implementing a mechanism to renew the refresh token after refreshing, specifically when the access token has expired.