### PR TITLE
M2-4702: [Admin Panel] DataViz: Activity header is missed on the Summary tab if open the Activity details

### DIFF
--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Report.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Report.test.tsx
@@ -199,8 +199,8 @@ describe('Report component', () => {
   });
 
   test('renders Report correctly with no data', async () => {
-    jest.spyOn(reactHookForm, 'useWatch').mockReturnValue([[], {}, 0, {}, [], []]);
-    renderWithProviders(<Report activity={mockedActivity} identifiers={[]} versions={[]} />, {
+    jest.spyOn(reactHookForm, 'useWatch').mockReturnValue([[], {}, 0, mockedActivity, [], []]);
+    renderWithProviders(<Report />, {
       route,
       routePath,
       preloadedState,
@@ -208,5 +208,21 @@ describe('Report component', () => {
 
     expect(screen.getByTestId('report-empty-state')).toBeInTheDocument();
     expect(screen.getByText('No match was found. Try to adjust filters.')).toBeInTheDocument();
+  });
+
+  test('renders Report correctly with no answers', async () => {
+    const activityMocked = {
+      ...mockedActivity,
+      hasAnswer: false,
+    };
+    jest.spyOn(reactHookForm, 'useWatch').mockReturnValue([[], {}, 0, activityMocked, [], []]);
+    renderWithProviders(<Report />, {
+      route,
+      routePath,
+      preloadedState,
+    });
+
+    expect(screen.getByTestId('summary-empty-state')).toBeInTheDocument();
+    expect(screen.getByText('No available Data for this Activity yet')).toBeInTheDocument();
   });
 });

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Report.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Report.tsx
@@ -7,7 +7,13 @@ import { useWatch, useFormContext } from 'react-hook-form';
 
 import { Spinner, Svg } from 'shared/components';
 import { useAsync } from 'shared/hooks';
-import { StyledTitleLarge, theme, variables } from 'shared/styles';
+import {
+  StyledFlexAllCenter,
+  StyledTitleLarge,
+  headerFullHeight,
+  theme,
+  variables,
+} from 'shared/styles';
 import { DatavizActivity, getLatestReportApi, Version } from 'api';
 import { getErrorMessage } from 'shared/utils';
 import { applet } from 'shared/state';
@@ -33,6 +39,7 @@ import {
   LATEST_REPORT_TYPE,
 } from './Report.const';
 import { ReportHeader } from './ReportHeader';
+import { StyledEmptyReview } from '../RespondentDataSummary.styles';
 
 export const Report = () => {
   const { t } = useTranslation('app');
@@ -127,40 +134,54 @@ export const Report = () => {
           isButtonDisabled={disabledLatestReport}
           error={latestReportError ? getErrorMessage(latestReportError) : null}
         />
-        <Box sx={{ m: theme.spacing(4.8, 6.4) }}>
-          <ReportContext.Provider
-            value={{ currentActivityCompletionData, setCurrentActivityCompletionData }}
-          >
-            <ReportFilters
-              identifiers={identifiers}
-              versions={apiVersions}
-              setIsLoading={setIsLoading}
-            />
-            {!isLoading && answers.length > 0 && (
-              <>
-                <ActivityCompleted answers={answers} versions={apiVersions} />
-                {!!subscalesFrequency && (
-                  <Subscales
-                    answers={answers}
-                    versions={apiVersions}
-                    subscalesFrequency={subscalesFrequency}
-                  />
-                )}
-                {responseOptions && !!Object.values(responseOptions).length && (
-                  <ResponseOptions responseOptions={responseOptions} versions={apiVersions} />
-                )}
-              </>
-            )}
-            {!isLoading && !answers.length && (
-              <StyledEmptyState data-testid="report-empty-state">
-                <Svg id="chart" width="80" height="80" />
-                <StyledTitleLarge sx={{ mt: theme.spacing(1.6) }} color={variables.palette.outline}>
-                  {t('noDataForActivityFilters')}
-                </StyledTitleLarge>
-              </StyledEmptyState>
-            )}
-          </ReportContext.Provider>
-        </Box>
+        {!selectedActivity.hasAnswer ? (
+          <StyledFlexAllCenter sx={{ height: `calc(100% - ${headerFullHeight})` }}>
+            <StyledEmptyReview data-testid="summary-empty-state">
+              <Svg id="chart" width="80" height="80" />
+              <StyledTitleLarge sx={{ mt: theme.spacing(1.6) }} color={variables.palette.outline}>
+                {t('noDataForActivity')}
+              </StyledTitleLarge>
+            </StyledEmptyReview>
+          </StyledFlexAllCenter>
+        ) : (
+          <Box sx={{ m: theme.spacing(4.8, 6.4) }}>
+            <ReportContext.Provider
+              value={{ currentActivityCompletionData, setCurrentActivityCompletionData }}
+            >
+              <ReportFilters
+                identifiers={identifiers}
+                versions={apiVersions}
+                setIsLoading={setIsLoading}
+              />
+              {!isLoading && answers.length > 0 && (
+                <>
+                  <ActivityCompleted answers={answers} versions={apiVersions} />
+                  {!!subscalesFrequency && (
+                    <Subscales
+                      answers={answers}
+                      versions={apiVersions}
+                      subscalesFrequency={subscalesFrequency}
+                    />
+                  )}
+                  {responseOptions && !!Object.values(responseOptions).length && (
+                    <ResponseOptions responseOptions={responseOptions} versions={apiVersions} />
+                  )}
+                </>
+              )}
+              {!isLoading && !answers.length && (
+                <StyledEmptyState data-testid="report-empty-state">
+                  <Svg id="chart" width="80" height="80" />
+                  <StyledTitleLarge
+                    sx={{ mt: theme.spacing(1.6) }}
+                    color={variables.palette.outline}
+                  >
+                    {t('noDataForActivityFilters')}
+                  </StyledTitleLarge>
+                </StyledEmptyState>
+              )}
+            </ReportContext.Provider>
+          </Box>
+        )}
       </StyledReport>
     </>
   );

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Report.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Report.tsx
@@ -138,16 +138,7 @@ export const Report = () => {
           isButtonDisabled={disabledLatestReport}
           error={latestReportError ? getErrorMessage(latestReportError) : null}
         />
-        {!selectedActivity.hasAnswer ? (
-          <StyledFlexAllCenter sx={{ height: `calc(100% - ${headerFullHeight})` }}>
-            <StyledEmptyReview data-testid="summary-empty-state">
-              <Svg id="chart" width="80" height="80" />
-              <StyledTitleLarge sx={{ mt: theme.spacing(1.6) }} color={variables.palette.outline}>
-                {t('noDataForActivity')}
-              </StyledTitleLarge>
-            </StyledEmptyReview>
-          </StyledFlexAllCenter>
-        ) : (
+        {selectedActivity.hasAnswer ? (
           <Box sx={{ m: theme.spacing(4.8, 6.4) }}>
             <ReportContext.Provider
               value={{ currentActivityCompletionData, setCurrentActivityCompletionData }}
@@ -196,6 +187,15 @@ export const Report = () => {
               )}
             </ReportContext.Provider>
           </Box>
+        ) : (
+          <StyledFlexAllCenter sx={{ height: `calc(100% - ${headerFullHeight})` }}>
+            <StyledEmptyReview data-testid="summary-empty-state">
+              <Svg id="chart" width="80" height="80" />
+              <StyledTitleLarge sx={{ mt: theme.spacing(1.6) }} color={variables.palette.outline}>
+                {t('noDataForActivity')}
+              </StyledTitleLarge>
+            </StyledEmptyReview>
+          </StyledFlexAllCenter>
         )}
       </StyledReport>
     </>

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/RespondentDataSummary.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/RespondentDataSummary.test.tsx
@@ -76,16 +76,6 @@ const emptyStateCases = [
     selectedActivity: {
       id: 'd65e8a64-a023-4830-9c84-7433c4b96440',
       name: 'Activity 1',
-      isPerformanceTask: false,
-      hasAnswer: false,
-    },
-    expectedEmptyStateMessage: 'No available Data for this Activity yet',
-    description: "renders empty state component if selected activity doesn't have answers",
-  },
-  {
-    selectedActivity: {
-      id: 'd65e8a64-a023-4830-9c84-7433c4b96440',
-      name: 'Activity 1',
       isPerformanceTask: true,
       hasAnswer: true,
     },

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/RespondentDataSummary.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/RespondentDataSummary.tsx
@@ -43,7 +43,7 @@ export const RespondentDataSummary = () => {
 
   const reportContent = useMemo(() => {
     if (selectedActivity && isLoading) return <Spinner />;
-    if (!selectedActivity || !selectedActivity.hasAnswer || selectedActivity.isPerformanceTask) {
+    if (!selectedActivity || selectedActivity.isPerformanceTask) {
       return (
         <StyledFlexAllCenter sx={{ height: '100%' }}>
           <StyledEmptyReview data-testid="summary-empty-state">

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/RespondentDataSummary.utils.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/RespondentDataSummary.utils.test.tsx
@@ -50,18 +50,6 @@ describe('Respondent Data Summary utils', () => {
         screen.getByText(/Data visualization for Performance Tasks not supported/),
       ).toBeInTheDocument();
     });
-
-    test('returns JSX for activity with no data', () => {
-      const selectedActivity = {
-        hasAnswer: false,
-      };
-
-      const result = getEmptyState(selectedActivity);
-
-      render(<>{result}</>);
-
-      expect(screen.getByText(/No available Data for this Activity yet/)).toBeInTheDocument();
-    });
   });
 
   describe('getDateISO', () => {

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/RespondentDataSummary.utils.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/RespondentDataSummary.utils.tsx
@@ -84,16 +84,6 @@ export const getEmptyState = (selectedActivity: DatavizActivity | null) => {
       </>
     );
   }
-  if (!selectedActivity.hasAnswer) {
-    return (
-      <>
-        <Svg id="chart" width="80" height="80" />
-        <StyledTitleLarge sx={{ mt: theme.spacing(1.6) }} color={variables.palette.outline}>
-          {t('noDataForActivity')}
-        </StyledTitleLarge>
-      </>
-    );
-  }
 };
 
 export const getUniqueIdentifierOptions = (identifiers: Identifier[]) => {

--- a/src/shared/styles/styledComponents/StickyHeader.ts
+++ b/src/shared/styles/styledComponents/StickyHeader.ts
@@ -6,9 +6,11 @@ import { StyledFlexTopCenter } from 'shared/styles/styledComponents/Flex';
 import { shouldForwardProp } from 'shared/utils/shouldForwardProp';
 import { commonStickyStyles } from 'shared/styles/stylesConsts';
 
+export const headerFullHeight = '9.6rem';
+
 export const StyledStickyHeader = styled(StyledFlexTopCenter, shouldForwardProp)`
   ${commonStickyStyles};
   padding: ${theme.spacing(0, 6.4)};
-  min-height: ${({ isSticky }: { isSticky?: boolean }) => (isSticky ? '5.6rem' : '9.6rem')};
+  min-height: ${({ isSticky }: { isSticky?: boolean }) => (isSticky ? '5.6rem' : headerFullHeight)};
   box-shadow: ${({ isSticky }) => (isSticky ? variables.boxShadow.light0 : 'none')};
 `;


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [X] Tests for the changes have been added
- [ ] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-4702](https://mindlogger.atlassian.net/browse/M2-4702)

### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| ![image](https://github.com/ChildMindInstitute/mindlogger-admin/assets/16320432/75460037-1311-402f-a20d-466de1229243) | ![image](https://github.com/ChildMindInstitute/mindlogger-admin/assets/16320432/fd72b721-c52d-486f-894d-7c7f051ab4de) |

### ✏️ Notes

<!--
Replace this line with anything else you think may be relevant or related PRs

If there are no notes, then delete this section.
-->
