### PR TITLE
[M2-6098] Update applet participant/respondent routing

### DIFF
--- a/src/modules/Dashboard/components/Banners/ShellAccountSuccessBanner/ShellAccountSuccessBanner.styles.ts
+++ b/src/modules/Dashboard/components/Banners/ShellAccountSuccessBanner/ShellAccountSuccessBanner.styles.ts
@@ -1,4 +1,4 @@
-import { styled } from '@mui/material';
+import { Button, styled } from '@mui/material';
 
 import { StyledClearedButton } from 'shared/styles';
 
@@ -16,4 +16,4 @@ export const StyledLinkBtn = styled(StyledClearedButton)`
   &.MuiButton-text:hover {
     background-color: transparent;
   }
-`;
+` as typeof Button;

--- a/src/modules/Dashboard/components/Banners/ShellAccountSuccessBanner/ShellAccountSuccessBanner.test.tsx
+++ b/src/modules/Dashboard/components/Banners/ShellAccountSuccessBanner/ShellAccountSuccessBanner.test.tsx
@@ -14,11 +14,7 @@ const props = {
   onClose: mockOnClose,
   'data-testid': dataTestid,
 };
-const mockedUseNavigate = jest.fn();
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useNavigate: () => mockedUseNavigate,
-}));
+
 const route = `/dashboard/${mockedAppletId}/add-user`;
 const routePath = page.appletAddUser;
 
@@ -30,6 +26,7 @@ describe('ShellAccountSuccessBanner', () => {
   test('should render', () => {
     const { getByTestId, getByText } = renderWithProviders(
       <ShellAccountSuccessBanner {...props} />,
+      { route, routePath },
     );
 
     expect(getByTestId(dataTestid)).toBeInTheDocument();
@@ -40,7 +37,10 @@ describe('ShellAccountSuccessBanner', () => {
   });
 
   test('clicking the close button hides the banner', () => {
-    const { getByTitle } = renderWithProviders(<ShellAccountSuccessBanner {...props} />);
+    const { getByTitle } = renderWithProviders(<ShellAccountSuccessBanner {...props} />, {
+      route,
+      routePath,
+    });
 
     const closeButton = getByTitle('Close');
     fireEvent.click(closeButton);
@@ -56,10 +56,10 @@ describe('ShellAccountSuccessBanner', () => {
       routePath,
     });
 
-    const button = getAllByRole('button');
-    fireEvent.click(button[0]);
+    const link = getAllByRole('link');
+    expect(link[0]).toHaveAttribute('href', `/dashboard/${mockedAppletId}/respondents`);
+    fireEvent.click(link[0]);
 
-    expect(mockedUseNavigate).toBeCalledWith(`/dashboard/${mockedAppletId}/respondents`);
     expect(mockDispatch).nthCalledWith(1, {
       payload: { key: 'ShellAccountSuccessBanner' },
       type: 'banners/removeBanner',

--- a/src/modules/Dashboard/components/Banners/ShellAccountSuccessBanner/ShellAccountSuccessBanner.tsx
+++ b/src/modules/Dashboard/components/Banners/ShellAccountSuccessBanner/ShellAccountSuccessBanner.tsx
@@ -1,21 +1,20 @@
-import { generatePath, useParams, useNavigate } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import { Trans } from 'react-i18next';
 
-import { page } from 'resources';
 import { Banner, BannerProps } from 'shared/components/Banners/Banner';
 import { useAppDispatch } from 'redux/store';
 import { banners } from 'redux/modules';
+import { useMultiInformantParticipantPath } from 'shared/hooks/useMultiInformantParticipantPath';
 
 import { StyledLinkBtn } from './ShellAccountSuccessBanner.styles';
 import { BANNER_DURATION } from './ShellAccountSuccessBanner.const';
 
 export const ShellAccountSuccessBanner = ({ id, ...props }: BannerProps) => {
-  const navigate = useNavigate();
   const { appletId } = useParams();
+  const participantPath = useMultiInformantParticipantPath({ appletId });
   const dispatch = useAppDispatch();
 
   const handleRedirectClick = () => {
-    navigate(generatePath(page.appletRespondents, { appletId }));
     dispatch(banners.actions.removeBanner({ key: 'ShellAccountSuccessBanner' }));
   };
 
@@ -28,7 +27,10 @@ export const ShellAccountSuccessBanner = ({ id, ...props }: BannerProps) => {
             <>{{ id }}</>
           </strong>
           was successfully created and is available on the
-          <StyledLinkBtn onClick={handleRedirectClick}>Respondents</StyledLinkBtn> tab.
+          <StyledLinkBtn component={Link} to={participantPath} onClick={handleRedirectClick}>
+            Respondents
+          </StyledLinkBtn>
+          tab.
         </>
       </Trans>
     </Banner>

--- a/src/modules/Dashboard/features/Applet/AddUser/AddUserForm/AddUserForm.styles.tsx
+++ b/src/modules/Dashboard/features/Applet/AddUser/AddUserForm/AddUserForm.styles.tsx
@@ -1,4 +1,4 @@
-import { styled, Box, Grid } from '@mui/material';
+import { styled, Box, Grid, Button } from '@mui/material';
 
 import { variables, theme, StyledClearedButton } from 'shared/styles';
 
@@ -35,4 +35,4 @@ export const StyledLinkBtn = styled(StyledClearedButton)`
   &.MuiButton-text:hover {
     background-color: transparent;
   }
-`;
+` as typeof Button;

--- a/src/modules/Dashboard/features/Applet/AddUser/AddUserForm/AddUserForm.tsx
+++ b/src/modules/Dashboard/features/Applet/AddUser/AddUserForm/AddUserForm.tsx
@@ -1,5 +1,5 @@
 import { ChangeEvent, useEffect, useState } from 'react';
-import { generatePath, useParams, useNavigate } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Trans, useTranslation } from 'react-i18next';
@@ -25,7 +25,7 @@ import { users, workspaces, banners } from 'redux/modules';
 import { Svg, Tooltip } from 'shared/components';
 import { useAppDispatch } from 'redux/store';
 import { useFormError } from 'modules/Dashboard/hooks';
-import { page } from 'resources';
+import { useMultiInformantParticipantPath } from 'shared/hooks/useMultiInformantParticipantPath';
 
 import { StyledRow, StyledTooltip, StyledLinkBtn, StyledGridContainer } from './AddUserForm.styles';
 import {
@@ -46,7 +46,7 @@ export const AddUserForm = ({ getInvitationsHandler, roles }: AddUserFormProps) 
   const { appletId } = useParams();
   const dispatch = useAppDispatch();
   const { t } = useTranslation('app');
-  const navigate = useNavigate();
+  const participantPath = useMultiInformantParticipantPath({ appletId });
 
   const [workspaceInfo, setWorkspaceInfo] = useState<WorkspaceInfo | null>(null);
   const [hasCommonError, setHasCommonError] = useState(false);
@@ -161,13 +161,13 @@ export const AddUserForm = ({ getInvitationsHandler, roles }: AddUserFormProps) 
     }
   };
 
-  const handleRedirectClick = () => navigate(generatePath(page.appletRespondents, { appletId }));
-
   const emailInUse = (
     <Trans i18nKey="emailAlreadyInUse">
       That email is
-      <StyledLinkBtn onClick={handleRedirectClick}>already in use</StyledLinkBtn>. Please enter
-      another one.
+      <StyledLinkBtn component={Link} to={participantPath}>
+        already in use
+      </StyledLinkBtn>
+      . Please enter another one.
     </Trans>
   );
 

--- a/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { Controller, useForm, useWatch } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { generatePath, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 import {
   Modal,
@@ -14,13 +14,13 @@ import {
 import { StyledErrorText, StyledLinkBtn, StyledModalWrapper } from 'shared/styles';
 import { useFormError } from 'modules/Dashboard/hooks';
 import { NON_UNIQUE_VALUE_MESSAGE, Roles, VALIDATION_DEBOUNCE_VALUE } from 'shared/consts';
-import { page } from 'resources';
 import { Mixpanel, getErrorMessage } from 'shared/utils';
 import { Languages, postAppletInvitationApi, postAppletShellAccountApi } from 'api';
 import { useAppDispatch } from 'redux/store';
 import { useAsync } from 'shared/hooks';
 import { banners } from 'redux/modules';
 import { AccountType } from 'modules/Dashboard/types/Dashboard.types';
+import { useMultiInformantParticipantPath } from 'shared/hooks/useMultiInformantParticipantPath';
 
 import {
   EMAIL_IN_USE,
@@ -60,10 +60,10 @@ export const AddParticipantPopup = ({
     mode: 'all',
     delayError: VALIDATION_DEBOUNCE_VALUE,
   });
+  const participantPath = useMultiInformantParticipantPath({ appletId });
   const accountType = useWatch({ control, name: 'accountType' });
   const isFullAccount = accountType === AccountType.Full;
   const dispatch = useAppDispatch();
-  const navigate = useNavigate();
   const [step, setStep] = useState(AddParticipantSteps.AccountType);
   const [hasCommonError, setHasCommonError] = useState(false);
 
@@ -158,13 +158,13 @@ export const AddParticipantPopup = ({
     setStep(AddParticipantSteps.AccountType);
   };
 
-  const handleRedirectClick = () => navigate(generatePath(page.appletParticipants, { appletId }));
-
   const emailInUse = (
     <Trans i18nKey="emailAlreadyInUse">
       That email is
-      <StyledLinkBtn onClick={handleRedirectClick}>already in use</StyledLinkBtn>. Please enter
-      another one.
+      <StyledLinkBtn component={Link} to={participantPath}>
+        already in use
+      </StyledLinkBtn>
+      . Please enter another one.
     </Trans>
   );
 
@@ -183,7 +183,7 @@ export const AddParticipantPopup = ({
       {
         fieldName: Fields.email,
         apiMessage: RESPONDENT_ALREADY_INVITED,
-        errorMessage: t('participantAlreadyInvited'),
+        errorMessage: emailInUse,
       },
       {
         fieldName: Fields.email,

--- a/src/modules/Dashboard/features/Applets/AppletsTable/AppletItem/AppletItem.tsx
+++ b/src/modules/Dashboard/features/Applets/AppletsTable/AppletItem/AppletItem.tsx
@@ -14,6 +14,7 @@ import {
   AppletPasswordRefType,
 } from 'modules/Dashboard/features/Applet/Popups';
 import { page } from 'resources';
+import { useMultiInformantParticipantPath } from 'shared/hooks/useMultiInformantParticipantPath';
 import {
   Encryption,
   falseReturnFunc,
@@ -44,6 +45,8 @@ export const AppletItem = ({ item, onPublish }: AppletItemProps) => {
   const { id: accountId } = userData?.user || {};
   const workspaceRoles = workspaces.useRolesData();
   const appletId = item.id;
+  const participantPath = useMultiInformantParticipantPath({ appletId });
+
   const setAppletPrivateKey = useAppletPrivateKeySetter();
   const encryptionDataRef = useRef<{
     encryption?: Encryption;
@@ -74,9 +77,6 @@ export const AppletItem = ({ item, onPublish }: AppletItemProps) => {
   const [passwordPopupVisible, setPasswordPopupVisible] = useState(false);
   const [hasVisibleActions, setHasVisibleActions] = useState(false);
 
-  const APPLET_RESPONDENTS = generatePath(page.appletRespondents, {
-    appletId,
-  });
   const APPLET_SCHEDULE = generatePath(page.appletSchedule, {
     appletId,
   });
@@ -92,7 +92,7 @@ export const AppletItem = ({ item, onPublish }: AppletItemProps) => {
     await fetchData();
   };
 
-  const handleAppletClick = () => checkAppletEncryption(() => navigate(APPLET_RESPONDENTS));
+  const handleAppletClick = () => checkAppletEncryption(() => navigate(participantPath));
 
   const onDragStart = (event: DragEvent<HTMLTableRowElement>) => {
     event.persist();
@@ -125,7 +125,7 @@ export const AppletItem = ({ item, onPublish }: AppletItemProps) => {
       await setFolder({ appletId });
       await fetchData();
     },
-    viewUsers: () => checkAppletEncryption(() => navigate(APPLET_RESPONDENTS)),
+    viewUsers: () => checkAppletEncryption(() => navigate(participantPath)),
     viewCalendar: () =>
       checkAppletEncryption(() => {
         navigate(APPLET_SCHEDULE);

--- a/src/modules/Dashboard/pages/RespondentData/RespondentData.tsx
+++ b/src/modules/Dashboard/pages/RespondentData/RespondentData.tsx
@@ -1,26 +1,22 @@
 import { useEffect } from 'react';
-import { generatePath, useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 import { StyledBody, StyledDirectoryUpButton } from 'shared/styles/styledComponents';
 import { EmptyState, Svg } from 'shared/components';
 import { Roles } from 'shared/consts';
 import { Mixpanel } from 'shared/utils/mixpanel';
-import { page } from 'resources';
 import { workspaces } from 'redux/modules';
 import { RespondentData as RespondentDataFeature } from 'modules/Dashboard/features/RespondentData/RespondentData';
+import { useMultiInformantParticipantPath } from 'shared/hooks/useMultiInformantParticipantPath';
 
 export const RespondentData = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { appletId } = useParams();
+  const participantPath = useMultiInformantParticipantPath({ appletId });
 
-  const navigateUp = () =>
-    navigate(
-      generatePath(page.appletRespondents, {
-        appletId,
-      }),
-    );
+  const navigateUp = () => navigate(participantPath);
 
   useEffect(() => {
     Mixpanel.trackPageView('Data Viz');

--- a/src/shared/hooks/useMultiInformantParticipantPath.test.ts
+++ b/src/shared/hooks/useMultiInformantParticipantPath.test.ts
@@ -1,0 +1,44 @@
+import { renderHook } from '@testing-library/react';
+
+import * as launchDarklyHook from 'shared/hooks/useLaunchDarkly';
+import { useMultiInformantParticipantPath } from 'shared/hooks/useMultiInformantParticipantPath';
+
+const appletId = `applet-test-id`;
+
+describe('useMultiInformantParticipantPath', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('when `enableMultiInformant` is set', () => {
+    beforeEach(() => {
+      jest
+        .spyOn(launchDarklyHook, 'useLaunchDarkly')
+        .mockReturnValue({ flags: { enableMultiInformant: true } } as unknown as ReturnType<
+          typeof launchDarklyHook.useLaunchDarkly
+        >);
+    });
+
+    test('it returns the participant path', async () => {
+      const { result } = renderHook(() => useMultiInformantParticipantPath({ appletId }));
+
+      expect(result.current).toEqual('/dashboard/applet-test-id/participants');
+    });
+  });
+
+  describe('when `enableMultiInformant` is not set', () => {
+    beforeEach(() => {
+      jest
+        .spyOn(launchDarklyHook, 'useLaunchDarkly')
+        .mockReturnValue({ flags: { enableMultiInformant: false } } as unknown as ReturnType<
+          typeof launchDarklyHook.useLaunchDarkly
+        >);
+    });
+
+    test('it returns the respondent path', async () => {
+      const { result } = renderHook(() => useMultiInformantParticipantPath({ appletId }));
+
+      expect(result.current).toEqual('/dashboard/applet-test-id/respondents');
+    });
+  });
+});

--- a/src/shared/hooks/useMultiInformantParticipantPath.ts
+++ b/src/shared/hooks/useMultiInformantParticipantPath.ts
@@ -1,0 +1,15 @@
+import { generatePath } from 'react-router-dom';
+
+import { page } from 'resources';
+import { useLaunchDarkly } from 'shared/hooks/useLaunchDarkly';
+
+export function useMultiInformantParticipantPath(pathOptions: { appletId?: string | null }) {
+  const {
+    flags: { enableMultiInformant },
+  } = useLaunchDarkly();
+
+  return generatePath(
+    enableMultiInformant ? page.appletParticipants : page.appletRespondents,
+    pathOptions,
+  );
+}

--- a/src/shared/styles/styledComponents/Buttons.ts
+++ b/src/shared/styles/styledComponents/Buttons.ts
@@ -48,4 +48,4 @@ export const StyledLinkBtn = styled(StyledClearedButton)`
   &.MuiButton-text:hover {
     background-color: transparent;
   }
-`;
+` as typeof Button;


### PR DESCRIPTION
### 🔗 Related Tasks

- [M2-6098](https://mindlogger.atlassian.net/browse/M2-6098): [Admin][Multi-Informant] - Update existing `/dashboard/[applet_id]/respondents` links to use `participants`

### 📝 Description

This PR updates a number of links to either `"/dashboard/:appletId/respondents"` or `"/dashboard/:appletId/participants"` to uniformly resolve to either one or the other based on the `enableMultiInformant` feature flag setting.

I added a new hook, `useMultiInformantParticipantPath`, to handle this. It accepts the parameters for the route, and returns the formatted path based on the state of the feature flag. I opted to approach it this way (rather than using `useParams` directly in the hook) to allow for link generation without the applet ID existing in the current path.

A handful of the links updated are used exclusively on "multi-informant" or "non-multi-informant" pages already, but I opted to change these anyway for consistency and to redirect users in case they happened to get lost (eg, by entering a URL to one or the other page directly).

Finally, I found a couple links were actually `<button>` elements with `onClick` handlers. I swapped those for react-router `Link`s so that they would render semantically as anchor tags.


[M2-6098]: https://mindlogger.atlassian.net/browse/M2-6098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ