### PR TITLE
M2-6115: DataViz: the top of the table overlaps the Activity name

### DIFF
--- a/src/shared/styles/stylesConsts.ts
+++ b/src/shared/styles/stylesConsts.ts
@@ -6,7 +6,7 @@ export const commonStickyStyles = `
   width: 100%;
   top: 0;
   background-color: ${variables.palette.surface};
-  z-index: ${theme.zIndex.fab};
+  z-index: ${theme.zIndex.appBar};
   transition: ${variables.transitions.all};
 `;
 


### PR DESCRIPTION
- [ ] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-6115](https://mindlogger.atlassian.net/browse/M2-6115)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->


### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| ![overlapping](https://github.com/ChildMindInstitute/mindlogger-admin/assets/115553085/6fb629ba-c945-4140-a8ad-a55d163d3d92)| ![Снимок экрана 2024-04-09 в 13 01 28](https://github.com/ChildMindInstitute/mindlogger-admin/assets/115553085/cd1c2268-53b6-49cf-bb75-b6e52c2019a1)|
