### PR TITLE
M2-6085: No display of the skipped item in DataViz

### DIFF
--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Review/Review.utils.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Review/Review.utils.test.tsx
@@ -123,6 +123,19 @@ describe('getResponseItem (supported response items), check rendering of child c
     expect(screen.getByTestId(expected)).toBeInTheDocument();
   });
 
+  test('renders empty state', () => {
+    renderWithProviders(
+      getResponseItem({
+        activityItem: {
+          responseType: ItemResponseType.SingleSelection,
+        },
+        answer: null,
+      }),
+    );
+
+    expect(screen.getByTestId('no-response-data')).toBeInTheDocument();
+  });
+
   test('renders child component for time', () => {
     renderWithProviders(
       getResponseItem({

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Review/Review.utils.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Review/Review.utils.tsx
@@ -4,7 +4,7 @@ import { Box } from '@mui/material';
 import { DateFormats, ItemResponseType } from 'shared/consts';
 import { ActivityItemAnswer, DecryptedTimeAnswer } from 'shared/types';
 import { Svg } from 'shared/components/Svg';
-import { StyledTitleLarge, theme, variables } from 'shared/styles';
+import { StyledBodyLarge, StyledTitleLarge, theme, variables } from 'shared/styles';
 import i18n from 'i18n';
 
 import {
@@ -68,6 +68,14 @@ export const renderEmptyState = (selectedAnswer: Answer | null, isActivitySelect
 };
 
 export const getResponseItem = (activityItemAnswer: ActivityItemAnswer) => {
+  if (!activityItemAnswer.answer) {
+    return (
+      <StyledBodyLarge color={variables.palette.outline} data-testid="no-response-data">
+        {t('noResponseData')}
+      </StyledBodyLarge>
+    );
+  }
+
   switch (activityItemAnswer.activityItem.responseType) {
     case ItemResponseType.SingleSelection:
       return <SingleSelectResponseItem {...(activityItemAnswer as SingleSelectItemAnswer)} />;

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -772,6 +772,7 @@
   "noMatchWasFoundShort": "No match was found for '{{searchValue}}'.",
   "noPendingInvitations": "No pending invitations",
   "noPermissions": "You have no permissions to view this tab.",
+  "noResponseData":"No response data provided.",
   "responseIdentifier": "Response Identifier",
   "noResponseIdentifier": "No response identifier yet.",
   "viewingResponsesSubmitted": "Viewing responses submitted on:",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -771,6 +771,7 @@
   "noMatchWasFoundShort": "Aucune correspondance trouvée pour '{{searchValue}}'.",
   "noPendingInvitations": "Aucune invitation en attente",
   "noPermissions": "Vous n'avez pas les permissions pour voir cet onglet.",
+  "noResponseData": "Aucune donnée de réponse fournie.",
   "responseIdentifier": "Identifiant de réponse",
   "noResponseIdentifier": "Aucun identifiant de réponse pour le moment.",
   "viewingResponsesSubmitted": "Consultation des réponses soumises le :",


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added
- [x] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-6085](https://mindlogger.atlassian.net/browse/M2-6085)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
|![Снимок экрана 2024-04-22 в 20 22 30](https://github.com/ChildMindInstitute/mindlogger-admin/assets/115553085/cfbde4ac-1404-44f1-95f1-78f8670800e3)| ![Снимок экрана 2024-04-22 в 20 14 36](https://github.com/ChildMindInstitute/mindlogger-admin/assets/115553085/280939b2-810f-4204-8812-058f1669a716) |

