### PR TITLE
M2-6111: [Participant Overview] Link row to participant detail page

### DIFF
--- a/src/modules/Dashboard/components/DashboardTable/DashboardTable.tsx
+++ b/src/modules/Dashboard/components/DashboardTable/DashboardTable.tsx
@@ -76,6 +76,7 @@ export const DashboardTable = ({
                     width={row[key].width}
                     hasColFixedWidth={hasColFixedWidth}
                     sx={{ cursor: row[key].onClick ? 'pointer' : 'default' }}
+                    data-testid={`${dataTestid}-${index}-cell-${key}`}
                   >
                     {row[key].contentWithTooltip
                       ? row[key].contentWithTooltip

--- a/src/modules/Dashboard/features/Participants/Participants.test.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.test.tsx
@@ -1,5 +1,6 @@
 import { waitFor, screen, fireEvent } from '@testing-library/react';
 import mockAxios from 'jest-mock-axios';
+import { generatePath } from 'react-router-dom';
 
 import { renderWithProviders } from 'shared/utils';
 import {
@@ -53,6 +54,8 @@ const getMockedGetWithParticipants = (isAnonymousRespondent = false) => ({
   },
 });
 
+const mockedUseNavigate = jest.fn();
+
 const clickActionDots = async () => {
   const actionsDots = await waitFor(() =>
     screen.getByTestId('dashboard-participants-table-actions-dots'),
@@ -103,6 +106,22 @@ describe('Participants component tests', () => {
       tableColumnNames.forEach((column) => expect(screen.getByText(column)).toBeInTheDocument());
       participantColumns.forEach((column) => expect(screen.getByText(column)).toBeInTheDocument());
     });
+  });
+
+  test('participant row should link to participant details page', async () => {
+    mockAxios.get.mockResolvedValue(getMockedGetWithParticipants());
+    renderWithProviders(<Participants />, { preloadedState, route, routePath });
+    const firstParticipantSecretIdCell = await waitFor(() =>
+      screen.getByTestId('dashboard-participants-table-0-cell-secretIds'),
+    );
+    fireEvent.click(firstParticipantSecretIdCell);
+
+    expect(mockedUseNavigate).toHaveBeenCalledWith(
+      generatePath(page.appletParticipantActivities, {
+        appletId: mockedAppletId,
+        participantId: mockedRespondentId,
+      }),
+    );
   });
 
   test('should pin participant', async () => {

--- a/src/modules/Dashboard/features/Participants/Participants.test.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.test.tsx
@@ -44,6 +44,13 @@ const preloadedState = {
   },
 };
 
+const mockedUseNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedUseNavigate,
+}));
+
 const getMockedGetWithParticipants = (isAnonymousRespondent = false) => ({
   status: ApiResponseCodes.SuccessfulResponse,
   data: {
@@ -53,8 +60,6 @@ const getMockedGetWithParticipants = (isAnonymousRespondent = false) => ({
     count: 1,
   },
 });
-
-const mockedUseNavigate = jest.fn();
 
 const clickActionDots = async () => {
   const actionsDots = await waitFor(() =>

--- a/src/modules/Dashboard/features/Participants/Participants.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.tsx
@@ -284,6 +284,15 @@ export const Participants = () => {
     const stringSecretIds = joinWihComma(secretIds, true);
     const respondentOrSubjectId = respondentId ?? details[0].subjectId;
 
+    const defaultOnClick = () => {
+      navigate(
+        generatePath(page.appletParticipantActivities, {
+          appletId,
+          participantId: respondentOrSubjectId,
+        }),
+      );
+    };
+
     return {
       checkbox: {
         content: () => (
@@ -310,16 +319,19 @@ export const Participants = () => {
         content: () => stringSecretIds,
         value: stringSecretIds,
         width: ParticipantsColumnsWidth.Default,
+        onClick: defaultOnClick,
       },
       nicknames: {
         content: () => stringNicknames,
         value: stringNicknames,
         width: ParticipantsColumnsWidth.Default,
+        onClick: defaultOnClick,
       },
       tags: {
         content: () => <>--</>,
         value: '',
         width: ParticipantsColumnsWidth.Default,
+        onClick: defaultOnClick,
       },
       status: {
         content: () => (
@@ -331,17 +343,20 @@ export const Participants = () => {
         ),
         value: '',
         width: ParticipantsColumnsWidth.Status,
+        onClick: defaultOnClick,
       },
       lastSeen: {
         content: () => latestActive,
         value: latestActive,
         width: ParticipantsColumnsWidth.Default,
+        onClick: defaultOnClick,
       },
       ...(appletId && {
         schedule: {
           content: () => schedule,
           value: schedule,
           width: ParticipantsColumnsWidth.Schedule,
+          onClick: defaultOnClick,
         },
       }),
       actions: {

--- a/src/shared/layouts/BaseLayout/components/TopBar/Breadcrumbs/Breadcrumbs.hooks.test.ts
+++ b/src/shared/layouts/BaseLayout/components/TopBar/Breadcrumbs/Breadcrumbs.hooks.test.ts
@@ -595,7 +595,7 @@ describe('useBreadcrumbs', () => {
       icon: '',
       key: expect.any(String),
       label: 'Mocked Applet',
-      navPath: '/dashboard/71d90215-e4ae-41c5-8c30-776e69f5378b/respondents',
+      navPath: '/dashboard/71d90215-e4ae-41c5-8c30-776e69f5378b/participants',
       useCustomIcon: true,
     });
     expect(participant).toEqual({
@@ -656,7 +656,7 @@ describe('useBreadcrumbs', () => {
       icon: '',
       key: expect.any(String),
       label: 'Mocked Applet',
-      navPath: '/dashboard/71d90215-e4ae-41c5-8c30-776e69f5378b/respondents',
+      navPath: '/dashboard/71d90215-e4ae-41c5-8c30-776e69f5378b/participants',
       useCustomIcon: true,
     });
     expect(participant).toEqual({
@@ -724,7 +724,7 @@ describe('useBreadcrumbs', () => {
       icon: '',
       key: expect.any(String),
       label: 'Mocked Applet',
-      navPath: `/dashboard/${appletId}/respondents`,
+      navPath: `/dashboard/${appletId}/participants`,
       useCustomIcon: true,
     });
     expect(participant).toEqual({

--- a/src/shared/layouts/BaseLayout/components/TopBar/Breadcrumbs/Breadcrumbs.hooks.ts
+++ b/src/shared/layouts/BaseLayout/components/TopBar/Breadcrumbs/Breadcrumbs.hooks.ts
@@ -97,12 +97,16 @@ export const useBreadcrumbs = (restCrumbs?: Breadcrumb[]) => {
     }
 
     if (appletId && (isDashboard || isBuilder)) {
+      const participantsPath = enableMultiInformant
+        ? page.appletParticipants
+        : page.appletRespondents;
+
       newBreadcrumbs.push({
         icon: appletData?.image || '',
         useCustomIcon: true,
         label: appletLabel,
         chip: isBuilder ? t('editing') : undefined,
-        navPath: generatePath(isDashboard ? page.appletRespondents : page.builderApplet, {
+        navPath: generatePath(isDashboard ? participantsPath : page.builderApplet, {
           appletId,
         }),
         hasUrl: !!appletData?.image,


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-6111](https://mindlogger.atlassian.net/browse/M2-6111)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Adds a default `onClick` action for cells in the Participants Table that navigates to the participant detail page.

I wanted to just add a single `onClick` for the row itself, but `DatabaseTable` (the underlying component for `ParticipantsTable`) isn't set up to do that right now and is used in other places on the site. So while not the most DRY, this solution will hopefully do for now...

Also fixes the breadcrumbs for the Participants Detail page to go to `/participants` instead of `/respondents` if the feature flag is on

### 🪤 Peer Testing

<!-- If peer testing is not needed, then delete this section -->
<!-- Uncomment out any of the following as needed:           -->
<!-- **Requires `npm install`**     -->

<!--
Replace this with a series of test steps & expected outcomes.

Example test step:

- This is a test step.  Highlight actions **in bold**.

    **Expected outcome:** This is what to expect after the step
-->

- This change is based off the `feature/multiinformant-metapod` branch and requires that the `enable-multi-informant` feature flag is **ON**
- On the participants overview page, clicking on a participant row should navigate to the participant details page for that participant
- Clicking on checkmark in row should NOT navigate to participant details page
- Clicking on pin in row should NOT navigate to participant details page
- Clicking on actions in row should NOT navigate to participant details page

### ✏️ Notes

<!--
Replace this line with anything else you think may be relevant or related PRs

If there are no notes, then delete this section.
-->
