### PR TITLE
M2-6385: Refresh cycling at the screen after removing Manager role in admin panel

### DIFF
--- a/src/modules/Builder/pages/BuilderApplet/BuilderApplet.tsx
+++ b/src/modules/Builder/pages/BuilderApplet/BuilderApplet.tsx
@@ -9,7 +9,7 @@ import { SaveAndPublish } from 'modules/Builder/features/SaveAndPublish';
 import { LinkedTabs, Spinner } from 'shared/components';
 import { useCheckIfNewApplet, useRemoveAppletData, usePermissions } from 'shared/hooks';
 import { StyledBody } from 'shared/styles/styledComponents';
-import { applet } from 'shared/state';
+import { applet, forbiddenState } from 'shared/state';
 import { workspaces } from 'redux/modules';
 import { AppletFormValues } from 'modules/Builder/types';
 import { themes } from 'modules/Builder/state';
@@ -31,6 +31,7 @@ export const BuilderApplet = () => {
   const dispatch = useAppDispatch();
   const { appletId } = useParams();
   const isNewApplet = useCheckIfNewApplet();
+  const navigatedFromBuilder = forbiddenState.useData()?.navigatedFromBuilder ?? {};
   const { result: appletData } = applet.useAppletData() ?? {};
   const { getAppletWithItems } = applet.thunk;
   const { result: themesList = [] } = themes.useThemesData() || {};
@@ -54,7 +55,7 @@ export const BuilderApplet = () => {
   const defaultThemeId = getDefaultThemeId(themesList);
 
   const { isForbidden, noPermissionsComponent } = usePermissions(() =>
-    appletId && ownerId && !isNewApplet
+    appletId && ownerId && !isNewApplet && !navigatedFromBuilder
       ? dispatch(getAppletWithItems({ ownerId, appletId }))
       : undefined,
   );

--- a/src/modules/Builder/pages/BuilderApplet/BuilderApplet.tsx
+++ b/src/modules/Builder/pages/BuilderApplet/BuilderApplet.tsx
@@ -31,7 +31,7 @@ export const BuilderApplet = () => {
   const dispatch = useAppDispatch();
   const { appletId } = useParams();
   const isNewApplet = useCheckIfNewApplet();
-  const navigatedFromBuilder = forbiddenState.useData()?.navigatedFromBuilder ?? {};
+  const redirectedFromBuilder = forbiddenState.useData()?.redirectedFromBuilder ?? {};
   const { result: appletData } = applet.useAppletData() ?? {};
   const { getAppletWithItems } = applet.thunk;
   const { result: themesList = [] } = themes.useThemesData() || {};
@@ -55,7 +55,7 @@ export const BuilderApplet = () => {
   const defaultThemeId = getDefaultThemeId(themesList);
 
   const { isForbidden, noPermissionsComponent } = usePermissions(() =>
-    appletId && ownerId && !isNewApplet && !navigatedFromBuilder
+    appletId && ownerId && !isNewApplet && !redirectedFromBuilder
       ? dispatch(getAppletWithItems({ ownerId, appletId }))
       : undefined,
   );

--- a/src/modules/Dashboard/features/Managers/Managers.tsx
+++ b/src/modules/Dashboard/features/Managers/Managers.tsx
@@ -101,7 +101,7 @@ export const Managers = () => {
 
   const removeManagerAccessOnClose = (step?: number) => {
     setRemoveAccessPopupVisible(false);
-    step === 2 && handleReload();
+    step === 3 && handleReload();
   };
 
   const editManagerAccessOnClose = (shouldRefetch?: boolean) => {

--- a/src/shared/components/NoPermissionPopup/NoPermissionPopup.hooks.ts
+++ b/src/shared/components/NoPermissionPopup/NoPermissionPopup.hooks.ts
@@ -27,7 +27,7 @@ export const useNoPermissionPopup = (): UseNoPermissionPopupReturn => {
 
   const handleSubmit = async () => {
     dispatch(forbiddenState.actions.clearForbiddenError());
-    isBuilder && dispatch(forbiddenState.actions.setNavigatedFromBuilder());
+    isBuilder && dispatch(forbiddenState.actions.setRedirectedFromBuilder());
     dispatch(applet.actions.resetApplet());
     dispatch(alerts.actions.resetAlerts());
     dispatch(alerts.thunk.getAlerts({ limit: DEFAULT_ROWS_PER_PAGE }));
@@ -43,7 +43,7 @@ export const useNoPermissionPopup = (): UseNoPermissionPopupReturn => {
       Promise.resolve(
         navigate(page.dashboardApplets, { state: { [LocationStateKeys.Workspace]: workspace } }),
       ).then(() => {
-        isBuilder && dispatch(forbiddenState.actions.resetNavigatedFromBuilder());
+        isBuilder && dispatch(forbiddenState.actions.resetRedirectedFromBuilder());
       });
 
       return;

--- a/src/shared/components/NoPermissionPopup/NoPermissionPopup.hooks.ts
+++ b/src/shared/components/NoPermissionPopup/NoPermissionPopup.hooks.ts
@@ -27,6 +27,7 @@ export const useNoPermissionPopup = (): UseNoPermissionPopupReturn => {
 
   const handleSubmit = async () => {
     dispatch(forbiddenState.actions.clearForbiddenError());
+    isBuilder && dispatch(forbiddenState.actions.setNavigatedFromBuilder());
     dispatch(applet.actions.resetApplet());
     dispatch(alerts.actions.resetAlerts());
     dispatch(alerts.thunk.getAlerts({ limit: DEFAULT_ROWS_PER_PAGE }));
@@ -38,7 +39,12 @@ export const useNoPermissionPopup = (): UseNoPermissionPopupReturn => {
       const workspacesData = result.payload.data.result as Workspace[];
       const workspace = workspacesData.find((item) => item.ownerId === id);
       dispatch(workspaces.actions.setCurrentWorkspace(workspace ?? null));
-      navigate(page.dashboardApplets, { state: { [LocationStateKeys.Workspace]: workspace } });
+
+      Promise.resolve(
+        navigate(page.dashboardApplets, { state: { [LocationStateKeys.Workspace]: workspace } }),
+      ).then(() => {
+        isBuilder && dispatch(forbiddenState.actions.resetNavigatedFromBuilder());
+      });
 
       return;
     }

--- a/src/shared/components/NoPermissionPopup/NoPermissionPopup.test.tsx
+++ b/src/shared/components/NoPermissionPopup/NoPermissionPopup.test.tsx
@@ -19,6 +19,7 @@ const getPreloadedState = (hasForbiddenError = true): PreloadedState<RootState> 
   forbiddenState: {
     data: {
       hasForbiddenError,
+      redirectedFromBuilder: false,
     },
   },
 });

--- a/src/shared/state/ForbiddenState/ForbiddenState.reducer.ts
+++ b/src/shared/state/ForbiddenState/ForbiddenState.reducer.ts
@@ -7,10 +7,10 @@ export const reducers = {
   clearForbiddenError: (state: ForbiddenStateSchema): void => {
     state.data.hasForbiddenError = false;
   },
-  setNavigatedFromBuilder: (state: ForbiddenStateSchema): void => {
-    state.data.navigatedFromBuilder = true;
+  setRedirectedFromBuilder: (state: ForbiddenStateSchema): void => {
+    state.data.redirectedFromBuilder = true;
   },
-  resetNavigatedFromBuilder: (state: ForbiddenStateSchema): void => {
-    state.data.navigatedFromBuilder = false;
+  resetRedirectedFromBuilder: (state: ForbiddenStateSchema): void => {
+    state.data.redirectedFromBuilder = false;
   },
 };

--- a/src/shared/state/ForbiddenState/ForbiddenState.reducer.ts
+++ b/src/shared/state/ForbiddenState/ForbiddenState.reducer.ts
@@ -7,4 +7,10 @@ export const reducers = {
   clearForbiddenError: (state: ForbiddenStateSchema): void => {
     state.data.hasForbiddenError = false;
   },
+  setNavigatedFromBuilder: (state: ForbiddenStateSchema): void => {
+    state.data.navigatedFromBuilder = true;
+  },
+  resetNavigatedFromBuilder: (state: ForbiddenStateSchema): void => {
+    state.data.navigatedFromBuilder = false;
+  },
 };

--- a/src/shared/state/ForbiddenState/ForbiddenState.schema.ts
+++ b/src/shared/state/ForbiddenState/ForbiddenState.schema.ts
@@ -1,5 +1,6 @@
 export type ForbiddenStateSchema = {
   data: {
     hasForbiddenError: boolean;
+    navigatedFromBuilder: boolean;
   };
 };

--- a/src/shared/state/ForbiddenState/ForbiddenState.schema.ts
+++ b/src/shared/state/ForbiddenState/ForbiddenState.schema.ts
@@ -1,6 +1,6 @@
 export type ForbiddenStateSchema = {
   data: {
     hasForbiddenError: boolean;
-    navigatedFromBuilder: boolean;
+    redirectedFromBuilder: boolean;
   };
 };

--- a/src/shared/state/ForbiddenState/ForbiddenState.state.tsx
+++ b/src/shared/state/ForbiddenState/ForbiddenState.state.tsx
@@ -3,5 +3,6 @@ import { ForbiddenStateSchema } from './ForbiddenState.schema';
 export const state: ForbiddenStateSchema = {
   data: {
     hasForbiddenError: false,
+    navigatedFromBuilder: false,
   },
 };

--- a/src/shared/state/ForbiddenState/ForbiddenState.state.tsx
+++ b/src/shared/state/ForbiddenState/ForbiddenState.state.tsx
@@ -3,6 +3,6 @@ import { ForbiddenStateSchema } from './ForbiddenState.schema';
 export const state: ForbiddenStateSchema = {
   data: {
     hasForbiddenError: false,
-    navigatedFromBuilder: false,
+    redirectedFromBuilder: false,
   },
 };


### PR DESCRIPTION
- [ ] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

🔗 [Jira Ticket M2-6385](https://mindlogger.atlassian.net/browse/M2-6385)

Changes include:

 -  Added a global state property redirectedFromBuilder to prevent the AppletBuilder component from re-rendering after navigating to the Dashboard.
 -  Fixed removeManagerAccessOnClose to refresh the list of managers and include recent information (in Managers.tsx).
 -  Added unit tests to cover setting and resetting the redirectedFromBuilder global state.