### PR TITLE
M2-6302: DataViz: Scrolling tables on the Summary tab corrupts the la…

### DIFF
--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ReportTable/ReportTable.styles.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ReportTable/ReportTable.styles.ts
@@ -3,12 +3,14 @@ import { Box, styled } from '@mui/material';
 import { theme, variables } from 'shared/styles';
 
 export const StyledTableWrapper = styled(Box)`
-  max-height: 37.5rem;
   margin-top: ${theme.spacing(2.4)};
-  overflow-y: auto;
 
   .MuiTableCell-root {
     font-size: ${variables.font.size.md};
+  }
+
+  thead {
+    background-color: ${variables.palette.surface};
   }
 
   thead tr:first-of-type .MuiTableCell-root {

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ReportTable/ReportTable.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ReportTable/ReportTable.tsx
@@ -72,6 +72,7 @@ export const ReportTable = ({
           handleChangePage={handleChangePage}
           count={answers.length}
           emptyComponent={visibleRows.length ? undefined : emptyState}
+          maxHeight="37.5rem"
         />
       </StyledTableWrapper>
     </Box>


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [ ] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-6302](https://mindlogger.atlassian.net/browse/M2-6302)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->


### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| ![Снимок экрана 2024-04-19 в 11 24 32](https://github.com/ChildMindInstitute/mindlogger-admin/assets/115553085/e4d623c0-abc0-4dae-af6f-c74cff1058ef) | ![Снимок экрана 2024-04-19 в 11 22 41](https://github.com/ChildMindInstitute/mindlogger-admin/assets/115553085/6af22154-11b4-4ba4-8da2-d90d7743fdd7)|
