### PR TITLE
[M2-6424] [M2-6392]: [FE] [Participant Detail] Revert activities endpoint to `/activities/applet/{appletId}`

### DIFF
--- a/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.tsx
+++ b/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.tsx
@@ -41,9 +41,12 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
     (participant: ParticipantsData['result'][0]): ParticipantDropdownOption => {
       const stringNicknames = joinWihComma(participant.nicknames, true);
       const stringSecretIds = joinWihComma(participant.secretIds, true);
-      const id = participant.id ?? participant.details[0].subjectId;
 
-      return { id, secretId: stringSecretIds, nickname: stringNicknames };
+      return {
+        id: participant.details[0].subjectId,
+        secretId: stringSecretIds,
+        nickname: stringNicknames,
+      };
     },
     [],
   );
@@ -77,6 +80,7 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
       }
 
       const ownerOption: ParticipantDropdownOption = {
+        // Here we use the user ID instead of the subject ID
         id: userData.user.id,
         secretId: userData.user.id,
         nickname: ownerNickname,

--- a/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.tsx
+++ b/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.tsx
@@ -75,7 +75,7 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
       if (userData.user.firstName) {
         ownerNickname += `${userData.user.firstName}`;
         if (userData.user.lastName) {
-          ownerNickname += ` ${userData.user.lastName[0].toUpperCase()}.`;
+          ownerNickname += ` ${userData.user.lastName}`;
         }
       }
 

--- a/src/modules/Dashboard/features/Applet/Activities/Activities.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Activities/Activities.test.tsx
@@ -300,7 +300,7 @@ describe('Dashboard > Applet > Activities screen', () => {
         .querySelector('input');
 
       expect(inputElement).toHaveValue(
-        `${mockedUserData.id} (${mockedUserData.firstName} ${mockedUserData.lastName[0]}.)`,
+        `${mockedUserData.id} (${mockedUserData.firstName} ${mockedUserData.lastName})`,
       );
     });
   });

--- a/src/modules/Dashboard/features/Participant/Activities/Activities.test.tsx
+++ b/src/modules/Dashboard/features/Participant/Activities/Activities.test.tsx
@@ -318,7 +318,7 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
       expect(subjectInputElement).toHaveValue(`${secretUserId} (${nickname})`);
 
       expect(participantInputElement).toHaveValue(
-        `${mockedUserData.id} (${mockedUserData.firstName} ${mockedUserData.lastName[0]}.)`,
+        `${mockedUserData.id} (${mockedUserData.firstName} ${mockedUserData.lastName})`,
       );
     });
   });

--- a/src/modules/Dashboard/features/Participant/Activities/Activities.tsx
+++ b/src/modules/Dashboard/features/Participant/Activities/Activities.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
-import { DatavizActivity, getSummaryActivitiesApi } from 'api';
+import { DatavizActivity, getAppletActivitiesApi } from 'api';
 import { useAsync } from 'shared/hooks';
 import {
   ActivityActionProps,
@@ -33,20 +33,11 @@ export const Activities = () => {
     openTakeNowModal,
   } = useActivityGrid(dataTestId, activitiesData);
 
-  /**
-   * TODO M2-6223:
-   * getAppletActivitiesApi returns activities for the currently logged in user (an admin/collaborator). This behavior is correct for M2-5585, as per the note:
-   *  "for this ticket all activities in the applet are assigned to the user as we have not yet introduced the concept of assigning activities to users."
-   * This endpoint could be updated to include a `participant_id` param and retrieve _other_ user's assigned activities
-   *
-   * Alternatively, we can use `getSummaryActivitiesApi` as that endpoint _does_ retrieve the target users activities
-   * However this endpoint returns a reduced response (id, name, isPerformanceTask, hasAnswer) that doesn't include all Activity metadata
-   * so it needs to be updated to include everything (id, name, image )
-   */
-  const { execute: getSummaryActivities } = useAsync(
-    getSummaryActivitiesApi,
+  // TODO M2-6223: Update this call to include a `participant_id` param
+  const { execute: getActivities } = useAsync(
+    getAppletActivitiesApi,
     (response) => {
-      const activities = response?.data.result;
+      const activities = response?.data.result.activitiesDetails;
 
       return setActivitiesData({ result: activities, count: activities.length });
     },
@@ -57,8 +48,12 @@ export const Activities = () => {
   useEffect(() => {
     if (!appletId || !participantId) return;
 
-    getSummaryActivities({ appletId, targetSubjectId: participantId });
-  }, [appletId, participantId, getSummaryActivities]);
+    getActivities({
+      params: {
+        appletId,
+      },
+    });
+  }, [appletId, getActivities]);
 
   const activities = useMemo(
     () =>


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-6424](https://mindlogger.atlassian.net/browse/M2-6424)
🔗 [Jira Ticket M2-6392](https://mindlogger.atlassian.net/browse/M2-6392)

This PR reverts the activities tab on the participant detail screen to use the `/activities/applet/{appletId}` endpoint to fetch a list of activities, instead of the `/answers/applet/{appletId}/summary/activities` endpoint. This will allow admin users with a `Coordinator` role to access this page where they were previously blocked.

I also took the opportunity to fix two other small bugs:
- Always use the subject ID for the "who is this activity about" dropdown field in the Take Now modal - The web app is expecting the subject ID, and we were previously using the user ID for full accounts, which would result in an error on the web app side
- Stop abbreviating the admin name in the "Who is responding field" - This is a quick fix for [M2-6392](https://mindlogger.atlassian.net/browse/M2-6392). While we currently don't have access to the nickname for the currently logged in user, the constructed nickname doesn't conform to the default nickname format of `{firstName} {lastName}`. This fixes that

### 📸 Screenshots

#### Coordinator access

https://github.com/ChildMindInstitute/mindlogger-admin/assets/14842108/f7942526-2f08-4cf8-a46a-66a29c673816

#### Proper admin nickname in dropdown

<img width="1726" alt="image" src="https://github.com/ChildMindInstitute/mindlogger-admin/assets/14842108/1e371249-235c-415a-b23d-879862029a17">

#### Using the subject ID

https://github.com/ChildMindInstitute/mindlogger-admin/assets/14842108/7bef2e25-7269-473e-ae10-28381b899c99

### 🪤 Peer Testing

You'll need a workspace with:
- An owner
- A Coordinator
- An applet with 1 activity

#### Coordinator access

- Log in with the coordinator user
- Navigate to the activities tab on the participant detail page of the coordinator (or some other full account participant) as in the video
- Confirm that you can see the list of activities

#### Admin nickname

- Navigate to the applet activities tab
- Open the Take Now modal
- Confirm that the admin name in the "who is responding" dropdown is the same as their full name in the system

#### Subject ID usage

- Start up your participant web app locally on the `dev` branch
- Log in to the admin app as the owner
- Navigate to the applet activities tab of the admin app
- Open the Take Now modal
- Select the Coordinator user as the value of the "who is this activity about" dropdown
- Click the **Start Activity** button
- Confirm that no errors are shown in the participant web app tab

### ✏️ Notes

N/A


[M2-6392]: https://mindlogger.atlassian.net/browse/M2-6392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ