### PR TITLE
[M2-5582] Remove checkbox columns from Participant & Manager tables

### DIFF
--- a/src/modules/Dashboard/features/Managers/Managers.test.tsx
+++ b/src/modules/Dashboard/features/Managers/Managers.test.tsx
@@ -9,7 +9,6 @@ import {
   mockedOwnerId,
   mockedManager,
   mockedEmail,
-  mockedManagerId,
 } from 'shared/mock';
 import { Roles } from 'shared/consts';
 import { initialStateData } from 'shared/state';
@@ -100,24 +99,6 @@ describe('Managers component tests', () => {
       expect(screen.getByTestId('dashboard-managers-table')).toBeInTheDocument();
       tableColumnNames.forEach((column) => expect(screen.getByText(column)).toBeInTheDocument());
       managersColumns.forEach((column) => expect(screen.getByText(column)).toBeInTheDocument());
-    });
-  });
-
-  test('should pin manager', async () => {
-    mockAxios.get.mockResolvedValueOnce(getMockedGetWithManagers());
-    mockAxios.post.mockResolvedValueOnce(null);
-    renderWithProviders(<Managers />, { preloadedState, route, routePath });
-
-    const managerPin = await waitFor(() => screen.getByTestId('dashboard-managers-pin'));
-    fireEvent.click(managerPin);
-
-    await waitFor(() => {
-      expect(mockAxios.post).nthCalledWith(
-        1,
-        `/workspaces/${mockedOwnerId}/managers/${mockedManagerId}/pin`,
-        {},
-        { signal: undefined },
-      );
     });
   });
 

--- a/src/modules/Dashboard/features/Managers/Managers.test.tsx
+++ b/src/modules/Dashboard/features/Managers/Managers.test.tsx
@@ -9,6 +9,7 @@ import {
   mockedOwnerId,
   mockedManager,
   mockedEmail,
+  mockedManagerId,
 } from 'shared/mock';
 import { Roles } from 'shared/consts';
 import { initialStateData } from 'shared/state';
@@ -99,6 +100,24 @@ describe('Managers component tests', () => {
       expect(screen.getByTestId('dashboard-managers-table')).toBeInTheDocument();
       tableColumnNames.forEach((column) => expect(screen.getByText(column)).toBeInTheDocument());
       managersColumns.forEach((column) => expect(screen.getByText(column)).toBeInTheDocument());
+    });
+  });
+
+  test('should pin manager', async () => {
+    mockAxios.get.mockResolvedValueOnce(getMockedGetWithManagers());
+    mockAxios.post.mockResolvedValueOnce(null);
+    renderWithProviders(<Managers />, { preloadedState, route, routePath });
+
+    const managerPin = await waitFor(() => screen.getByTestId('dashboard-managers-pin'));
+    fireEvent.click(managerPin);
+
+    await waitFor(() => {
+      expect(mockAxios.post).nthCalledWith(
+        1,
+        `/workspaces/${mockedOwnerId}/managers/${mockedManagerId}/pin`,
+        {},
+        { signal: undefined },
+      );
     });
   });
 

--- a/src/modules/Dashboard/features/Managers/Managers.tsx
+++ b/src/modules/Dashboard/features/Managers/Managers.tsx
@@ -3,14 +3,13 @@ import { Avatar as MuiAvatar, Box, Checkbox } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 
-import { getWorkspaceManagersApi, updateManagersPinApi } from 'api';
+import { getWorkspaceManagersApi } from 'api';
 import {
   ActionsMenu,
   Avatar,
   AvatarUiType,
   Chip,
   MenuActionProps,
-  Pin,
   Search,
   Spinner,
 } from 'shared/components';
@@ -90,10 +89,6 @@ export const Managers = () => {
   const [removeAccessPopupVisible, setRemoveAccessPopupVisible] = useState(false);
   const [selectedManager, setSelectedManager] = useState<Manager | null>(null);
 
-  const { execute: handlePinUpdate } = useAsync(updateManagersPinApi, handleReload, undefined, () =>
-    setIsLoading(false),
-  );
-
   const actions = {
     removeAccessAction: ({ context: user }: MenuActionProps<Manager>) => {
       setSelectedManager(user || null);
@@ -103,11 +98,6 @@ export const Managers = () => {
       setSelectedManager(user || null);
       setEditAccessPopupVisible(true);
     },
-  };
-
-  const handlePinClick = (userId: string) => {
-    setIsLoading(true);
-    handlePinUpdate({ ownerId, userId });
   };
 
   const removeManagerAccessOnClose = (step?: number) => {
@@ -127,7 +117,7 @@ export const Managers = () => {
     () =>
       managersData?.result?.map((user) => {
         const filteredManager = filterAppletsByRoles(user);
-        const { applets, email, firstName, lastName, roles, id, isPinned } = user;
+        const { applets, email, firstName, lastName, roles, id } = user;
         const stringRoles = joinWihComma(roles);
         const appletRole = applets.find(({ id }) => id === appletId);
         const renderedRoles = appletRole?.roles.map(({ role }) => (
@@ -149,11 +139,6 @@ export const Managers = () => {
             ),
             value: '',
             width: '8rem',
-          },
-          pin: {
-            content: () => <Pin isPinned={isPinned} data-testid="dashboard-managers-pin" />,
-            value: '',
-            onClick: () => handlePinClick(id),
           },
           avatar: {
             content: () => (

--- a/src/modules/Dashboard/features/Managers/Managers.tsx
+++ b/src/modules/Dashboard/features/Managers/Managers.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Avatar as MuiAvatar, Box, Checkbox } from '@mui/material';
+import { Avatar as MuiAvatar, Box } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 
@@ -129,17 +129,6 @@ export const Managers = () => {
         ));
 
         return {
-          checkbox: {
-            content: () => (
-              <Checkbox
-                aria-label={`${firstName} ${lastName}`}
-                checked={false}
-                data-testid="dashboard-managers-checkbox"
-              />
-            ),
-            value: '',
-            width: '8rem',
-          },
           avatar: {
             content: () => (
               <MuiAvatar

--- a/src/modules/Dashboard/features/Managers/Managers.tsx
+++ b/src/modules/Dashboard/features/Managers/Managers.tsx
@@ -3,13 +3,14 @@ import { Avatar as MuiAvatar, Box, Checkbox } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 
-import { getWorkspaceManagersApi } from 'api';
+import { getWorkspaceManagersApi, updateManagersPinApi } from 'api';
 import {
   ActionsMenu,
   Avatar,
   AvatarUiType,
   Chip,
   MenuActionProps,
+  Pin,
   Search,
   Spinner,
 } from 'shared/components';
@@ -89,6 +90,10 @@ export const Managers = () => {
   const [removeAccessPopupVisible, setRemoveAccessPopupVisible] = useState(false);
   const [selectedManager, setSelectedManager] = useState<Manager | null>(null);
 
+  const { execute: handlePinUpdate } = useAsync(updateManagersPinApi, handleReload, undefined, () =>
+    setIsLoading(false),
+  );
+
   const actions = {
     removeAccessAction: ({ context: user }: MenuActionProps<Manager>) => {
       setSelectedManager(user || null);
@@ -98,6 +103,11 @@ export const Managers = () => {
       setSelectedManager(user || null);
       setEditAccessPopupVisible(true);
     },
+  };
+
+  const handlePinClick = (userId: string) => {
+    setIsLoading(true);
+    handlePinUpdate({ ownerId, userId });
   };
 
   const removeManagerAccessOnClose = (step?: number) => {
@@ -117,7 +127,7 @@ export const Managers = () => {
     () =>
       managersData?.result?.map((user) => {
         const filteredManager = filterAppletsByRoles(user);
-        const { applets, email, firstName, lastName, roles, id } = user;
+        const { applets, email, firstName, lastName, roles, id, isPinned } = user;
         const stringRoles = joinWihComma(roles);
         const appletRole = applets.find(({ id }) => id === appletId);
         const renderedRoles = appletRole?.roles.map(({ role }) => (
@@ -139,6 +149,11 @@ export const Managers = () => {
             ),
             value: '',
             width: '8rem',
+          },
+          pin: {
+            content: () => <Pin isPinned={isPinned} data-testid="dashboard-managers-pin" />,
+            value: '',
+            onClick: () => handlePinClick(id),
           },
           avatar: {
             content: () => (

--- a/src/modules/Dashboard/features/Managers/Managers.utils.test.tsx
+++ b/src/modules/Dashboard/features/Managers/Managers.utils.test.tsx
@@ -4,15 +4,7 @@ import { variables } from 'shared/styles';
 
 import { getManagerActions, getHeadCells } from './Managers.utils';
 
-const headCellProperties = [
-  'checkbox',
-  'avatar',
-  'firstName',
-  'lastName',
-  'title',
-  'email',
-  'actions',
-];
+const headCellProperties = ['avatar', 'firstName', 'lastName', 'title', 'email', 'actions'];
 const removeAccessAction = jest.fn();
 const editAccessAction = jest.fn();
 
@@ -20,7 +12,7 @@ describe('Managers utils tests', () => {
   describe('getHeadCells function', () => {
     test('returns the correct array of head cells without an id', () => {
       const headCells = getHeadCells();
-      expect(headCells).toHaveLength(7);
+      expect(headCells).toHaveLength(6);
       headCellProperties.forEach((property, index) => {
         expect(headCells[index]).toHaveProperty('id', property);
       });
@@ -28,8 +20,8 @@ describe('Managers utils tests', () => {
 
     test('returns the correct array of head cells with an id', () => {
       const headCells = getHeadCells(mockedAppletId);
-      expect(headCells).toHaveLength(8);
-      expect(headCells[5]).toHaveProperty('id', 'role');
+      expect(headCells).toHaveLength(7);
+      expect(headCells[4]).toHaveProperty('id', 'role');
     });
   });
 

--- a/src/modules/Dashboard/features/Managers/Managers.utils.test.tsx
+++ b/src/modules/Dashboard/features/Managers/Managers.utils.test.tsx
@@ -6,6 +6,7 @@ import { getManagerActions, getHeadCells } from './Managers.utils';
 
 const headCellProperties = [
   'checkbox',
+  'pin',
   'avatar',
   'firstName',
   'lastName',
@@ -20,7 +21,7 @@ describe('Managers utils tests', () => {
   describe('getHeadCells function', () => {
     test('returns the correct array of head cells without an id', () => {
       const headCells = getHeadCells();
-      expect(headCells).toHaveLength(7);
+      expect(headCells).toHaveLength(8);
       headCellProperties.forEach((property, index) => {
         expect(headCells[index]).toHaveProperty('id', property);
       });
@@ -28,8 +29,8 @@ describe('Managers utils tests', () => {
 
     test('returns the correct array of head cells with an id', () => {
       const headCells = getHeadCells(mockedAppletId);
-      expect(headCells).toHaveLength(8);
-      expect(headCells[5]).toHaveProperty('id', 'role');
+      expect(headCells).toHaveLength(9);
+      expect(headCells[6]).toHaveProperty('id', 'role');
     });
   });
 

--- a/src/modules/Dashboard/features/Managers/Managers.utils.test.tsx
+++ b/src/modules/Dashboard/features/Managers/Managers.utils.test.tsx
@@ -6,7 +6,6 @@ import { getManagerActions, getHeadCells } from './Managers.utils';
 
 const headCellProperties = [
   'checkbox',
-  'pin',
   'avatar',
   'firstName',
   'lastName',
@@ -21,7 +20,7 @@ describe('Managers utils tests', () => {
   describe('getHeadCells function', () => {
     test('returns the correct array of head cells without an id', () => {
       const headCells = getHeadCells();
-      expect(headCells).toHaveLength(8);
+      expect(headCells).toHaveLength(7);
       headCellProperties.forEach((property, index) => {
         expect(headCells[index]).toHaveProperty('id', property);
       });
@@ -29,8 +28,8 @@ describe('Managers utils tests', () => {
 
     test('returns the correct array of head cells with an id', () => {
       const headCells = getHeadCells(mockedAppletId);
-      expect(headCells).toHaveLength(9);
-      expect(headCells[6]).toHaveProperty('id', 'role');
+      expect(headCells).toHaveLength(8);
+      expect(headCells[5]).toHaveProperty('id', 'role');
     });
   });
 

--- a/src/modules/Dashboard/features/Managers/Managers.utils.tsx
+++ b/src/modules/Dashboard/features/Managers/Managers.utils.tsx
@@ -1,5 +1,3 @@
-import { Checkbox } from '@mui/material';
-
 import i18n from 'i18n';
 import { Svg } from 'shared/components/Svg';
 import { HeadCell } from 'shared/types/table';
@@ -12,11 +10,6 @@ export const getHeadCells = (id?: string): HeadCell[] => {
   const { t } = i18n;
 
   return [
-    {
-      id: 'checkbox',
-      label: <Checkbox aria-label={t('checkAll')} checked={false} />,
-      width: '8rem',
-    },
     {
       id: 'avatar',
       label: '',

--- a/src/modules/Dashboard/features/Managers/Managers.utils.tsx
+++ b/src/modules/Dashboard/features/Managers/Managers.utils.tsx
@@ -18,11 +18,6 @@ export const getHeadCells = (id?: string): HeadCell[] => {
       width: '8rem',
     },
     {
-      id: 'pin',
-      label: '',
-      width: '3.2rem',
-    },
-    {
       id: 'avatar',
       label: '',
       width: '8rem',

--- a/src/modules/Dashboard/features/Managers/Managers.utils.tsx
+++ b/src/modules/Dashboard/features/Managers/Managers.utils.tsx
@@ -18,6 +18,11 @@ export const getHeadCells = (id?: string): HeadCell[] => {
       width: '8rem',
     },
     {
+      id: 'pin',
+      label: '',
+      width: '3.2rem',
+    },
+    {
       id: 'avatar',
       label: '',
       width: '8rem',

--- a/src/modules/Dashboard/features/Participants/Participants.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { generatePath, useNavigate, useParams } from 'react-router-dom';
-import { Checkbox } from '@mui/material';
 
 import { EmptyDashboardTable } from 'modules/Dashboard/components/EmptyDashboardTable';
 import { ActionsMenu, Chip, MenuActionProps, Pin, Row, Spinner, Svg } from 'shared/components';
@@ -268,11 +267,6 @@ export const Participants = () => {
     };
 
     return {
-      checkbox: {
-        content: () => <Checkbox checked={false} data-testid="dashboard-participants-checkbox" />,
-        value: '',
-        width: ParticipantsColumnsWidth.Pin,
-      },
       pin: {
         content: () => <Pin isPinned={isPinned} data-testid="dashboard-participants-pin" />,
         value: '',

--- a/src/modules/Dashboard/features/Participants/Participants.utils.test.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.utils.test.tsx
@@ -34,7 +34,6 @@ const filteredApplets = {
   viewable: applets,
 };
 const headCellProperties = [
-  'checkbox',
   'pin',
   'tag',
   'secretIds',
@@ -172,7 +171,7 @@ describe('Participants utils tests', () => {
   describe('getHeadCells function', () => {
     test('returns the correct array of head cells without an id', () => {
       const headCells = getHeadCells();
-      expect(headCells).toHaveLength(8);
+      expect(headCells).toHaveLength(7);
       headCellProperties.forEach((property, index) => {
         expect(headCells[index]).toHaveProperty('id', property);
       });
@@ -180,9 +179,9 @@ describe('Participants utils tests', () => {
 
     test('returns the correct array of head cells with an id', () => {
       const headCells = getHeadCells(mockedAppletId);
-      expect(headCells).toHaveLength(9);
-      expect(headCells[7]).toHaveProperty('id', 'schedule');
-      expect(headCells[8]).toHaveProperty('id', 'actions');
+      expect(headCells).toHaveLength(8);
+      expect(headCells[6]).toHaveProperty('id', 'schedule');
+      expect(headCells[7]).toHaveProperty('id', 'actions');
     });
   });
 });

--- a/src/modules/Dashboard/features/Participants/Participants.utils.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.utils.tsx
@@ -1,5 +1,4 @@
 import { Dispatch, SetStateAction } from 'react';
-import { Checkbox } from '@mui/material';
 import { t } from 'i18next';
 
 import { Svg } from 'shared/components/Svg';
@@ -132,15 +131,8 @@ export const getHeadCells = (id?: string): HeadCell[] => {
 
   return [
     {
-      id: 'checkbox',
-      label: <Checkbox aria-label={t('checkAll')} checked={false} />,
-      enableSort: true,
-      width: ParticipantsColumnsWidth.Pin,
-    },
-    {
       id: 'pin',
       label: '',
-      enableSort: true,
       width: ParticipantsColumnsWidth.Pin,
     },
     {


### PR DESCRIPTION
### 📝 Description

🔗 [M2-5582](https://mindlogger.atlassian.net/browse/M2-5582): [Participant Overview] Pinning

The linked task is for adding pinning to the Participants table in the applet Dashboard. This already exists and appears to work as expected. It also, however, specifies that the functionality should match the pinning feature in the Managers table.

This previously existed, but I recently removed it in https://github.com/ChildMindInstitute/mindlogger-admin/pull/1657, because Pins were neither included in the linked designs from that task, _or_ the acceptance criteria, so I assumed it was deprecated functionality and removed it in order to match the new design specs. 😅

Based on the wording of M2-5582, I think this was accidental, so I restored the existing functionality in this PR.

[M2-5582]: https://mindlogger.atlassian.net/browse/M2-5582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ