### PR TITLE
M2-5590: [Activities Overview] Hook up "Edit Activity" action

### DIFF
--- a/src/modules/Dashboard/components/ActivitySummaryCard/ActivitySummaryCard.tsx
+++ b/src/modules/Dashboard/components/ActivitySummaryCard/ActivitySummaryCard.tsx
@@ -19,11 +19,12 @@ export const ActivitySummaryCard = ({
   name,
   participantCount,
   latestActivity,
+  'data-testid': dataTestId,
 }: ActivitySummaryCardProps) => {
   const { t } = useTranslation('app');
 
   return (
-    <StyledContainer>
+    <StyledContainer data-testid={dataTestId}>
       <StyledFlexSpaceBetween>
         <StyledImageContainer>
           {!!image && <StyledImg src={image} alt={name} />}

--- a/src/modules/Dashboard/features/Applet/Activities/Activities.tsx
+++ b/src/modules/Dashboard/features/Applet/Activities/Activities.tsx
@@ -17,7 +17,7 @@ import { getAppletActivitiesApi } from 'api';
 import { useAsync, useTable } from 'shared/hooks';
 import { DateFormats } from 'shared/consts';
 import { page } from 'resources';
-import { Activity } from 'redux/modules';
+import { Activity, workspaces } from 'redux/modules';
 import { ActivitySummaryCard } from 'modules/Dashboard/components';
 
 import { StyledButton, StyledSearch, StyledSvg } from './Activities.styles';
@@ -32,6 +32,9 @@ export const Activities = () => {
   const [isLoading, setIsLoading] = useState(false);
   const dataTestid = 'dashboard-applet-activities';
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+
+  const workspaceRoles = workspaces.useRolesData();
+  const roles = appletId ? workspaceRoles?.data?.[appletId] : undefined;
 
   const { execute: getActivities } = useAsync(
     getAppletActivitiesApi,
@@ -60,9 +63,13 @@ export const Activities = () => {
     () => ({
       editActivity: ({ context }: MenuActionProps<ActivityActionProps>) => {
         const { activityId } = context || {};
-        // TODO: Implement edit
-        // https://mindlogger.atlassian.net/browse/M2-5590
-        alert(`TODO: Edit activity (${activityId})`);
+
+        navigate(
+          generatePath(page.builderAppletActivity, {
+            appletId,
+            activityId,
+          }),
+        );
       },
       exportData: ({ context }: MenuActionProps<ActivityActionProps>) => {
         const { activityId } = context || {};
@@ -131,7 +138,7 @@ export const Activities = () => {
           content: () =>
             !!appletId && (
               <ActionsMenu
-                menuItems={getActivityActions({ actions, appletId, activityId })}
+                menuItems={getActivityActions({ actions, appletId, activityId, dataTestid, roles })}
                 data-testid={`${dataTestid}-activity-actions`}
                 buttonColor="secondary"
                 anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}

--- a/src/modules/Dashboard/features/Applet/Activities/Activities.types.ts
+++ b/src/modules/Dashboard/features/Applet/Activities/Activities.types.ts
@@ -1,5 +1,6 @@
 import { MenuActionProps } from 'shared/components';
 import { Activity } from 'redux/modules';
+import { Roles } from 'shared/consts';
 
 export type ActivityActionProps = {
   activityId: string;
@@ -18,6 +19,8 @@ export type ActivityActions = {
     assignActivity: (props: MenuActionProps<ActivityActionProps>) => void;
     takeNow: (props: MenuActionProps<ActivityActionProps>) => void;
   };
+  dataTestid: string;
   appletId: string;
   activityId: string;
+  roles?: Roles[];
 };

--- a/src/modules/Dashboard/features/Applet/Activities/Activities.utils.tsx
+++ b/src/modules/Dashboard/features/Applet/Activities/Activities.utils.tsx
@@ -2,6 +2,8 @@ import { t } from 'i18next';
 
 import { Svg } from 'shared/components/Svg';
 import { MenuItem, MenuItemType } from 'shared/components';
+import { isManagerOrOwner } from 'shared/utils';
+import { Roles } from 'shared/consts';
 
 import { ActivityActions, ActivityActionProps } from './Activities.types';
 
@@ -9,38 +11,47 @@ export const getActivityActions = ({
   actions: { editActivity, exportData, assignActivity, takeNow },
   appletId,
   activityId,
-}: ActivityActions): MenuItem<ActivityActionProps>[] => [
-  {
-    icon: <Svg id="edit" />,
-    action: editActivity,
-    title: t('editActivity'),
-    context: { appletId, activityId },
-    isDisplayed: true,
-    'data-testid': 'dashboard-applets-activities-activity-edit',
-  },
-  {
-    icon: <Svg id="export" />,
-    action: exportData,
-    title: t('exportData'),
-    context: { appletId, activityId },
-    isDisplayed: true,
-    'data-testid': 'dashboard-applets-activities-activity-export',
-  },
-  { type: MenuItemType.Divider },
-  {
-    icon: <Svg id="add" />,
-    action: assignActivity,
-    title: t('assignActivity'),
-    context: { appletId, activityId },
-    isDisplayed: true,
-    'data-testid': 'dashboard-applets-activities-activity-assign',
-  },
-  {
-    icon: <Svg id="play-outline" />,
-    action: takeNow,
-    title: t('takeNow'),
-    context: { appletId, activityId },
-    isDisplayed: true,
-    'data-testid': 'dashboard-applets-activities-activity-take-now',
-  },
-];
+  dataTestid,
+  roles,
+}: ActivityActions): MenuItem<ActivityActionProps>[] => {
+  const canEdit =
+    isManagerOrOwner(roles?.[0]) ||
+    roles?.includes(Roles.Editor) ||
+    roles?.includes(Roles.SuperAdmin);
+
+  return [
+    {
+      icon: <Svg id="edit" />,
+      action: editActivity,
+      title: t('editActivity'),
+      context: { appletId, activityId },
+      isDisplayed: canEdit,
+      'data-testid': `${dataTestid}-activity-edit`,
+    },
+    {
+      icon: <Svg id="export" />,
+      action: exportData,
+      title: t('exportData'),
+      context: { appletId, activityId },
+      isDisplayed: true,
+      'data-testid': `${dataTestid}-activity-export`,
+    },
+    { type: MenuItemType.Divider },
+    {
+      icon: <Svg id="add" />,
+      action: assignActivity,
+      title: t('assignActivity'),
+      context: { appletId, activityId },
+      isDisplayed: true,
+      'data-testid': `${dataTestid}-activity-assign`,
+    },
+    {
+      icon: <Svg id="play-outline" />,
+      action: takeNow,
+      title: t('takeNow'),
+      context: { appletId, activityId },
+      isDisplayed: true,
+      'data-testid': `${dataTestid}-activity-take-now`,
+    },
+  ];
+};

--- a/src/modules/Dashboard/features/Applets/AppletsTable/AppletItem/AppletItem.utils.tsx
+++ b/src/modules/Dashboard/features/Applets/AppletsTable/AppletItem/AppletItem.utils.tsx
@@ -2,7 +2,7 @@ import { t } from 'i18next';
 
 import { Svg } from 'shared/components/Svg';
 import { Roles } from 'shared/consts';
-import { isManagerOrOwner } from 'shared/utils';
+import { checkIfCanEdit, isManagerOrOwner } from 'shared/utils';
 import { variables } from 'shared/styles';
 
 import { AppletActions } from './AppletItem.types';
@@ -24,11 +24,10 @@ export const getAppletActions = ({
 }: AppletActions) => {
   const { isPublished } = item;
   const isReviewer = roles?.includes(Roles.Reviewer);
-  const isEditor = roles?.includes(Roles.Editor);
   const isOwner = roles?.includes(Roles.Owner);
   const isCoordinator = roles?.includes(Roles.Coordinator);
   const isSuperAdmin = roles?.includes(Roles.SuperAdmin);
-  const commonCondition = isManagerOrOwner(roles?.[0]) || isEditor || isSuperAdmin;
+  const canEdit = checkIfCanEdit(roles);
 
   return [
     {
@@ -56,14 +55,14 @@ export const getAppletActions = ({
       icon: <Svg id="widget" />,
       action: editAction,
       title: t('editAnApplet'),
-      isDisplayed: commonCondition,
+      isDisplayed: canEdit,
       'data-testid': 'dashboard-applets-applet-edit',
     },
     {
       icon: <Svg id="duplicate" />,
       action: duplicateAction,
       title: t('duplicateApplet'),
-      isDisplayed: commonCondition,
+      isDisplayed: canEdit,
       'data-testid': 'dashboard-applets-applet-duplicate',
     },
     {
@@ -92,7 +91,7 @@ export const getAppletActions = ({
       icon: <Svg id="trash" />,
       action: deleteAction,
       title: t('deleteApplet'),
-      isDisplayed: commonCondition,
+      isDisplayed: canEdit,
       customItemColor: variables.palette.dark_error_container,
       'data-testid': 'dashboard-applets-applet-delete',
     },

--- a/src/shared/utils/checkRole.test.ts
+++ b/src/shared/utils/checkRole.test.ts
@@ -1,6 +1,6 @@
 import { Roles } from 'shared/consts';
 
-import { isManagerOrOwner, isManagerOrOwnerOrEditor } from './checkRole';
+import { checkIfCanEdit, isManagerOrOwner, isManagerOrOwnerOrEditor } from './checkRole';
 
 describe('isManagerOrOwner', () => {
   test.each`
@@ -31,5 +31,21 @@ describe('isManagerOrOwnerOrEditor', () => {
     ${undefined}         | ${false} | ${'should be false for undefined'}
   `('$description', ({ role, expected }) => {
     expect(isManagerOrOwnerOrEditor(role)).toBe(expected);
+  });
+});
+
+describe('checkIfCanEdit', () => {
+  test.each`
+    roles                  | expected | description
+    ${[Roles.Manager]}     | ${true}  | ${'should be true for manager'}
+    ${[Roles.Editor]}      | ${true}  | ${'should be true for editor'}
+    ${[Roles.Coordinator]} | ${false} | ${'should be false for coordinator'}
+    ${[Roles.Owner]}       | ${true}  | ${'should be true for owner'}
+    ${[Roles.Respondent]}  | ${false} | ${'should be false for respondent'}
+    ${[Roles.Reviewer]}    | ${false} | ${'should be false for reviewer'}
+    ${[Roles.SuperAdmin]}  | ${true}  | ${'should be true for superadmin'}
+    ${undefined}           | ${false} | ${'should be false for undefined'}
+  `('$description', ({ roles, expected }) => {
+    expect(checkIfCanEdit(roles)).toBe(expected);
   });
 });

--- a/src/shared/utils/checkRole.ts
+++ b/src/shared/utils/checkRole.ts
@@ -4,3 +4,8 @@ export const isManagerOrOwner = (role?: Roles) => role === Roles.Manager || role
 
 export const isManagerOrOwnerOrEditor = (role?: Roles) =>
   isManagerOrOwner(role) || role === Roles.Editor;
+
+export const checkIfCanEdit = (roles?: Roles[]) =>
+  isManagerOrOwner(roles?.[0]) ||
+  roles?.includes(Roles.Editor) ||
+  roles?.includes(Roles.SuperAdmin);

--- a/src/shared/utils/checkRole.ts
+++ b/src/shared/utils/checkRole.ts
@@ -6,6 +6,8 @@ export const isManagerOrOwnerOrEditor = (role?: Roles) =>
   isManagerOrOwner(role) || role === Roles.Editor;
 
 export const checkIfCanEdit = (roles?: Roles[]) =>
-  isManagerOrOwner(roles?.[0]) ||
-  roles?.includes(Roles.Editor) ||
-  roles?.includes(Roles.SuperAdmin);
+  Boolean(
+    isManagerOrOwner(roles?.[0]) ||
+      roles?.includes(Roles.Editor) ||
+      roles?.includes(Roles.SuperAdmin),
+  );


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-5590](https://mindlogger.atlassian.net/browse/M2-5590)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Hooks up the "Edit Activity" menu item in the Activity Card on the Applet Dashboard Activities Overview page to the edit activity page. The "Edit Activity" Menu only displays if the user has permission to edit i.e. is a manager, owner, super admin, or editor — role logic that is the same as whether the "Edit an Applet" link will show on the applets screen

### 🪤 Peer Testing

<!-- If peer testing is not needed, then delete this section -->
<!-- Uncomment out any of the following as needed:           -->
<!-- **Requires `npm install`**     -->

<!--
Replace this with a series of test steps & expected outcomes.

Example test step:

- This is a test step.  Highlight actions **in bold**.

    **Expected outcome:** This is what to expect after the step
-->

**As privileged user**
1. Make sure the `enable-multi-informant` flag is **ON**
2. As an admin, open the Multi-Informant version of the Applet Dashboard, and click "Activities"
3. Click the "..." on one of the activity cards
4. **Verify that "Edit Activity link shows**
5. Click on the "Edit Activity" link
6. **Verify that you are routed to the edit page for that activity**

**As user without permissions**
1. Invite a user to the applet with the "Reviewer" permission
2. Log-in as that user and navigate to Applet Dashboard > Activities
3. Click the "..." on one of the activity cards
4. **Verify that "Edit Activity link does not show**