### PR TITLE
M2-5921: Create Update Jira Tickets GitHub Actions workflow

### DIFF
--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -1,0 +1,120 @@
+name: Update Jira Tickets
+
+on:
+  release:
+    types: [created]
+  # Allows running manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      tagName:
+        description: "Tag Name"
+        required: true
+
+jobs:
+  process-release:
+    env:
+      JENKINS_USER: ${{ secrets.JENKINS_USER }}
+      JENKINS_TOKEN: ${{ secrets.JENKINS_TOKEN }}
+      JIRA_WEBHOOK_URL: ${{ secrets.JIRA_WEBHOOK_URL }}
+      JENKINS_HOST: ${{ vars.JENKINS_HOST }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Get current tag
+        id: get-tag
+        run: |
+          if [ "${{ github.event_name }}" == "release" ]; then
+            currentTag=${GITHUB_REF#refs/tags/}
+          else
+            currentTag="${{ github.event.inputs.tagName }}"
+          fi
+          echo "Tag: ${currentTag}"
+          echo "tag=${currentTag}" >> $GITHUB_OUTPUT
+
+      - name: Validate tag
+        run: |
+          git fetch -q --tags
+          if ! git tag --list | grep -qx "${{ steps.get-tag.outputs.tag }}"; then
+            echo "Not a valid tag, ending workflow"
+            exit 1
+          fi
+
+      - name: Check if tag is a release candidate
+        run: |
+          if [[ ${{ steps.get-tag.outputs.tag }} != *"-rc"* ]]; then
+            echo "Not a release candidate, ending workflow."
+            exit 1
+          fi
+
+      - name: Ping Jenkins for previous successful tag
+        id: ping-jenkins
+        run: |
+          repoName=${GITHUB_REPOSITORY##*/}
+          currentTag="${{ steps.get-tag.outputs.tag }}"
+          git fetch -q --tags
+          rcTags=$(git tag --sort=-creatordate | grep -- -rc)
+          started=false
+          previousTag=""
+
+          for tagName in $rcTags
+          do
+            # Skip tags more recent than the current one
+            if [ "$tagName" != "$currentTag" ] && [ "$started" = false ]; then
+              continue;
+            elif [ "$tagName" == "$currentTag" ]; then
+              started=true;
+              continue;
+            fi
+
+            jenkinsUrl="${JENKINS_HOST}/job/${repoName}/view/tags/job/${tagName}/lastSuccessfulBuild"
+            echo "Checking for successful Jenkins build for GitHub tag ${tagName} at ${jenkinsUrl}"
+            
+            response=$(curl -o /dev/null --silent -w "%{http_code}\n" -u "${JENKINS_USER}:${JENKINS_TOKEN}" "${jenkinsUrl}/api/json")
+            echo "Response: ${response}" 
+            if [ "$response" == "200" ]; then
+              echo "Found successful Jenkins build for GitHub tag ${tagName}: ${jenkinsUrl}"
+              previousTag="${tagName}"
+              break
+            fi
+          done
+          
+          if [ "${previousTag}" == "" ]; then
+            echo "No successful Jenkins builds found for any previous tags. Ending workflow"
+            exit 1
+          else
+            echo "tagName=${previousTag}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Determine Jira tickets from commit messages
+        id: jira-tickets
+        run: |
+          currentTag="${{ steps.get-tag.outputs.tag }}"
+          previousTag="${{ steps.ping-jenkins.outputs.tagName }}"
+          commitMessages=$(git log --pretty=%B $previousTag..$currentTag)
+          echo "Commit messages since the last release: ${commitMessages}"
+          jiraTickets=$(echo "$commitMessages" | grep -io 'M2-[0-9]\+' | tr '[:lower:]' '[:upper:]' | sort | uniq | tr '\n' ' ')
+          echo "Jira tickets since the last release: ${jiraTickets}"
+          echo "tickets=${jiraTickets}" >> $GITHUB_OUTPUT
+
+      - name: Periodically ping Jenkins for current tag build status
+        run: |
+          repoName=${GITHUB_REPOSITORY##*/}
+          currentTag="${{ steps.get-tag.outputs.tag }}"
+          echo "Waiting for current build to finish.."
+          while true; do
+            echo -n "."
+            result=$(curl --silent -u "${JENKINS_USER}:${JENKINS_TOKEN}" "${JENKINS_HOST}/job/${repoName}/view/tags/job/${currentTag}/lastBuild/api/json" | jq -r .result)
+            if [[ "$result" == "SUCCESS" ]]; then
+              echo "Build successful! Submitting ticket numbers to Jira"
+              tickets="${{ steps.jira-tickets.outputs.tickets }}"
+              json="{ \"issues\": $(echo "${tickets}" | jq -R -s -c 'split(" ")[:-1]') }"
+              curl -X POST -H 'Content-Type: application/json' --url "${JIRA_WEBHOOK_URL}" --data "$json"
+              break
+            elif [[ "$result" != "null" ]]; then
+              echo "Build failed, ending workflow"
+              break
+            fi
+            sleep 60
+          done

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -119,7 +119,7 @@ jobs:
             fi
           
             echo -n "."
-            result=$(curl --silent -u "${JENKINS_USER}:${JENKINS_TOKEN}" -connect-timeout 10 -m 10 "${JENKINS_HOST}/job/${repoName}/view/tags/job/${currentTag}/lastBuild/api/json" | jq -r .result)
+            result=$(curl --silent -u "${JENKINS_USER}:${JENKINS_TOKEN}" --connect-timeout 10 -m 10 "${JENKINS_HOST}/job/${repoName}/view/tags/job/${currentTag}/lastBuild/api/json" | jq -r .result)
             if [[ "$result" == "SUCCESS" ]]; then
               echo "Build successful! Submitting ticket numbers to Jira"
               tickets="${{ steps.jira-tickets.outputs.tickets }}"

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -124,7 +124,7 @@ jobs:
               echo "Build successful! Submitting ticket numbers to Jira"
               tickets="${{ steps.jira-tickets.outputs.tickets }}"
               json="{ \"issues\": $(echo "${tickets}" | jq -R -s -c 'split(" ")[:-1]') }"
-              # curl -X POST -H 'Content-Type: application/json' --url "${JIRA_WEBHOOK_URL}" --data "$json"
+              curl -X POST -H 'Content-Type: application/json' --url "${JIRA_WEBHOOK_URL}" --data "$json"
               break
             elif [[ "$result" != "null" ]]; then
               echo "Build failed, ending workflow"

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -17,6 +17,9 @@ jobs:
       JENKINS_TOKEN: ${{ secrets.JENKINS_TOKEN }}
       JIRA_WEBHOOK_URL: ${{ secrets.JIRA_WEBHOOK_URL }}
       JENKINS_HOST: ${{ vars.JENKINS_HOST }}
+
+      # The max amount of time (in minutes) we should wait for the current Jenkins build to finish. Defaults to 6 hours
+      JENKINS_BUILD_MAX_WAIT_MINS: ${{ vars.JENKINS_BUILD_MAX_WAIT_MINS || 360 }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -70,7 +73,7 @@ jobs:
 
             jenkinsUrl="${JENKINS_HOST}/job/${repoName}/view/tags/job/${tagName}/lastSuccessfulBuild"
             echo "Checking for successful Jenkins build for GitHub tag ${tagName} at ${jenkinsUrl}"
-            
+          
             response=$(curl -o /dev/null --silent -w "%{http_code}\n" -u "${JENKINS_USER}:${JENKINS_TOKEN}" "${jenkinsUrl}/api/json")
             echo "Response: ${response}" 
             if [ "$response" == "200" ]; then
@@ -103,9 +106,20 @@ jobs:
           repoName=${GITHUB_REPOSITORY##*/}
           currentTag="${{ steps.get-tag.outputs.tag }}"
           echo "Waiting for current build to finish.."
+          
+          start_time=$(date +%s)
           while true; do
+            current_time=$(date +%s)
+            elapsed_time_mins=$(( (current_time - start_time) / 60 ))
+          
+            # Break out of the loop if we've been waiting longer than 6 hours
+            if [ $elapsed_time_mins -ge $JENKINS_BUILD_MAX_WAIT_MINS ]; then
+                echo "Timed out waiting for build to finish"
+                exit 1
+            fi
+          
             echo -n "."
-            result=$(curl --silent -u "${JENKINS_USER}:${JENKINS_TOKEN}" "${JENKINS_HOST}/job/${repoName}/view/tags/job/${currentTag}/lastBuild/api/json" | jq -r .result)
+            result=$(curl --silent -u "${JENKINS_USER}:${JENKINS_TOKEN}" -connect-timeout 10 -m 10 "${JENKINS_HOST}/job/${repoName}/view/tags/job/${currentTag}/lastBuild/api/json" | jq -r .result)
             if [[ "$result" == "SUCCESS" ]]; then
               echo "Build successful! Submitting ticket numbers to Jira"
               tickets="${{ steps.jira-tickets.outputs.tickets }}"
@@ -114,7 +128,7 @@ jobs:
               break
             elif [[ "$result" != "null" ]]; then
               echo "Build failed, ending workflow"
-              break
+              exit 1
             fi
             sleep 60
           done

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -110,7 +110,7 @@ jobs:
               echo "Build successful! Submitting ticket numbers to Jira"
               tickets="${{ steps.jira-tickets.outputs.tickets }}"
               json="{ \"issues\": $(echo "${tickets}" | jq -R -s -c 'split(" ")[:-1]') }"
-              curl -X POST -H 'Content-Type: application/json' --url "${JIRA_WEBHOOK_URL}" --data "$json"
+              # curl -X POST -H 'Content-Type: application/json' --url "${JIRA_WEBHOOK_URL}" --data "$json"
               break
             elif [[ "$result" != "null" ]]; then
               echo "Build failed, ending workflow"


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-5921](https://mindlogger.atlassian.net/browse/M2-5921)

This PR introduces a GitHub Actions workflow that submits a list of ticket numbers to a Jira webhook based on a number of factors.

The workflow is triggered by a GitHub release, and it collates the list of Jira ticket numbers that were worked on since the last GitHub release that had a successful Jenkins build. It then waits for the outcome of the current build (trigged by the release) and submits that list of Jira tickets if the build is successful.

My original approach to this ticket was to modify the Jenkins scripts, but I changed that because it's much simpler to have this logic in one workflow (instead of being split across multiple CodeCommit repos), and we eventually intent to move CI/CD to GitHub Actions anyway so this is a step in that direction

### 🪤 Peer Testing

The code in this workflow is the same as that in https://github.com/ChildMindInstitute/mindlogger-backend-refactor/pull/1205. You may refer to the Peer Testing section of that PR's description for some test runs of these test scenarios

- **Success**: The happy path where there is a Jenkins build found for the previous release candidate, and we're able to generate and submit the Jira tickets that have been worked on since then
- **Not a release candidate**: The case where the workflow is triggered by a release with a tag that does not contain `-rc`
- **Invalid tag name**: The case where the workflow is run manually with a tag name that does not exist in the repository
- **No successful Jenkins build found**: The case where we are not able to find a successful Jenkins build for any of the previous release candidate tags in the repository
- **No Jenkins build triggered for tag/release**: The case where the release that triggered this workflow did not create a Jenkins build for some reason
- **Jenkins responds with 500 error code**: The case where Jenkins is having server errors
- **Jenkins doesn't respond**: The case where Jenkins doesn't respond to API calls

### ✏️ Notes

This PR targets main because I believe the workflow has to be on the default branch in order to take effect

This workflow is currently using Jenkins API credentials that I created from my Jenkins user. Before this is merged, we need to replace those credentials with a dedicated API user

- [ ] Replace my Jenkins API credentials with API user