### PR TITLE
M2-5769, M2-6112: Update participant view header

### DIFF
--- a/src/modules/Dashboard/components/HeaderOptions/HeaderOptions.test.tsx
+++ b/src/modules/Dashboard/components/HeaderOptions/HeaderOptions.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, screen } from '@testing-library/react';
+
+import { DATA_TESTID_EXPORT_DATA_SETTINGS_POPUP } from 'shared/features/AppletSettings/ExportDataSetting/ExportDataSetting.const';
+import { renderWithProviders } from 'shared/utils';
+
+import { HeaderOptions } from './HeaderOptions';
+
+const testId = 'test-applet-id';
+const mockUseNavigate = jest.fn();
+const mockedUseParams = () => ({ appletId: testId });
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockUseNavigate,
+  useParams: () => mockedUseParams(),
+}));
+
+describe('HeaderOptions', () => {
+  beforeEach(() => {
+    renderWithProviders(<HeaderOptions />);
+  });
+
+  test('should open Export dialog when option is pressed', () => {
+    fireEvent.click(screen.getByTestId('header-option-export-button'));
+
+    expect(screen.queryByTestId(DATA_TESTID_EXPORT_DATA_SETTINGS_POPUP)).toBeInTheDocument();
+  });
+
+  test('should contain link to settings page', () => {
+    expect(screen.getByTestId('header-option-settings-link')).toHaveAttribute(
+      'href',
+      `/dashboard/${testId}/settings`,
+    );
+  });
+});

--- a/src/modules/Dashboard/components/HeaderOptions/HeaderOptions.tsx
+++ b/src/modules/Dashboard/components/HeaderOptions/HeaderOptions.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react';
-import { Box, Button } from '@mui/material';
+import { Button, IconButton } from '@mui/material';
 import { Link, generatePath, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 import { page } from 'resources';
 import { Svg } from 'shared/components';
 import { ExportDataSetting } from 'shared/features/AppletSettings';
-import { theme, variables } from 'shared/styles';
+import { StyledFlexTopCenter, variables } from 'shared/styles';
 import { Mixpanel } from 'shared/utils';
 
 export const HeaderOptions = () => {
@@ -25,27 +25,29 @@ export const HeaderOptions = () => {
   };
 
   return (
-    <Box sx={{ display: 'flex', gap: theme.spacing(1), placeItems: 'baseline' }}>
+    <StyledFlexTopCenter sx={{ gap: 1 }}>
       <Button
         data-testid="header-option-export-button"
         onClick={handleOpenExport}
-        startIcon={<Svg id="export" width={24} height={24} />}
+        startIcon={<Svg id="export" width={18} height={18} />}
         sx={{ color: variables.palette.on_surface_variant }}
       >
         {t('export')}
       </Button>
 
-      <Link
-        data-testid="header-option-settings-link"
+      <IconButton
+        component={Link}
+        sx={{ width: '4.8rem', height: '4.8rem' }}
         to={generatePath(page.appletSettings, { appletId })}
+        data-testid="header-option-settings-link"
       >
         <Svg id="settings" fill={isSettingsSelected ? variables.palette.primary : ''} />
-      </Link>
+      </IconButton>
 
       <ExportDataSetting
         isExportSettingsOpen={isExportOpen}
         onExportSettingsClose={handleCloseExport}
       />
-    </Box>
+    </StyledFlexTopCenter>
   );
 };

--- a/src/modules/Dashboard/components/HeaderOptions/HeaderOptions.tsx
+++ b/src/modules/Dashboard/components/HeaderOptions/HeaderOptions.tsx
@@ -1,12 +1,12 @@
-import { Box, Button } from '@mui/material';
 import { useState } from 'react';
+import { Box, Button } from '@mui/material';
 import { Link, generatePath, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 import { page } from 'resources';
 import { Svg } from 'shared/components';
 import { ExportDataSetting } from 'shared/features/AppletSettings';
-import { StyledTitleMedium, theme, variables } from 'shared/styles';
+import { theme, variables } from 'shared/styles';
 import { Mixpanel } from 'shared/utils';
 
 export const HeaderOptions = () => {
@@ -15,21 +15,24 @@ export const HeaderOptions = () => {
   const { appletId } = useParams();
   const isSettingsSelected = location.pathname.includes('settings');
 
+  const handleOpenExport = () => {
+    setIsExportOpen(true);
+    Mixpanel.track('Export Data click');
+  };
+
+  const handleCloseExport = () => {
+    setIsExportOpen(false);
+  };
+
   return (
     <Box sx={{ display: 'flex', gap: theme.spacing(1), placeItems: 'baseline' }}>
       <Button
         data-testid="header-option-export-button"
-        sx={{ color: variables.palette.on_surface_variant, gap: theme.spacing(1) }}
-        onClick={() => {
-          setIsExportOpen(true);
-          Mixpanel.track('Export Data click');
-        }}
+        onClick={handleOpenExport}
+        startIcon={<Svg id="export" width={24} height={24} />}
+        sx={{ color: variables.palette.on_surface_variant }}
       >
-        <Svg id="export" width={24} height={24} />
-
-        <StyledTitleMedium as="span" sx={{ color: variables.palette.on_surface_variant }}>
-          {t('export')}
-        </StyledTitleMedium>
+        {t('export')}
       </Button>
 
       <Link
@@ -41,9 +44,7 @@ export const HeaderOptions = () => {
 
       <ExportDataSetting
         isExportSettingsOpen={isExportOpen}
-        onExportSettingsClose={() => {
-          setIsExportOpen(false);
-        }}
+        onExportSettingsClose={handleCloseExport}
       />
     </Box>
   );

--- a/src/modules/Dashboard/components/HeaderOptions/HeaderOptions.tsx
+++ b/src/modules/Dashboard/components/HeaderOptions/HeaderOptions.tsx
@@ -1,0 +1,50 @@
+import { Box, Button } from '@mui/material';
+import { useState } from 'react';
+import { Link, generatePath, useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+
+import { page } from 'resources';
+import { Svg } from 'shared/components';
+import { ExportDataSetting } from 'shared/features/AppletSettings';
+import { StyledTitleMedium, theme, variables } from 'shared/styles';
+import { Mixpanel } from 'shared/utils';
+
+export const HeaderOptions = () => {
+  const [isExportOpen, setIsExportOpen] = useState(false);
+  const { t } = useTranslation('app');
+  const { appletId } = useParams();
+  const isSettingsSelected = location.pathname.includes('settings');
+
+  return (
+    <Box sx={{ display: 'flex', gap: theme.spacing(1), placeItems: 'baseline' }}>
+      <Button
+        data-testid="header-option-export-button"
+        sx={{ color: variables.palette.on_surface_variant, gap: theme.spacing(1) }}
+        onClick={() => {
+          setIsExportOpen(true);
+          Mixpanel.track('Export Data click');
+        }}
+      >
+        <Svg id="export" width={24} height={24} />
+
+        <StyledTitleMedium as="span" sx={{ color: variables.palette.on_surface_variant }}>
+          {t('export')}
+        </StyledTitleMedium>
+      </Button>
+
+      <Link
+        data-testid="header-option-settings-link"
+        to={generatePath(page.appletSettings, { appletId })}
+      >
+        <Svg id="settings" fill={isSettingsSelected ? variables.palette.primary : ''} />
+      </Link>
+
+      <ExportDataSetting
+        isExportSettingsOpen={isExportOpen}
+        onExportSettingsClose={() => {
+          setIsExportOpen(false);
+        }}
+      />
+    </Box>
+  );
+};

--- a/src/modules/Dashboard/components/HeaderOptions/index.ts
+++ b/src/modules/Dashboard/components/HeaderOptions/index.ts
@@ -1,0 +1,1 @@
+export * from './HeaderOptions';

--- a/src/modules/Dashboard/pages/Applet/AppletMultiInformant.tsx
+++ b/src/modules/Dashboard/pages/Applet/AppletMultiInformant.tsx
@@ -1,26 +1,22 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, Outlet, generatePath, useLocation, useParams } from 'react-router-dom';
-import { Button, Tooltip } from '@mui/material';
+import { Outlet, useLocation, useParams } from 'react-router-dom';
+import { Tooltip } from '@mui/material';
 
+import { HeaderOptions } from 'modules/Dashboard/components/HeaderOptions';
 import { LinkedTabs, Spinner, Svg } from 'shared/components';
 import {
   StyledBody,
   StyledFlexSpaceBetween,
-  StyledFlexTopBaseline,
   StyledFlexTopCenter,
   StyledHeadlineLarge,
   StyledLogo,
-  StyledTitleMedium,
   theme,
-  variables,
 } from 'shared/styles';
 import { applet } from 'shared/state';
 import { useAppDispatch } from 'redux/store';
 import { usePermissions, useRemoveAppletData } from 'shared/hooks';
 import { palette } from 'shared/styles/variables/palette';
-import { page } from 'resources';
-import { Mixpanel } from 'shared/utils';
 import { ExportDataSetting } from 'shared/features/AppletSettings';
 import { StyledPanel } from 'shared/components/Tabs/TabPanel/TabPanel.style';
 
@@ -54,7 +50,6 @@ export const AppletMultiInformant = () => {
   const isLoading = appletLoadingStatus === 'loading' || appletLoadingStatus === 'idle';
 
   const isTopLevelTab = appletTabs.map((tabConfig) => tabConfig.path).includes(location.pathname);
-  const isSettingsSelected = location.pathname.includes('settings');
 
   return (
     <StyledBody>
@@ -84,31 +79,7 @@ export const AppletMultiInformant = () => {
                 )}
               </StyledFlexTopCenter>
 
-              <StyledFlexTopBaseline gap={theme.spacing(1)}>
-                <Button
-                  sx={{
-                    gap: theme.spacing(1),
-                    color: variables.palette.on_surface_variant,
-                  }}
-                  onClick={() => {
-                    setIsExportOpen(true);
-                    Mixpanel.track('Export Data click');
-                  }}
-                >
-                  <Svg id="export" width={24} height={24} />
-                  <StyledTitleMedium as="span" sx={{ color: variables.palette.on_surface_variant }}>
-                    {t('export')}
-                  </StyledTitleMedium>
-                </Button>
-                <Link
-                  data-testid="dashboard-tab-settings"
-                  to={generatePath(page.appletSettings, {
-                    appletId,
-                  })}
-                >
-                  <Svg id="settings" fill={isSettingsSelected ? variables.palette.primary : ''} />
-                </Link>
-              </StyledFlexTopBaseline>
+              <HeaderOptions />
             </StyledFlexSpaceBetween>
           )}
 

--- a/src/modules/Dashboard/pages/ParticipantDetails/ParticipantDetails.tsx
+++ b/src/modules/Dashboard/pages/ParticipantDetails/ParticipantDetails.tsx
@@ -6,7 +6,7 @@ import { HeaderOptions } from 'modules/Dashboard/components/HeaderOptions';
 import { useAppDispatch } from 'redux/store';
 import { LinkedTabs, Spinner } from 'shared/components';
 import { workspaces } from 'shared/state';
-import { StyledBody, StyledHeadlineLarge, theme } from 'shared/styles';
+import { StyledBody, StyledHeadlineLarge } from 'shared/styles';
 import { applet as appletState } from 'shared/state';
 import { applets, users } from 'modules/Dashboard/state';
 import { getRespondentDetails } from 'modules/Dashboard/state/Users/Users.thunk';
@@ -67,13 +67,13 @@ export const ParticipantDetails = () => {
           <Box
             sx={{
               display: 'flex',
-              gap: theme.spacing(1.6),
-              marginX: theme.spacing(2.4),
-              marginBottom: theme.spacing(1.2),
+              gap: 1.6,
+              marginBottom: 1.2,
+              marginX: 2.4,
               placeContent: 'space-between',
             }}
           >
-            <Box sx={{ display: 'flex', gap: theme.spacing(1.6) }}>
+            <Box sx={{ display: 'flex', gap: 1.6 }}>
               <StyledHeadlineLarge>{respondent?.result.secretUserId}</StyledHeadlineLarge>
               <StyledHeadlineLarge color={palette.outline}>
                 {respondent?.result.nickname}

--- a/src/modules/Dashboard/pages/ParticipantDetails/ParticipantDetails.tsx
+++ b/src/modules/Dashboard/pages/ParticipantDetails/ParticipantDetails.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { generatePath, useNavigate, useParams } from 'react-router-dom';
 import { Box } from '@mui/material';
 
+import { HeaderOptions } from 'modules/Dashboard/components/HeaderOptions';
 import { useAppDispatch } from 'redux/store';
 import { LinkedTabs, Spinner } from 'shared/components';
 import { workspaces } from 'shared/state';
@@ -23,8 +24,6 @@ export const ParticipantDetails = () => {
   const appletLoadingStatus = appletState.useResponseStatus();
   const respondentLoadingStatus = users.useRespondentStatus();
   const { useRespondent } = users;
-  const { useAppletData } = appletState;
-  const applet = useAppletData();
   const respondent = useRespondent();
   const { getApplet } = appletState.thunk;
 
@@ -71,13 +70,19 @@ export const ParticipantDetails = () => {
               gap: theme.spacing(1.6),
               marginX: theme.spacing(2.4),
               marginBottom: theme.spacing(1.2),
+              placeContent: 'space-between',
             }}
           >
-            <StyledHeadlineLarge>{respondent?.result.secretUserId}</StyledHeadlineLarge>
-            <StyledHeadlineLarge color={palette.outline}>
-              {respondent?.result.nickname}
-            </StyledHeadlineLarge>
+            <Box sx={{ display: 'flex', gap: theme.spacing(1.6) }}>
+              <StyledHeadlineLarge>{respondent?.result.secretUserId}</StyledHeadlineLarge>
+              <StyledHeadlineLarge color={palette.outline}>
+                {respondent?.result.nickname}
+              </StyledHeadlineLarge>
+            </Box>
+
+            <HeaderOptions />
           </Box>
+
           <LinkedTabs tabs={respondentTabs} isCentered={false} deepPathCompare />
         </>
       )}


### PR DESCRIPTION
### 📝 Description

🔗 [M2-5769](https://mindlogger.atlassian.net/browse/M2-5769): [Participant Detail] Export Function
🔗 [M2-6112](https://mindlogger.atlassian.net/browse/M2-6112): [Participant Detail] Open Settings

This PR updates the Participant View Header to include the "Export" and "Settings" options that are already visible on the Applet View Header.

Because these options are the same, I opted to abstract these options and their related functionality to a new component, which I've named `HeaderOptions`.

### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

| Before | After |
|-|-|
| ![localhost_3000_dashboard_76112bef-c9f9-4c72-8165-5bc0b64ea609_participants_8466fe1b-17df-4c56-805c-4257542de561(iPad Pro)](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/83923554-39b4-45c8-9383-790bd369c646) | ![localhost_3000_dashboard_76112bef-c9f9-4c72-8165-5bc0b64ea609_participants_8466fe1b-17df-4c56-805c-4257542de561(iPad Pro) (1)](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/df016010-1388-4b9a-9504-76cbc65915ef) |

### 🪤 Peer Testing

- On the Applet dashboard, the "Export" and "Settings" options continue to function as expected.
- On the Participant Details page within an applet, the "Export" and "Settings" options are visible in the header and function identically to the ones on the Applet Dashboard.


[M2-5769]: https://mindlogger.atlassian.net/browse/M2-5769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[M2-6112]: https://mindlogger.atlassian.net/browse/M2-6112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ