### PR TITLE
M2-6111: Improve display of missing data in participants table

### DIFF
--- a/src/modules/Dashboard/features/Participants/Participants.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.tsx
@@ -13,6 +13,7 @@ import { DEFAULT_ROWS_PER_PAGE, Roles } from 'shared/consts';
 import { StyledBody } from 'shared/styles';
 import { Respondent, RespondentStatus } from 'modules/Dashboard/types';
 import { StyledIcon } from 'shared/components/Search/Search.styles';
+import { StyledMaybeEmpty } from 'shared/styles/styledComponents/MaybeEmpty';
 
 import {
   AddParticipantButton,
@@ -277,7 +278,7 @@ export const Participants = () => {
       status,
       email,
     } = user;
-    const latestActive = lastSeen ? timeAgo.format(getDateInUserTimezone(lastSeen)) : '--';
+    const latestActive = lastSeen ? timeAgo.format(getDateInUserTimezone(lastSeen)) : '';
     const schedule =
       appletId && details?.[0]?.hasIndividualSchedule ? t('individual') : t('default');
     const stringNicknames = joinWihComma(nicknames, true);
@@ -328,7 +329,9 @@ export const Participants = () => {
         onClick: defaultOnClick,
       },
       tags: {
-        content: () => <>--</>,
+        // TODO: Replace `null` with tag when available
+        // https://mindlogger.atlassian.net/browse/M2-5861
+        content: () => <StyledMaybeEmpty>{null}</StyledMaybeEmpty>,
         value: '',
         width: ParticipantsColumnsWidth.Default,
         onClick: defaultOnClick,
@@ -341,12 +344,12 @@ export const Participants = () => {
             isInviteDisabled={!filteredRespondents?.[respondentOrSubjectId]?.editable.length}
           />
         ),
-        value: '',
+        value: status,
         width: ParticipantsColumnsWidth.Status,
         onClick: defaultOnClick,
       },
       lastSeen: {
-        content: () => latestActive,
+        content: () => <StyledMaybeEmpty>{latestActive}</StyledMaybeEmpty>,
         value: latestActive,
         width: ParticipantsColumnsWidth.Default,
         onClick: defaultOnClick,


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-6111](https://mindlogger.atlassian.net/browse/M2-6111)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

This addresses some leftover comments that were left on https://github.com/ChildMindInstitute/mindlogger-admin/pull/1622 re: styling of missing data/setting status value in case we want to be able to sort by status later

### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

<img width="1621" alt="Screenshot 2024-04-04 at 10 59 10 AM" src="https://github.com/ChildMindInstitute/mindlogger-admin/assets/1165936/efb9e53d-999f-4456-be9d-4c83e3486c12">