### PR TITLE
[M2-5609] Update DashboardTable/Team Listing View

### DIFF
--- a/src/modules/Dashboard/components/DashboardTable/DashboardTable.styles.ts
+++ b/src/modules/Dashboard/components/DashboardTable/DashboardTable.styles.ts
@@ -1,6 +1,7 @@
 import { styled, TableCell } from '@mui/material';
 
 import { TableHead } from 'shared/components';
+import { theme } from 'shared/styles';
 import { variables } from 'shared/styles/variables';
 import { shouldForwardProp } from 'shared/utils/shouldForwardProp';
 
@@ -23,7 +24,7 @@ export const StyledTableCell = styled(TableCell, shouldForwardProp)`
       `;
     }
 
-    return { paddingTop: 12, paddingBottom: 12 };
+    return { paddingTop: theme.spacing(1.2), paddingBottom: theme.spacing(1.2) };
   }}
 `;
 

--- a/src/modules/Dashboard/components/DashboardTable/DashboardTable.styles.ts
+++ b/src/modules/Dashboard/components/DashboardTable/DashboardTable.styles.ts
@@ -1,13 +1,17 @@
 import { styled, TableCell } from '@mui/material';
 
+import { TableHead } from 'shared/components';
 import { variables } from 'shared/styles/variables';
 import { shouldForwardProp } from 'shared/utils/shouldForwardProp';
 
 export const StyledTableCell = styled(TableCell, shouldForwardProp)`
-  font-size: ${variables.font.size.md};
-  line-height: ${variables.font.lineHeight.md};
+  font-size: ${variables.font.size.lg};
   letter-spacing: ${variables.font.letterSpacing.sm};
-  word-break: break-all;
+  line-height: ${variables.font.lineHeight.lg};
+
+  &&:first-of-type {
+    padding-left: 2rem;
+  }
 
   ${({ hasColFixedWidth, width }: { hasColFixedWidth?: boolean; width?: string }) => {
     if (hasColFixedWidth) {
@@ -19,8 +23,11 @@ export const StyledTableCell = styled(TableCell, shouldForwardProp)`
       `;
     }
 
-    return `
-      height: 4.8rem;
-    `;
+    return { paddingTop: 12, paddingBottom: 12 };
   }}
 `;
+
+export const StyledTableHead = styled(TableHead)({
+  '&& tr:nth-of-type(2) th': { padding: '1.2rem' },
+  '&& tr th:first-of-type': { paddingLeft: '2rem' },
+});

--- a/src/modules/Dashboard/components/DashboardTable/DashboardTable.tsx
+++ b/src/modules/Dashboard/components/DashboardTable/DashboardTable.tsx
@@ -1,8 +1,7 @@
-import { Table as MuiTable, TableBody, TablePagination, TableRow } from '@mui/material';
+import { Box, Table as MuiTable, TableBody, TablePagination, TableRow } from '@mui/material';
 
 import {
   EmptyState,
-  TableHead,
   UiType,
   StyledTableCellContent,
   StyledTableContainer,
@@ -10,7 +9,7 @@ import {
 import { DEFAULT_ROWS_PER_PAGE } from 'shared/consts';
 
 import { DashboardTableProps } from './DashboardTable.types';
-import { StyledTableCell } from './DashboardTable.styles';
+import { StyledTableCell, StyledTableHead } from './DashboardTable.styles';
 
 export const DashboardTable = ({
   columns,
@@ -52,10 +51,11 @@ export const DashboardTable = ({
       uiType={uiType}
       hasColFixedWidth={hasColFixedWidth}
       onScroll={onScroll}
+      sx={{ height: rows?.length ? 'auto' : '100%' }}
     >
       {!!rows?.length && (
         <MuiTable stickyHeader data-testid={dataTestid}>
-          <TableHead
+          <StyledTableHead
             headCells={columns}
             order={order}
             orderBy={orderBy}
@@ -78,9 +78,13 @@ export const DashboardTable = ({
                     sx={{ cursor: row[key].onClick ? 'pointer' : 'default' }}
                     data-testid={`${dataTestid}-${index}-cell-${key}`}
                   >
-                    {row[key].contentWithTooltip
-                      ? row[key].contentWithTooltip
-                      : row[key].content(row)}
+                    <Box
+                      sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                    >
+                      {row[key].contentWithTooltip
+                        ? row[key].contentWithTooltip
+                        : row[key].content(row)}
+                    </Box>
                   </StyledTableCell>
                 ))}
               </TableRow>

--- a/src/modules/Dashboard/components/DashboardTable/DashboardTable.tsx
+++ b/src/modules/Dashboard/components/DashboardTable/DashboardTable.tsx
@@ -1,4 +1,4 @@
-import { Box, Table as MuiTable, TableBody, TablePagination, TableRow } from '@mui/material';
+import { Table as MuiTable, TableBody, TablePagination, TableRow } from '@mui/material';
 
 import {
   EmptyState,
@@ -7,6 +7,7 @@ import {
   StyledTableContainer,
 } from 'shared/components';
 import { DEFAULT_ROWS_PER_PAGE } from 'shared/consts';
+import { StyledEllipsisText } from 'shared/styles';
 
 import { DashboardTableProps } from './DashboardTable.types';
 import { StyledTableCell, StyledTableHead } from './DashboardTable.styles';
@@ -78,13 +79,11 @@ export const DashboardTable = ({
                     sx={{ cursor: row[key].onClick ? 'pointer' : 'default' }}
                     data-testid={`${dataTestid}-${index}-cell-${key}`}
                   >
-                    <Box
-                      sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
-                    >
+                    <StyledEllipsisText>
                       {row[key].contentWithTooltip
                         ? row[key].contentWithTooltip
                         : row[key].content(row)}
-                    </Box>
+                    </StyledEllipsisText>
                   </StyledTableCell>
                 ))}
               </TableRow>

--- a/src/modules/Dashboard/components/ParticipantSnippet/ParticipantSnippet.tsx
+++ b/src/modules/Dashboard/components/ParticipantSnippet/ParticipantSnippet.tsx
@@ -31,14 +31,7 @@ export const ParticipantSnippet = <T extends ElementType = BoxTypeMap['defaultCo
       https://mindlogger.atlassian.net/browse/M2-5861
       https://mindlogger.atlassian.net/browse/M2-6161
       */}
-      {!!tag && (
-        <Chip
-          color="secondary"
-          title={tag}
-          sxProps={{ pointerEvents: 'none', m: 0 }}
-          data-testid={`${dataTestId}-tag`}
-        />
-      )}
+      {!!tag && <Chip color="secondary" title={tag} data-testid={`${dataTestId}-tag`} />}
     </StyledFlexTopCenter>
   );
 };

--- a/src/modules/Dashboard/features/Managers/Managers.test.tsx
+++ b/src/modules/Dashboard/features/Managers/Managers.test.tsx
@@ -9,7 +9,6 @@ import {
   mockedOwnerId,
   mockedManager,
   mockedEmail,
-  mockedManagerId,
 } from 'shared/mock';
 import { Roles } from 'shared/consts';
 import { initialStateData } from 'shared/state';
@@ -93,31 +92,13 @@ describe('Managers component tests', () => {
   test('should render table with managers', async () => {
     mockAxios.get.mockResolvedValueOnce(getMockedGetWithManagers());
     renderWithProviders(<Managers />, { preloadedState, route, routePath });
-    const tableColumnNames = ['First Name', 'Last Name', 'Email', 'Roles', 'Actions'];
+    const tableColumnNames = ['First Name', 'Last Name', 'Title', 'Role', 'Email'];
     const managersColumns = ['TestFirstName', 'TestLastName', mockedEmail, 'Reviewer'];
 
     await waitFor(() => {
       expect(screen.getByTestId('dashboard-managers-table')).toBeInTheDocument();
       tableColumnNames.forEach((column) => expect(screen.getByText(column)).toBeInTheDocument());
       managersColumns.forEach((column) => expect(screen.getByText(column)).toBeInTheDocument());
-    });
-  });
-
-  test('should pin manager', async () => {
-    mockAxios.get.mockResolvedValueOnce(getMockedGetWithManagers());
-    mockAxios.post.mockResolvedValueOnce(null);
-    renderWithProviders(<Managers />, { preloadedState, route, routePath });
-
-    const managerPin = await waitFor(() => screen.getByTestId('dashboard-managers-pin'));
-    fireEvent.click(managerPin);
-
-    await waitFor(() => {
-      expect(mockAxios.post).nthCalledWith(
-        1,
-        `/workspaces/${mockedOwnerId}/managers/${mockedManagerId}/pin`,
-        {},
-        { signal: undefined },
-      );
     });
   });
 

--- a/src/modules/Dashboard/features/Managers/Managers.tsx
+++ b/src/modules/Dashboard/features/Managers/Managers.tsx
@@ -9,13 +9,12 @@ import {
   Avatar,
   AvatarUiType,
   Chip,
-  ChipShape,
   MenuActionProps,
   Search,
   Spinner,
-  Svg,
 } from 'shared/components';
 import { banners, workspaces } from 'redux/modules';
+import { StyledMaybeEmpty } from 'shared/styles/styledComponents/MaybeEmpty';
 import { useAsync, usePermissions, useTable } from 'shared/hooks';
 import { DashboardTable, DashboardTableProps } from 'modules/Dashboard/components';
 import { Manager } from 'modules/Dashboard/types';
@@ -26,8 +25,8 @@ import { useAppDispatch } from 'redux/store';
 
 import { ManagersRemoveAccessPopup, EditAccessPopup } from './Popups';
 import { ManagersTableHeader } from './Managers.styles';
-import { getManagerActions, getHeadCells } from './Managers.utils';
 import { ManagersData } from './Managers.types';
+import { getManagerActions, getHeadCells } from './Managers.utils';
 
 export const Managers = () => {
   const { t } = useTranslation('app');
@@ -90,6 +89,17 @@ export const Managers = () => {
   const [removeAccessPopupVisible, setRemoveAccessPopupVisible] = useState(false);
   const [selectedManager, setSelectedManager] = useState<Manager | null>(null);
 
+  const actions = {
+    removeAccessAction: ({ context: user }: MenuActionProps<Manager>) => {
+      setSelectedManager(user || null);
+      setRemoveAccessPopupVisible(true);
+    },
+    editAccessAction: ({ context: user }: MenuActionProps<Manager>) => {
+      setSelectedManager(user || null);
+      setEditAccessPopupVisible(true);
+    },
+  };
+
   const removeManagerAccessOnClose = (step?: number) => {
     setRemoveAccessPopupVisible(false);
     step === 2 && handleReload();
@@ -113,26 +123,10 @@ export const Managers = () => {
         const renderedRoles = appletRole?.roles.map(({ role }) => (
           <Chip
             color="secondary"
-            shape={ChipShape.Rounded}
             key={role}
             title={`${role.charAt(0).toLocaleUpperCase()}${role.slice(1)}`}
           />
         ));
-        const actions = {
-          removeAccessAction: ({ context: user }: MenuActionProps<Manager>) => {
-            setSelectedManager(user || null);
-            setRemoveAccessPopupVisible(true);
-          },
-          editAccessAction: ({ context: user }: MenuActionProps<Manager>) => {
-            setSelectedManager(user || null);
-            setEditAccessPopupVisible(true);
-          },
-        };
-        const emptyContent = (
-          <Box component="span" sx={{ color: variables.palette.outline_variant2 }}>
-            --
-          </Box>
-        );
 
         return {
           checkbox: {
@@ -141,14 +135,6 @@ export const Managers = () => {
                 aria-label={`${firstName} ${lastName}`}
                 checked={false}
                 data-testid="dashboard-managers-checkbox"
-                icon={
-                  <Svg
-                    fill={variables.palette.outline_variant2}
-                    height="20"
-                    id="checkbox-empty-outlined"
-                    width="20"
-                  />
-                }
               />
             ),
             value: '',
@@ -173,25 +159,25 @@ export const Managers = () => {
             width: '8rem',
           },
           firstName: {
-            content: () => firstName ?? emptyContent,
+            content: () => <StyledMaybeEmpty>{firstName}</StyledMaybeEmpty>,
             value: firstName,
           },
           lastName: {
-            content: () => lastName ?? emptyContent,
+            content: () => <StyledMaybeEmpty>{lastName}</StyledMaybeEmpty>,
             value: lastName,
           },
           title: {
-            content: () => emptyContent,
+            content: () => <StyledMaybeEmpty />,
             value: '',
           },
           ...(appletId && {
             roles: {
-              content: () => <>{renderedRoles ?? emptyContent}</>,
+              content: () => <StyledMaybeEmpty>{renderedRoles}</StyledMaybeEmpty>,
               value: stringRoles,
             },
           }),
           email: {
-            content: () => email ?? emptyContent,
+            content: () => <StyledMaybeEmpty>{email}</StyledMaybeEmpty>,
             value: email,
           },
           actions: {
@@ -201,10 +187,11 @@ export const Managers = () => {
               }
 
               return (
-                <Box display="flex" justifyContent="flex-end" alignItems="center" width="100%">
+                <Box sx={{ alignItems: 'center', display: 'flex', justifyContent: 'flex-end' }}>
                   <ActionsMenu
-                    menuItems={getManagerActions(actions, filteredManager)}
+                    buttonColor="secondary"
                     data-testid="dashboard-managers-table-actions"
+                    menuItems={getManagerActions(actions, filteredManager)}
                   />
                 </Box>
               );

--- a/src/modules/Dashboard/features/Managers/Managers.utils.test.tsx
+++ b/src/modules/Dashboard/features/Managers/Managers.utils.test.tsx
@@ -4,7 +4,15 @@ import { variables } from 'shared/styles';
 
 import { getManagerActions, getHeadCells } from './Managers.utils';
 
-const headCellProperties = ['pin', 'firstName', 'lastName', 'email', 'actions'];
+const headCellProperties = [
+  'checkbox',
+  'avatar',
+  'firstName',
+  'lastName',
+  'title',
+  'email',
+  'actions',
+];
 const removeAccessAction = jest.fn();
 const editAccessAction = jest.fn();
 
@@ -12,7 +20,7 @@ describe('Managers utils tests', () => {
   describe('getHeadCells function', () => {
     test('returns the correct array of head cells without an id', () => {
       const headCells = getHeadCells();
-      expect(headCells).toHaveLength(5);
+      expect(headCells).toHaveLength(7);
       headCellProperties.forEach((property, index) => {
         expect(headCells[index]).toHaveProperty('id', property);
       });
@@ -20,8 +28,8 @@ describe('Managers utils tests', () => {
 
     test('returns the correct array of head cells with an id', () => {
       const headCells = getHeadCells(mockedAppletId);
-      expect(headCells).toHaveLength(6);
-      expect(headCells[4]).toHaveProperty('id', 'roles');
+      expect(headCells).toHaveLength(8);
+      expect(headCells[5]).toHaveProperty('id', 'role');
     });
   });
 

--- a/src/modules/Dashboard/features/Managers/Managers.utils.tsx
+++ b/src/modules/Dashboard/features/Managers/Managers.utils.tsx
@@ -1,3 +1,5 @@
+import { Checkbox } from '@mui/material';
+
 import i18n from 'i18n';
 import { Svg } from 'shared/components/Svg';
 import { HeadCell } from 'shared/types/table';
@@ -17,42 +19,61 @@ export const getHeadCells = (id?: string): HeadCell[] => {
 
   return [
     {
-      id: 'pin',
+      id: 'checkbox',
+      label: (
+        <Checkbox
+          aria-label="Check all"
+          checked={false}
+          data-testid="dashboard-managers-checkbox-header"
+          icon={
+            <Svg
+              fill={variables.palette.outline_variant2}
+              height="20"
+              id="checkbox-empty-outlined"
+              width="20"
+            />
+          }
+        />
+      ),
+      width: '8rem',
+    },
+    {
+      id: 'avatar',
       label: '',
-      enableSort: true,
-      width: ManagersColumnsWidth.Pin,
+      width: '8rem',
     },
     {
       id: 'firstName',
       label: t('firstName'),
       enableSort: true,
-      width: ManagersColumnsWidth.Default,
     },
     {
       id: 'lastName',
       label: t('lastName'),
       enableSort: true,
-      width: ManagersColumnsWidth.Default,
     },
     {
-      id: 'email',
-      label: t('email'),
-      enableSort: true,
-      width: ManagersColumnsWidth.Email,
+      id: 'title',
+      label: 'Title',
     },
     ...(id
       ? [
           {
-            id: 'roles',
-            label: t('roles'),
+            id: 'role',
+            label: t('role'),
             enableSort: true,
-            width: ManagersColumnsWidth.Default,
           },
         ]
       : []),
     {
+      id: 'email',
+      label: t('email'),
+      enableSort: true,
+    },
+    {
       id: 'actions',
-      label: t('actions'),
+      label: '',
+      width: '8rem',
     },
   ];
 };

--- a/src/modules/Dashboard/features/Managers/Managers.utils.tsx
+++ b/src/modules/Dashboard/features/Managers/Managers.utils.tsx
@@ -8,33 +8,13 @@ import { variables } from 'shared/styles';
 
 import { ManagersActions } from './Managers.types';
 
-export enum ManagersColumnsWidth {
-  Pin = '4.8rem',
-  Default = '22rem',
-  Email = '35rem',
-}
-
 export const getHeadCells = (id?: string): HeadCell[] => {
   const { t } = i18n;
 
   return [
     {
       id: 'checkbox',
-      label: (
-        <Checkbox
-          aria-label="Check all"
-          checked={false}
-          data-testid="dashboard-managers-checkbox-header"
-          icon={
-            <Svg
-              fill={variables.palette.outline_variant2}
-              height="20"
-              id="checkbox-empty-outlined"
-              width="20"
-            />
-          }
-        />
-      ),
+      label: <Checkbox aria-label={t('checkAll')} checked={false} />,
       width: '8rem',
     },
     {

--- a/src/modules/Dashboard/features/Participants/Participants.const.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.const.tsx
@@ -1,6 +1,5 @@
 export enum ParticipantsColumnsWidth {
   Pin = '8rem',
-  Actions = '3.2rem',
   Default = '28rem',
   Schedule = '15rem',
   AccountType = '16rem',

--- a/src/modules/Dashboard/features/Participants/Participants.const.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.const.tsx
@@ -1,5 +1,6 @@
 export enum ParticipantsColumnsWidth {
-  Pin = '4.8rem',
+  Pin = '8rem',
+  Actions = '3.2rem',
   Default = '28rem',
   Schedule = '15rem',
   AccountType = '16rem',

--- a/src/modules/Dashboard/features/Participants/Participants.styles.ts
+++ b/src/modules/Dashboard/features/Participants/Participants.styles.ts
@@ -2,7 +2,6 @@ import { Button, styled } from '@mui/material';
 
 import { DashboardTable } from 'modules/Dashboard/components';
 import { Search } from 'shared/components';
-import { StyledIcon } from 'shared/components/Search/Search.styles';
 import { StyledFlexSpaceBetween, StyledFlexTopCenter } from 'shared/styles/styledComponents';
 import theme from 'shared/styles/theme';
 import { variables } from 'shared/styles/variables';
@@ -52,21 +51,7 @@ export const AddParticipantButton = styled(StyledButton)`
   min-width: 13.7rem;
 `;
 
-export const StyledCheckBox = styled(StyledIcon)`
-  svg {
-    fill: ${variables.palette.outline_variant};
-  }
-`;
-
 export const ParticipantsTable = styled(DashboardTable)`
-  th:nth-child(1) {
-    padding-left: 2.4rem;
-  }
-
-  td:nth-child(1) {
-    padding-left: 1.4rem;
-  }
-
   td,
   th {
     min-width: 13rem;

--- a/src/modules/Dashboard/features/Participants/Participants.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.tsx
@@ -4,14 +4,23 @@ import { generatePath, useNavigate, useParams } from 'react-router-dom';
 import { Checkbox } from '@mui/material';
 
 import { EmptyDashboardTable } from 'modules/Dashboard/components/EmptyDashboardTable';
-import { ActionsMenu, Chip, MenuActionProps, Pin, Row, Spinner, Svg } from 'shared/components';
+import {
+  ActionsMenu,
+  Chip,
+  ChipShape,
+  MenuActionProps,
+  Pin,
+  Row,
+  Spinner,
+  Svg,
+} from 'shared/components';
 import { workspaces } from 'redux/modules';
 import { useAsync, usePermissions, useTable, useTimeAgo } from 'shared/hooks';
 import { getWorkspaceRespondentsApi, updateRespondentsPinApi, updateSubjectsPinApi } from 'api';
 import { page } from 'resources';
 import { getDateInUserTimezone, isManagerOrOwner, joinWihComma, Mixpanel } from 'shared/utils';
 import { DEFAULT_ROWS_PER_PAGE, Roles } from 'shared/consts';
-import { StyledBody } from 'shared/styles';
+import { StyledBody, variables } from 'shared/styles';
 import { Respondent, RespondentStatus } from 'modules/Dashboard/types';
 import { StyledIcon } from 'shared/components/Search/Search.styles';
 import { StyledMaybeEmpty } from 'shared/styles/styledComponents/MaybeEmpty';
@@ -27,7 +36,6 @@ import {
   HeaderSectionLeft,
   HeaderSectionRight,
   ParticipantsTable,
-  StyledCheckBox,
 } from './Participants.styles';
 import {
   getAppletsSmallTableRows,
@@ -273,9 +281,12 @@ export const Participants = () => {
           <Checkbox
             checked={false}
             icon={
-              <StyledCheckBox>
-                <Svg id="checkbox-empty-outlined" height="20" width="20" />
-              </StyledCheckBox>
+              <Svg
+                fill={variables.palette.outline_variant2}
+                height="20"
+                id="checkbox-empty-outlined"
+                width="20"
+              />
             }
             data-testid="dashboard-participants-checkbox"
           />
@@ -313,9 +324,7 @@ export const Participants = () => {
       accountType: {
         // TODO: Replace with new Chip/Tag variant when available
         // https://mindlogger.atlassian.net/browse/M2-6161
-        content: () => (
-          <Chip title={accountType} color="secondary" sxProps={{ pointerEvents: 'none', m: 0 }} />
-        ),
+        content: () => <Chip color="secondary" shape={ChipShape.Rounded} title={accountType} />,
         value: accountType,
         width: ParticipantsColumnsWidth.AccountType,
         onClick: defaultOnClick,
@@ -354,6 +363,7 @@ export const Participants = () => {
           />
         ),
         value: '',
+        width: ParticipantsColumnsWidth.Pin,
       },
     };
   };

--- a/src/modules/Dashboard/features/Participants/Participants.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.tsx
@@ -4,16 +4,7 @@ import { generatePath, useNavigate, useParams } from 'react-router-dom';
 import { Checkbox } from '@mui/material';
 
 import { EmptyDashboardTable } from 'modules/Dashboard/components/EmptyDashboardTable';
-import {
-  ActionsMenu,
-  Chip,
-  ChipShape,
-  MenuActionProps,
-  Pin,
-  Row,
-  Spinner,
-  Svg,
-} from 'shared/components';
+import { ActionsMenu, Chip, MenuActionProps, Pin, Row, Spinner, Svg } from 'shared/components';
 import { workspaces } from 'redux/modules';
 import { useAsync, usePermissions, useTable, useTimeAgo } from 'shared/hooks';
 import { getWorkspaceRespondentsApi, updateRespondentsPinApi, updateSubjectsPinApi } from 'api';
@@ -265,6 +256,7 @@ export const Participants = () => {
       [RespondentStatus.NotInvited]: t('limited'),
       [RespondentStatus.Pending]: t('pendingInvite'),
     }[status];
+    const isPending = status === RespondentStatus.Pending;
 
     const defaultOnClick = () => {
       navigate(
@@ -308,9 +300,13 @@ export const Participants = () => {
         onClick: defaultOnClick,
       },
       accountType: {
-        // TODO: Replace with new Chip/Tag variant when available
-        // https://mindlogger.atlassian.net/browse/M2-6161
-        content: () => <Chip color="secondary" shape={ChipShape.Rounded} title={accountType} />,
+        content: () => (
+          <Chip
+            icon={isPending ? <Svg id="email-outlined" width={18} height={18} /> : undefined}
+            color={isPending ? 'warning' : 'secondary'}
+            title={accountType}
+          />
+        ),
         value: accountType,
         onClick: defaultOnClick,
       },

--- a/src/modules/Dashboard/features/Participants/Participants.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.tsx
@@ -20,7 +20,7 @@ import { getWorkspaceRespondentsApi, updateRespondentsPinApi, updateSubjectsPinA
 import { page } from 'resources';
 import { getDateInUserTimezone, isManagerOrOwner, joinWihComma, Mixpanel } from 'shared/utils';
 import { DEFAULT_ROWS_PER_PAGE, Roles } from 'shared/consts';
-import { StyledBody, variables } from 'shared/styles';
+import { StyledBody } from 'shared/styles';
 import { Respondent, RespondentStatus } from 'modules/Dashboard/types';
 import { StyledIcon } from 'shared/components/Search/Search.styles';
 import { StyledMaybeEmpty } from 'shared/styles/styledComponents/MaybeEmpty';
@@ -277,20 +277,7 @@ export const Participants = () => {
 
     return {
       checkbox: {
-        content: () => (
-          <Checkbox
-            checked={false}
-            icon={
-              <Svg
-                fill={variables.palette.outline_variant2}
-                height="20"
-                id="checkbox-empty-outlined"
-                width="20"
-              />
-            }
-            data-testid="dashboard-participants-checkbox"
-          />
-        ),
+        content: () => <Checkbox checked={false} data-testid="dashboard-participants-checkbox" />,
         value: '',
         width: ParticipantsColumnsWidth.Pin,
       },
@@ -318,7 +305,6 @@ export const Participants = () => {
       nicknames: {
         content: () => nickname,
         value: nickname,
-        width: ParticipantsColumnsWidth.Default,
         onClick: defaultOnClick,
       },
       accountType: {
@@ -326,26 +312,24 @@ export const Participants = () => {
         // https://mindlogger.atlassian.net/browse/M2-6161
         content: () => <Chip color="secondary" shape={ChipShape.Rounded} title={accountType} />,
         value: accountType,
-        width: ParticipantsColumnsWidth.AccountType,
         onClick: defaultOnClick,
       },
       lastSeen: {
         content: () => <StyledMaybeEmpty>{latestActive}</StyledMaybeEmpty>,
         value: latestActive,
-        width: ParticipantsColumnsWidth.Default,
         onClick: defaultOnClick,
       },
       ...(appletId && {
         schedule: {
           content: () => schedule,
           value: schedule,
-          width: ParticipantsColumnsWidth.Schedule,
           onClick: defaultOnClick,
         },
       }),
       actions: {
         content: () => (
           <ActionsMenu
+            buttonColor="secondary"
             menuItems={getParticipantActions({
               actions,
               filteredApplets: filteredRespondents?.[respondentOrSubjectId],
@@ -498,7 +482,6 @@ export const Participants = () => {
           ) : undefined
         }
         count={respondentsData?.count || 0}
-        hasColFixedWidth
         data-testid={`${dataTestid}-table`}
         {...tableProps}
       />

--- a/src/modules/Dashboard/features/Participants/Participants.utils.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.utils.tsx
@@ -1,4 +1,5 @@
 import { Dispatch, SetStateAction } from 'react';
+import { Checkbox } from '@mui/material';
 import { t } from 'i18next';
 
 import { Svg } from 'shared/components/Svg';
@@ -17,7 +18,6 @@ import { MenuItemType } from 'shared/components';
 
 import { ChosenAppletData, GetParticipantActionsProps } from './Participants.types';
 import { ParticipantsColumnsWidth } from './Participants.const';
-import { StyledCheckBox } from './Participants.styles';
 
 export const getParticipantActions = ({
   actions: { editParticipant, upgradeAccount, exportData, removeParticipant, assignActivity },
@@ -134,9 +134,17 @@ export const getHeadCells = (id?: string): HeadCell[] => {
     {
       id: 'checkbox',
       label: (
-        <StyledCheckBox>
-          <Svg id="checkbox-empty-outlined" height="20" width="20" />
-        </StyledCheckBox>
+        <Checkbox
+          checked={false}
+          icon={
+            <Svg
+              fill={variables.palette.outline_variant2}
+              height="20"
+              id="checkbox-empty-outlined"
+              width="20"
+            />
+          }
+        />
       ),
       enableSort: true,
       width: ParticipantsColumnsWidth.Pin,

--- a/src/modules/Dashboard/features/Participants/Participants.utils.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.utils.tsx
@@ -133,19 +133,7 @@ export const getHeadCells = (id?: string): HeadCell[] => {
   return [
     {
       id: 'checkbox',
-      label: (
-        <Checkbox
-          checked={false}
-          icon={
-            <Svg
-              fill={variables.palette.outline_variant2}
-              height="20"
-              id="checkbox-empty-outlined"
-              width="20"
-            />
-          }
-        />
-      ),
+      label: <Checkbox aria-label={t('checkAll')} checked={false} />,
       enableSort: true,
       width: ParticipantsColumnsWidth.Pin,
     },
@@ -171,32 +159,29 @@ export const getHeadCells = (id?: string): HeadCell[] => {
       id: 'nicknames',
       label: t('nickname'),
       enableSort: true,
-      width: ParticipantsColumnsWidth.Default,
     },
     {
       id: 'accountType',
       label: t('accountType'),
       enableSort: true,
-      width: ParticipantsColumnsWidth.AccountType,
     },
     {
       id: 'lastSeen',
       label: t('latestActivity'),
       enableSort: true,
-      width: ParticipantsColumnsWidth.Default,
     },
     ...(id
       ? [
           {
             id: 'schedule',
             label: t('schedule'),
-            width: ParticipantsColumnsWidth.Schedule,
           },
         ]
       : []),
     {
       id: 'actions',
       label: '',
+      width: ParticipantsColumnsWidth.Pin,
     },
   ];
 };

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -223,6 +223,7 @@
   "changeScoreConditionIdText": "You are referencing this score condition as a variable in the markdown. Changing the Score Condition ID will cause the variable names to update everywhere.",
   "characters": "characters",
   "chars": "chars.",
+  "checkAll": "Check all",
   "checkYourEmail": "Check your email",
   "chooseLanguage": "Choose a language",
   "clear": "Clear",

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -863,7 +863,7 @@
   "passwordSpecialChar": "At least one special character must be included.",
   "passwordsMustMatch": "Your passwords do not match",
   "pendingInvitations": "Pending Invitations",
-  "pendingInvite": "Pending Invite",
+  "pendingInvite": "Pending",
   "performanceTasks": {
     "abTrailsIpad": "A/B Trails iPad",
     "abTrailsMobile": "A/B Trails Mobile",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -862,7 +862,7 @@
   "passwordSpecialChar": "Au moins un caractère spécial doit être inclus.",
   "passwordsMustMatch": "Vos mots de passe ne correspondent pas",
   "pendingInvitations": "Invitations en Attente",
-  "pendingInvite": "invitation en attente",
+  "pendingInvite": "En attente",
   "performanceTasks": {
     "abTrailsIpad": "A/B Trails iPad",
     "abTrailsMobile": "A/B Trails Mobile",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -223,6 +223,7 @@
   "changeScoreConditionIdText": "Vous faites référence à cette condition de score en tant que variable dans la démarque. La modification de l'ID de la condition de score entraînera la mise à jour des noms de variables partout.",
   "characters": "caractères",
   "chars": "caract.",
+  "checkAll": "Cochez toutes",
   "checkYourEmail": "Vérifiez vos e-mail",
   "chooseLanguage": "Choisissez une langue",
   "clear": "Effacer",

--- a/src/shared/components/Chip/Chip.styles.ts
+++ b/src/shared/components/Chip/Chip.styles.ts
@@ -1,14 +1,12 @@
 import { styled } from '@mui/material';
 import Chip from '@mui/material/Chip';
 
-import theme from 'shared/styles/theme';
 import { variables } from 'shared/styles/variables';
 import { StyledClearedButton as ClearedButton } from 'shared/styles/styledComponents';
 
 import { ChipShape } from './Chip.types';
 
 export const StyledChip = styled(Chip)`
-  margin: ${theme.spacing(0.8, 0.8, 0, 0)};
   border-radius: ${({ shape }: { shape: ChipShape }) =>
     shape === ChipShape.Rounded ? variables.borderRadius.xxl : variables.borderRadius.md};
 `;

--- a/src/shared/components/Chip/Chip.tsx
+++ b/src/shared/components/Chip/Chip.tsx
@@ -4,19 +4,15 @@ import { ChipProps, ChipShape } from './Chip.types';
 import { StyledChip, StyledClearedButton } from './Chip.styles';
 
 export const Chip = ({
+  shape = ChipShape.Rounded,
   title,
-  icon,
-  color = 'primary',
-  shape = ChipShape.Rectangular,
   onRemove,
   canRemove = true,
-  onClick,
-  sxProps,
   'data-testid': dataTestid,
+  ...otherProps
 }: ChipProps) => (
   <StyledChip
     shape={shape}
-    color={color}
     deleteIcon={
       canRemove ? (
         <StyledClearedButton data-testid={`${dataTestid || 'chip'}-close-button`}>
@@ -25,10 +21,8 @@ export const Chip = ({
       ) : undefined
     }
     label={title}
-    icon={icon || undefined}
     onDelete={onRemove}
-    onClick={onClick}
-    sx={sxProps}
     data-testid={dataTestid}
+    {...otherProps}
   />
 );

--- a/src/shared/components/Chip/Chip.types.ts
+++ b/src/shared/components/Chip/Chip.types.ts
@@ -1,19 +1,15 @@
-import { ReactElement } from 'react';
-import { SxProps } from '@mui/material';
+import { ChipOwnProps } from '@mui/material';
 
 export enum ChipShape {
   Rectangular = 'rectangular',
   Rounded = 'rounded',
 }
 
-export type ChipProps = {
-  title: string | JSX.Element;
-  onRemove?: () => void;
-  color?: 'primary' | 'secondary' | 'error';
-  shape?: ChipShape;
-  icon?: ReactElement | undefined;
+export interface ChipProps extends ChipOwnProps {
+  ['data-testid']?: string;
   canRemove?: boolean;
   onClick?: () => void;
-  sxProps?: SxProps;
-  'data-testid'?: string;
-};
+  onRemove?: () => void;
+  shape?: ChipShape;
+  title: string | JSX.Element;
+}

--- a/src/shared/components/FormComponents/TagsController/TagsController.tsx
+++ b/src/shared/components/FormComponents/TagsController/TagsController.tsx
@@ -33,7 +33,7 @@ export const TagsController = <T extends FieldValues>({
           key={index}
           title={tag}
           onRemove={disabled ? undefined : () => onRemoveTagClick(index)}
-          sxProps={
+          sx={
             isSecondaryUiType
               ? { m: theme.spacing(0.2), ...(disabled && { pointerEvents: 'none' }) }
               : null

--- a/src/shared/components/Table/TableHead/TableHead.styles.ts
+++ b/src/shared/components/Table/TableHead/TableHead.styles.ts
@@ -9,6 +9,7 @@ import { UiType } from '../Table.types';
 const HEAD_ROW_HEIGHT = '5.3rem';
 
 export const StyledTableHead = styled(TableHead, shouldForwardProp)`
+  background-color: ${variables.palette.surface};
   top: 0;
   position: sticky;
   z-index: ${theme.zIndex.fab};
@@ -17,7 +18,6 @@ export const StyledTableHead = styled(TableHead, shouldForwardProp)`
     hasColFixedWidth &&
     `
     display: block;
-    background-color: ${variables.palette.surface};
   `};
 
   && {
@@ -31,7 +31,7 @@ export const StyledTableHead = styled(TableHead, shouldForwardProp)`
           return `background-color: ${tableHeadBg || variables.palette.surface1}`;
         }
 
-        return `background-color: ${tableHeadBg || variables.palette.surface}`;
+        return `background-color: ${tableHeadBg || variables.palette.surface}; border-bottom: 0`;
       }};
     }
   }
@@ -57,13 +57,19 @@ export const StyledTableCell = styled(TableCell, shouldForwardProp)`
   }};
 
   &.MuiTableCell-head {
-    ${({ uiType }) =>
-      uiType === UiType.Tertiary &&
-      `
-    color: ${variables.palette.outline};
-    font-size: ${variables.font.size.md};
-    line-height: ${variables.font.lineHeight.md};
-    letter-spacing: ${variables.font.letterSpacing.lg};
-  `}
-  }
+    ${({ uiType }) => {
+      switch (uiType) {
+        case UiType.Primary:
+          return { borderBottom: 0 };
+        case UiType.Tertiary:
+          return {
+            color: variables.palette.outline,
+            fontSize: variables.font.size.md,
+            letterSpacing: variables.font.letterSpacing.lg,
+            lineHeight: variables.font.lineHeight.md,
+          };
+        default:
+          return {};
+      }
+    }}
 `;

--- a/src/shared/components/Table/TableHead/TableHead.tsx
+++ b/src/shared/components/Table/TableHead/TableHead.tsx
@@ -6,6 +6,7 @@ import { StyledTableCell, StyledTableHead } from './TableHead.styles';
 import { TableHeadProps } from './TableHead.types';
 
 export const TableHead = ({
+  className,
   tableHeader,
   headCells,
   order,
@@ -19,7 +20,12 @@ export const TableHead = ({
     onRequestSort(event, property);
 
   return (
-    <StyledTableHead uiType={uiType} hasColFixedWidth={hasColFixedWidth} tableHeadBg={tableHeadBg}>
+    <StyledTableHead
+      className={className}
+      uiType={uiType}
+      hasColFixedWidth={hasColFixedWidth}
+      tableHeadBg={tableHeadBg}
+    >
       {(uiType === UiType.Primary || uiType === UiType.Quaternary) && (
         <TableRow>
           <TableCell sx={{ flexGrow: 1 }} colSpan={headCells.length}>

--- a/src/shared/components/Table/TableHead/TableHead.types.ts
+++ b/src/shared/components/Table/TableHead/TableHead.types.ts
@@ -3,6 +3,7 @@ import { HeadCell, Order } from 'shared/types/table';
 import { UiType } from '../Table.types';
 
 export type TableHeadProps = {
+  className?: string;
   tableHeader: JSX.Element | null;
   headCells: HeadCell[];
   onRequestSort: (event: React.MouseEvent<unknown>, property: string) => void;

--- a/src/shared/styles/theme.ts
+++ b/src/shared/styles/theme.ts
@@ -289,7 +289,8 @@ export const theme = createTheme({
       styleOverrides: {
         root: {
           color: variables.palette.on_surface_variant,
-          padding: '0.6rem 1.2rem',
+          padding: '0.2rem 0.8rem',
+          height: 24,
           borderRadius: variables.borderRadius.md,
           fontSize: variables.font.size.md,
           fontWeight: variables.font.weight.regular,
@@ -305,16 +306,8 @@ export const theme = createTheme({
             },
           },
           '&.MuiChip-colorSecondary': {
-            borderWidth: variables.borderWidth.md,
-            border: `${variables.borderWidth.md} solid ${variables.palette.outline}`,
             color: variables.palette.on_surface_variant,
-            backgroundColor: 'transparent',
-            '&:hover': {
-              backgroundColor: variables.palette.on_surface_variant_alfa8,
-            },
-            a: {
-              color: variables.palette.on_surface_variant,
-            },
+            backgroundColor: variables.palette.inverse_on_surface,
           },
           '&.MuiChip-colorError': {
             borderWidth: variables.borderWidth.md,

--- a/src/shared/styles/theme.tsx
+++ b/src/shared/styles/theme.tsx
@@ -2,9 +2,11 @@ import { SelectClasses, createTheme, Theme } from '@mui/material';
 import { OverridesStyleRules } from '@mui/material/styles/overrides';
 import 'react-datepicker/dist/react-datepicker.min.css';
 
+import { Svg } from 'shared/components/Svg';
 import { typography } from 'shared/styles/typography';
 import { variables } from 'shared/styles/variables';
 import { blendColorsNormal } from 'shared/utils/colors';
+import { getChipStyleOverrides } from 'shared/styles/utils';
 
 declare module '@mui/system/createTheme/createBreakpoints' {
   interface BreakpointOverrides {
@@ -287,48 +289,20 @@ export const theme = createTheme({
     },
     MuiChip: {
       styleOverrides: {
-        root: {
-          color: variables.palette.on_surface_variant,
-          padding: '0.2rem 0.8rem',
-          height: 24,
+        root: ({ ownerState }) => ({
           borderRadius: variables.borderRadius.md,
           fontSize: variables.font.size.md,
           fontWeight: variables.font.weight.regular,
+          gap: '0.4rem',
+          height: '2.4rem',
           lineHeight: variables.font.lineHeight.md,
-          '&.MuiChip-colorPrimary': {
-            border: 'none',
-            backgroundColor: variables.palette.secondary_container,
-            '&:hover': {
-              backgroundColor: blendColorsNormal(
-                variables.palette.secondary_container,
-                variables.palette.on_secondary_container_alfa8,
-              ),
-            },
-          },
-          '&.MuiChip-colorSecondary': {
-            color: variables.palette.on_surface_variant,
-            backgroundColor: variables.palette.inverse_on_surface,
-          },
-          '&.MuiChip-colorError': {
-            borderWidth: variables.borderWidth.md,
-            border: `${variables.borderWidth.md} solid ${variables.palette.on_error_container}`,
-            color: variables.palette.on_error_container,
-            backgroundColor: variables.palette.error_container,
-            '&:hover': {
-              backgroundColor: variables.palette.on_surface_variant_alfa8,
-            },
-            a: {
-              color: variables.palette.on_error_container,
-              textDecorationColor: variables.palette.on_error_container,
-            },
-          },
-          '.MuiChip-label': {
-            padding: 0,
-          },
-          '.MuiChip-deleteIcon': {
-            margin: '0 0 0 0.8rem',
-          },
-        },
+          padding: '0.2rem 0.8rem',
+          ...getChipStyleOverrides({ color: ownerState.color, variant: ownerState.variant }),
+
+          '.MuiChip-deleteIcon': { margin: 0 },
+          '.MuiChip-icon': { fill: 'currentColor', margin: 0 },
+          '.MuiChip-label': { padding: 0 },
+        }),
       },
     },
     MuiToggleButtonGroup: {
@@ -543,10 +517,14 @@ export const theme = createTheme({
       },
     },
     MuiCheckbox: {
+      defaultProps: {
+        icon: <Svg height="20" id="checkbox-empty-outlined" width="20" />,
+        checkedIcon: <Svg height="20" id="checkbox-filled" width="20" />,
+      },
       styleOverrides: {
-        root: {
-          color: variables.palette.primary,
-        },
+        root: ({ checked = false }) => ({
+          fill: checked ? variables.palette.primary : variables.palette.outline_variant2,
+        }),
       },
     },
     MuiSwitch: {

--- a/src/shared/styles/theme.tsx
+++ b/src/shared/styles/theme.tsx
@@ -6,7 +6,7 @@ import { Svg } from 'shared/components/Svg';
 import { typography } from 'shared/styles/typography';
 import { variables } from 'shared/styles/variables';
 import { blendColorsNormal } from 'shared/utils/colors';
-import { getChipStyleOverrides } from 'shared/styles/utils';
+import { getChipStyleOverrides } from 'shared/styles/theme.utils';
 
 declare module '@mui/system/createTheme/createBreakpoints' {
   interface BreakpointOverrides {

--- a/src/shared/styles/theme.utils.ts
+++ b/src/shared/styles/theme.utils.ts
@@ -1,6 +1,6 @@
 import { ChipOwnProps } from '@mui/material';
 
-import { variables } from '../variables';
+import { variables } from './variables';
 
 export const getChipStyleOverrides = ({
   color,
@@ -19,6 +19,9 @@ export const getChipStyleOverrides = ({
         color: variables.palette.on_surface_variant,
         [key]: variables.palette.inverse_on_surface,
 
+        // MUI applies tabindex to make Chip's focusable when they receive
+        // `onDelete` or`onClick` props. This selector (and the repeated ones
+        // below) conditionally applies hover styles _only_ to interactive chips.
         '&[tabindex="0"]:hover': {
           borderColor: variables.palette.neutral60,
           backgroundColor: variables.palette[isFilled ? 'neutral60' : 'inverse_on_surface'],

--- a/src/shared/styles/utils/index.ts
+++ b/src/shared/styles/utils/index.ts
@@ -1,0 +1,60 @@
+import { ChipOwnProps } from '@mui/material';
+
+import { variables } from '../variables';
+
+export const getChipStyleOverrides = ({
+  color,
+  variant,
+}: {
+  color?: ChipOwnProps['color'];
+  variant?: ChipOwnProps['variant'];
+}) => {
+  const isFilled = variant === 'filled';
+  const key = isFilled ? 'backgroundColor' : 'borderColor';
+
+  switch (color) {
+    case 'default':
+    case 'secondary':
+      return {
+        color: variables.palette.on_surface_variant,
+        [key]: variables.palette.inverse_on_surface,
+
+        '&[tabindex="0"]:hover': {
+          borderColor: variables.palette.neutral60,
+          backgroundColor: variables.palette[isFilled ? 'neutral60' : 'inverse_on_surface'],
+        },
+      };
+    case 'primary':
+      return {
+        color: variables.palette.on_surface_variant,
+        [key]: variables.palette.primary95,
+
+        '&[tabindex="0"]:hover': {
+          borderColor: variables.palette.primary_container,
+          backgroundColor: isFilled ? variables.palette.primary_container : undefined,
+        },
+      };
+    case 'warning':
+      return {
+        color: variables.palette.on_surface_variant,
+        [key]: variables.palette.yellow_light,
+
+        '&[tabindex="0"]:hover': {
+          borderColor: variables.palette.semantic.yellow,
+          backgroundColor: isFilled ? variables.palette.semantic.yellow : undefined,
+        },
+      };
+    case 'error':
+      return {
+        color: variables.palette.on_error_container,
+        [key]: variables.palette.error_container,
+
+        '&[tabindex="0"]:hover': {
+          borderColor: variables.palette.on_surface_variant_alfa8,
+          backgroundColor: isFilled ? variables.palette.on_surface_variant_alfa8 : undefined,
+        },
+      };
+    default:
+      return {};
+  }
+};

--- a/src/shared/styles/variables/palette.ts
+++ b/src/shared/styles/variables/palette.ts
@@ -14,6 +14,7 @@ export const palette = {
   on_surface_variant: '#42474e',
   outline: '#72777f',
   outline_variant: '#c4c9d0',
+  outline_variant2: '#C2C7CF',
   surface_variant: '#dee3eb',
   surface: '#fcfcff',
   on_secondary_container: '#0e1d2a',

--- a/src/shared/styles/variables/palette.ts
+++ b/src/shared/styles/variables/palette.ts
@@ -1,6 +1,7 @@
 export const palette = {
   primary: '#00639a',
   primary50: '#207cbb',
+  primary95: '#e8f2ff',
   primary_container: '#cee5ff',
   secondary: '#51606f',
   secondary60: '#8392a3',
@@ -14,7 +15,7 @@ export const palette = {
   on_surface_variant: '#42474e',
   outline: '#72777f',
   outline_variant: '#c4c9d0',
-  outline_variant2: '#C2C7CF',
+  outline_variant2: '#c2c7cF',
   surface_variant: '#dee3eb',
   surface: '#fcfcff',
   on_secondary_container: '#0e1d2a',
@@ -43,6 +44,7 @@ export const palette = {
   white_alfa50: 'rgb(255 255 255 / 50%)',
   dark_error_container: '#93000a',
   neutral60: '#909194',
+  yellow_light: '#f5e6b3',
 
   black: '#000',
   white: '#fff',


### PR DESCRIPTION
### 📝 Description

🔗 [M2-5609](https://mindlogger.atlassian.net/browse/M2-5609): [FE][Teams Overview] Team Listing View

This PR updates the appearance of the Dashboard Table to match the specs from Figma. While the associated task is intended for the "Team Listing View", the table UI itself is reused across many of the table views in the various applet tabs, and some of the UI changes I've made impacts those screens as well.

In addition to the changes to the Dashboard Table UI, which mostly consist of border and padding updates, I've also tweaked the columns shown on the Team Listing view. This includes:

- Removing the pins column/ability to pin a row, per the Figma specs.
- Updating the "Role" column to be titled in the singular, and to render the role as a `Chip` component.
- Adding a "Checkmark" column, intended for performing bulk operations
- Removing the title of the "Actions" column
- Re-ordering columns

### 📸 Screenshots

#### Team Listing

| Before | After |
|-|-|
| ![team-before](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/d237251b-bff8-405c-9676-44cf267943c7) | ![team-after](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/21a44196-0b37-4533-9fd9-02618a411cf1) |


[M2-5609]: https://mindlogger.atlassian.net/browse/M2-5609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ