### PR TITLE
[M2-6247] Fix Participant Details screen for non-"Full" accounts

### DIFF
--- a/src/modules/Dashboard/features/Participant/Activities/Activities.test.tsx
+++ b/src/modules/Dashboard/features/Participant/Activities/Activities.test.tsx
@@ -56,15 +56,16 @@ const routePath = page.appletParticipantActivities;
 const preloadedState: PreloadedState<RootState> = {
   ...getPreloadedState(),
   users: {
-    respondentDetails: mockSchema({
+    respondentDetails: mockSchema(null),
+    allRespondents: mockSchema(null),
+    subjectDetails: mockSchema({
       result: {
+        id: 'test-id',
         secretUserId: 'secretUserId',
         nickname: 'nickname',
         lastSeen: null,
       },
     }),
-    allRespondents: mockSchema(null),
-    subjectDetails: mockSchema(null),
   },
 };
 
@@ -142,7 +143,7 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
     `('$description', async ({ canEdit, role }) => {
       mockAxios.get.mockResolvedValue(successfulGetAppletActivitiesMock);
       renderWithProviders(<Activities />, {
-        preloadedState: getPreloadedState(role),
+        preloadedState: { ...preloadedState, ...getPreloadedState(role) },
         route,
         routePath,
       });
@@ -187,7 +188,7 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
             successfulEmptyHttpResponseMock,
         });
         renderWithProviders(<Activities />, {
-          preloadedState: getPreloadedState(role),
+          preloadedState: { ...preloadedState, ...getPreloadedState(role) },
           route,
           routePath,
         });
@@ -235,7 +236,7 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
         });
 
         renderWithProviders(<Activities />, {
-          preloadedState: getPreloadedState(role),
+          preloadedState: { ...preloadedState, ...getPreloadedState(role) },
           route,
           routePath,
         });
@@ -298,8 +299,7 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
         .getByTestId(`${testId}-take-now-modal-participant-dropdown`)
         .querySelector('input');
 
-      const { secretUserId, nickname } =
-        preloadedState?.users?.respondentDetails.data?.result ?? {};
+      const { secretUserId, nickname } = preloadedState?.users?.subjectDetails.data?.result ?? {};
 
       expect(subjectInputElement).toHaveValue(`${secretUserId} (${nickname})`);
 

--- a/src/modules/Dashboard/features/Participant/Activities/Activities.tsx
+++ b/src/modules/Dashboard/features/Participant/Activities/Activities.tsx
@@ -14,8 +14,8 @@ import { users } from 'modules/Dashboard/state';
 
 export const Activities = () => {
   const { appletId, participantId } = useParams();
-  const respondentLoadingStatus = users.useRespondentStatus();
-  const respondent = users.useRespondent();
+  const subjectLoadingStatus = users.useSubjectStatus();
+  const subject = users.useSubject();
   const [activitiesData, setActivitiesData] = useState<{
     result: DatavizActivity[];
     count: number;
@@ -23,8 +23,7 @@ export const Activities = () => {
   const [isLoading, setIsLoading] = useState(true);
   const dataTestId = 'dashboard-applet-participant-activities';
 
-  const isParticipantLoading =
-    respondentLoadingStatus === 'loading' || respondentLoadingStatus === 'idle';
+  const isSubjectLoading = subjectLoadingStatus === 'loading' || subjectLoadingStatus === 'idle';
 
   const {
     formatRow,
@@ -58,10 +57,7 @@ export const Activities = () => {
   useEffect(() => {
     if (!appletId || !participantId) return;
 
-    getSummaryActivities({
-      appletId,
-      targetSubjectId: participantId,
-    });
+    getSummaryActivities({ appletId, targetSubjectId: participantId });
   }, [appletId, participantId, getSummaryActivities]);
 
   const activities = useMemo(
@@ -75,11 +71,11 @@ export const Activities = () => {
             if (activity) {
               const options: OpenTakeNowModalOptions = {};
 
-              if (participantId && respondent) {
+              if (participantId && subject) {
                 options.subject = {
                   id: participantId,
-                  secretId: respondent.result.secretUserId,
-                  nickname: respondent.result.nickname,
+                  secretId: subject.result.secretUserId,
+                  nickname: subject.result.nickname,
                 };
               }
 
@@ -99,7 +95,7 @@ export const Activities = () => {
       TakeNowModal={TakeNowModal}
       order={'desc'}
       orderBy={''}
-      isLoading={isLoading || isParticipantLoading}
+      isLoading={isLoading || isSubjectLoading}
       data-testid={dataTestId}
     />
   );

--- a/src/modules/Dashboard/features/Participants/Participants.test.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.test.tsx
@@ -10,6 +10,7 @@ import {
   mockedOwnerId,
   mockedRespondentId,
   mockedRespondent,
+  mockedSubjectId1,
 } from 'shared/mock';
 import { Roles } from 'shared/consts';
 import { initialStateData } from 'shared/state';
@@ -131,7 +132,7 @@ describe('Participants component tests', () => {
     expect(mockedUseNavigate).toHaveBeenCalledWith(
       generatePath(page.appletParticipantActivities, {
         appletId: mockedAppletId,
-        participantId: mockedRespondentId,
+        participantId: mockedSubjectId1,
       }),
     );
   });

--- a/src/modules/Dashboard/features/Participants/Participants.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.tsx
@@ -262,7 +262,7 @@ export const Participants = () => {
       navigate(
         generatePath(page.appletParticipantActivities, {
           appletId,
-          participantId: respondentOrSubjectId,
+          participantId: details[0].subjectId,
         }),
       );
     };

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewMenu/ReviewMenu.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewMenu/ReviewMenu.test.tsx
@@ -53,6 +53,7 @@ const preloadedState = {
       ...initialStateData,
       data: {
         result: {
+          id: 'test-id',
           nickname: 'Mocked Respondent',
           secretUserId: '3921968c-3903-4872-8f30-a6e6a10cef36',
           lastSeen: null,

--- a/src/modules/Dashboard/pages/ParticipantDetails/ParticipantDetails.tsx
+++ b/src/modules/Dashboard/pages/ParticipantDetails/ParticipantDetails.tsx
@@ -9,7 +9,7 @@ import { workspaces } from 'shared/state';
 import { StyledBody, StyledHeadlineLarge } from 'shared/styles';
 import { applet as appletState } from 'shared/state';
 import { applets, users } from 'modules/Dashboard/state';
-import { getRespondentDetails } from 'modules/Dashboard/state/Users/Users.thunk';
+import { getSubjectDetails } from 'modules/Dashboard/state/Users/Users.thunk';
 import { palette } from 'shared/styles/variables/palette';
 import { page } from 'resources';
 
@@ -20,49 +20,41 @@ export const ParticipantDetails = () => {
   const navigate = useNavigate();
   const { appletId, participantId } = useParams();
   const { ownerId } = workspaces.useData() || {};
+  const { useSubject, useSubjectStatus } = users;
   const appletLoadingStatus = appletState.useResponseStatus();
-  const respondentLoadingStatus = users.useRespondentStatus();
-  const { useRespondent } = users;
-  const respondent = useRespondent();
-  const respondentTabs = useParticipantDetailsTabs();
+  const subjectLoadingStatus = useSubjectStatus();
+  const { result: subject } = useSubject() ?? {};
   const { getApplet } = appletState.thunk;
+  const respondentTabs = useParticipantDetailsTabs();
 
   useEffect(() => {
     if (!appletId) return;
     dispatch(getApplet({ appletId }));
 
     if (!participantId || !ownerId) return;
-    dispatch(getRespondentDetails({ ownerId, appletId, respondentId: participantId }));
+    dispatch(getSubjectDetails({ subjectId: participantId }));
 
     return () => {
       dispatch(applets.actions.resetEventsData());
     };
   }, [appletId, participantId, ownerId]);
 
-  const navigateUp = () => {
-    navigate(
-      generatePath(page.appletParticipants, {
-        appletId,
-      }),
-    );
-  };
-
   const loading =
     appletLoadingStatus === 'loading' ||
     appletLoadingStatus === 'idle' ||
-    respondentLoadingStatus === 'loading' ||
-    respondentLoadingStatus === 'idle';
+    subjectLoadingStatus === 'loading' ||
+    subjectLoadingStatus === 'idle';
 
   useEffect(() => {
-    if (!loading && !respondent) {
-      navigateUp();
+    if (!loading && !subject) {
+      navigate(generatePath(page.appletParticipants, { appletId }));
     }
-  }, [loading, respondent]);
+  }, [loading, subject]);
 
   return (
     <StyledBody>
       {loading && <Spinner />}
-      {!loading && !!respondent && (
+      {!loading && !!subject && (
         <>
           <Box
             sx={{
@@ -74,10 +66,8 @@ export const ParticipantDetails = () => {
             }}
           >
             <Box sx={{ display: 'flex', gap: 1.6 }}>
-              <StyledHeadlineLarge>{respondent?.result.secretUserId}</StyledHeadlineLarge>
-              <StyledHeadlineLarge color={palette.outline}>
-                {respondent?.result.nickname}
-              </StyledHeadlineLarge>
+              <StyledHeadlineLarge>{subject?.secretUserId}</StyledHeadlineLarge>
+              <StyledHeadlineLarge color={palette.outline}>{subject?.nickname}</StyledHeadlineLarge>
             </Box>
 
             <HeaderOptions />

--- a/src/modules/Dashboard/state/Users/index.ts
+++ b/src/modules/Dashboard/state/Users/index.ts
@@ -60,4 +60,12 @@ export const users = {
         },
       }) => data,
     ),
+  useSubjectStatus: (): UsersSchema['subjectDetails']['status'] =>
+    useAppSelector(
+      ({
+        users: {
+          subjectDetails: { status },
+        },
+      }) => status,
+    ),
 };

--- a/src/modules/Dashboard/types/Dashboard.types.ts
+++ b/src/modules/Dashboard/types/Dashboard.types.ts
@@ -52,6 +52,7 @@ export type Respondent = {
 };
 
 export type RespondentDetails = {
+  id: string;
   nickname: string;
   secretUserId: string;
   lastSeen: string | null;

--- a/src/shared/utils/state.ts
+++ b/src/shared/utils/state.ts
@@ -105,5 +105,6 @@ export const getRejectedData = <T extends Record<string, BaseSchema>, K>({
       selectedProperty.requestId = initialState[key].requestId;
       selectedProperty.status = 'error';
       selectedProperty.error = action.payload;
+      selectedProperty.data = initialState[key].data;
     }
   });


### PR DESCRIPTION
### 📝 Description

🔗 [M2-6247](https://mindlogger.atlassian.net/browse/M2-6247): [FE][Participant Overview] Open participant detail page for both limited and pending accounts

This PR corrects a handful of issues related to linking to the `/dashboard/${appletId}/participants/${subjectId}` route from the Participants table in the applet dashboard screen.

This includes

- Updating links and expecting the `${subjectId}` portion of that route to definitively be the _Subject_ ID, and not a _User_ ID.
- Updating the queries on the participant details screen to fetch Subject details from the `/subjects/${subjectID}` endpoint, instead of the `/{owner_id}/applets/{applet_id}/respondents/{respondent_id}` endpoint.
- Adding a redux selector for the status of Subject-related requests
- Updating shared state utils to clear existing data on a fetch error related to that data. This fixes an issue where you could see data for an unrelated request if the state was populated by a successful request prior to a subsequent one that errored (EG, if, outside of this branch, you visited the Participant Details screen for a "Full" account, and then navigated back, and visited the Participant Details screen for a "Limited" account, you would see the details screen would show data related to the "Full" account.)


[M2-6247]: https://mindlogger.atlassian.net/browse/M2-6247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ