### PR TITLE
M2-6506: Fix handling of user ID in schedule popups.

### DIFF
--- a/src/modules/Dashboard/features/Applet/Schedule/ClearScheduledEventsPopup/ClearScheduledEventsPopup.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/ClearScheduledEventsPopup/ClearScheduledEventsPopup.test.tsx
@@ -49,10 +49,13 @@ describe('ClearScheduledEventsPopup', () => {
     const route = `/dashboard/${mockedAppletId}/schedule/${mockedRespondentId}`;
     const routePath = page.appletScheduleIndividual;
     mockAxios.delete.mockResolvedValueOnce(null);
-    renderWithProviders(<ClearScheduledEventsPopup {...basicProps} isDefault={false} />, {
-      route,
-      routePath,
-    });
+    renderWithProviders(
+      <ClearScheduledEventsPopup {...basicProps} isDefault={false} userId={mockedRespondentId} />,
+      {
+        route,
+        routePath,
+      },
+    );
 
     const popupText = screen.getByTestId(`${dataTestid}-text`);
     expect(popupText).toHaveTextContent(

--- a/src/modules/Dashboard/features/Applet/Schedule/ClearScheduledEventsPopup/ClearScheduledEventsPopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/ClearScheduledEventsPopup/ClearScheduledEventsPopup.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
 
 import { Modal, Spinner, SpinnerUiType, SubmitBtnColor } from 'shared/components';
 import { StyledBodyLarge, StyledModalWrapper, theme, variables } from 'shared/styles';
@@ -21,9 +20,9 @@ export const ClearScheduledEventsPopup = ({
   appletId,
   isDefault = true,
   'data-testid': dataTestid,
+  userId,
 }: ClearScheduledEventsPopupProps) => {
   const { t } = useTranslation();
-  const { respondentId } = useParams();
   const dispatch = useAppDispatch();
   const [step, setStep] = useState<Steps>(0);
   const {
@@ -36,7 +35,7 @@ export const ClearScheduledEventsPopup = ({
     error: deleteIndividualScheduledError,
     isLoading: deleteIndividualScheduledLoading,
   } = useAsync(deleteIndividualEventsApi, () =>
-    dispatch(applets.thunk.getEvents({ appletId, respondentId })),
+    dispatch(applets.thunk.getEvents({ appletId, respondentId: userId })),
   );
 
   const isLoading = deleteScheduledLoading || deleteIndividualScheduledLoading;
@@ -53,7 +52,7 @@ export const ClearScheduledEventsPopup = ({
       return await deleteScheduledEvents({ appletId });
     }
 
-    return respondentId && (await deleteIndividualScheduledEvents({ appletId, respondentId }));
+    return userId && (await deleteIndividualScheduledEvents({ appletId, respondentId: userId }));
   };
 
   const onSubmit = async () => {

--- a/src/modules/Dashboard/features/Applet/Schedule/ClearScheduledEventsPopup/ClearScheduledEventsPopup.types.ts
+++ b/src/modules/Dashboard/features/Applet/Schedule/ClearScheduledEventsPopup/ClearScheduledEventsPopup.types.ts
@@ -6,6 +6,7 @@ export type ClearScheduledEventsPopupProps = {
   name?: string;
   isDefault?: boolean;
   'data-testid'?: string;
+  userId?: string;
 };
 
 export type Steps = 0 | 1;

--- a/src/modules/Dashboard/features/Applet/Schedule/CreateEventPopup/CreateEventPopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/CreateEventPopup/CreateEventPopup.tsx
@@ -25,7 +25,7 @@ export const CreateEventPopup = ({
   const [removeAlwaysAvailablePopupVisible, setRemoveAlwaysAvailablePopupVisible] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const handleCreateEventClose = () => setCreateEventPopupVisible(false);
-  const userId = searchParams.get('user');
+  const userId = searchParams.get('user') ?? undefined;
 
   const isIndividualCalendar = !!userId;
   const analyticsPrefix = isIndividualCalendar
@@ -98,6 +98,7 @@ export const CreateEventPopup = ({
               defaultStartDate={defaultStartDate}
               onFormIsLoading={handleFormIsLoading}
               data-testid={`${dataTestid}-form`}
+              userId={userId}
             />
           </>
         </Modal>

--- a/src/modules/Dashboard/features/Applet/Schedule/EditEventPopup/EditEventPopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/EditEventPopup/EditEventPopup.tsx
@@ -1,6 +1,6 @@
 import { RefObject, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 
 import { Modal, Spinner, SpinnerUiType, Svg } from 'shared/components';
 import { useAsync } from 'shared/hooks/useAsync';
@@ -32,18 +32,20 @@ export const EditEventPopup = ({
   const [isFormChanged, setIsFormChanged] = useState(false);
   const [isClosable, setIsClosable] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-  const { appletId, respondentId } = useParams();
+  const [searchParams] = useSearchParams();
+  const { appletId } = useParams();
+  const userId = searchParams.get('user') ?? undefined;
   const dispatch = useAppDispatch();
   const dataTestid = 'dashboard-calendar-edit-event';
 
-  const isIndividualCalendar = !!respondentId;
+  const isIndividualCalendar = !!userId;
   const analyticsPrefix = isIndividualCalendar
     ? AnalyticsCalendarPrefix.IndividualCalendar
     : AnalyticsCalendarPrefix.GeneralCalendar;
 
   const { execute: removeEvent, isLoading: removeEventIsLoading } = useAsync(
     deleteEventApi,
-    () => appletId && dispatch(applets.thunk.getEvents({ appletId, respondentId })),
+    () => appletId && dispatch(applets.thunk.getEvents({ appletId, respondentId: userId })),
   );
 
   const handleFormChanged = (isChanged: boolean) => {
@@ -154,6 +156,7 @@ export const EditEventPopup = ({
               onFormIsLoading={handleFormIsLoading}
               onFormChange={handleFormChanged}
               data-testid={`${dataTestid}-popup-form`}
+              userId={userId}
             />
           </>
         </Modal>

--- a/src/modules/Dashboard/features/Applet/Schedule/EventForm/EventForm.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/EventForm/EventForm.tsx
@@ -2,7 +2,6 @@ import { forwardRef, useEffect, useImperativeHandle, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FormProvider, useForm, useFormState } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { useParams } from 'react-router-dom';
 import { ObjectSchema } from 'yup';
 
 import { Option, SelectController } from 'shared/components/FormComponents';
@@ -40,20 +39,20 @@ export const EventForm = forwardRef<EventFormRef, EventFormProps>(
       onFormIsLoading,
       onFormChange,
       'data-testid': dataTestid,
+      userId,
     },
     ref,
   ) => {
     const [activitiesOrFlows, setActivitiesOrFlows] = useState<null | Option[]>(null);
     const { t } = useTranslation('app');
     const dispatch = useAppDispatch();
-    const { respondentId } = useParams();
     const appletData = applet.useAppletData();
     const { ownerId } = workspaces.useData() || {};
     const appletId = appletData?.result.id;
     const defaultValues = getDefaultValues(defaultStartDate, editedEvent);
     const eventsData = calendarEvents.useCreateEventsData() || [];
 
-    const isIndividualCalendar = !!respondentId;
+    const isIndividualCalendar = !!userId;
     const analyticsPrefix = isIndividualCalendar
       ? AnalyticsCalendarPrefix.IndividualCalendar
       : AnalyticsCalendarPrefix.GeneralCalendar;
@@ -101,8 +100,8 @@ export const EventForm = forwardRef<EventFormRef, EventFormProps>(
 
     const getEvents = () => {
       if (!appletId) return;
-      dispatch(applets.thunk.getEvents({ appletId, respondentId }));
-      if (respondentId && ownerId && eventsData.length === 0) {
+      dispatch(applets.thunk.getEvents({ appletId, respondentId: userId }));
+      if (userId && ownerId && eventsData.length === 0) {
         dispatch(
           users.thunk.getAllWorkspaceRespondents({
             params: {
@@ -147,10 +146,15 @@ export const EventForm = forwardRef<EventFormRef, EventFormProps>(
       if (!appletId) {
         return;
       }
-      const body = getEventPayload(defaultStartDate, getValues, respondentId);
+      const body = getEventPayload(defaultStartDate, getValues, userId);
 
       if (editedEvent) {
-        const { activityId, flowId, respondentId, ...updateEventBody } = body;
+        const {
+          activityId: _activityId,
+          flowId: _flowId,
+          respondentId: _respondentId,
+          ...updateEventBody
+        } = body;
         await updateEvent({
           appletId,
           eventId: editedEvent.eventId,

--- a/src/modules/Dashboard/features/Applet/Schedule/EventForm/EventForm.types.ts
+++ b/src/modules/Dashboard/features/Applet/Schedule/EventForm/EventForm.types.ts
@@ -25,6 +25,7 @@ export type EventFormProps = {
   editedEvent?: CalendarEvent;
   onFormChange?: (isChanged: boolean) => void;
   'data-testid'?: string;
+  userId?: string;
 };
 
 export type Warning = {

--- a/src/modules/Dashboard/features/Applet/Schedule/Legend/Legend.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/Legend/Legend.tsx
@@ -256,6 +256,7 @@ export const Legend = ({
           open={clearScheduledEventsPopupVisible}
           appletName={appletName}
           appletId={appletId}
+          userId={userId}
           isDefault={!isIndividual}
           name={respondentName}
           onClose={() => setClearScheduledEventsPopupVisible(false)}
@@ -270,6 +271,7 @@ export const Legend = ({
           onClose={() => setRemoveIndividualSchedulePopupVisible(false)}
           setSchedule={setSchedule}
           onSelectUser={onSelectUser}
+          respondentId={userId}
           data-testid={`${dataTestid}-remove-individual-schedule-popup`}
         />
       )}


### PR DESCRIPTION
### 🔗 Related Issues

[M2-6506](https://mindlogger.atlassian.net/browse/M2-6506): [Admin Panel] Issues with modifying events from Participant Detail Schedule tab

### 📝 Description

This PR fixes an issue with a few popups on the schedule view. As part of my recent changes, I refactored a number of schedule view components to use query parameters for determining if the user is viewing a schedule for a specific user, or viewing the default schedule. This was a change from the previous approach of using the presence of a respondentId in the route path to determine this, as this would not be true when viewing the schedule from the participant details route. 

I must have missed these dialogs when making this change, as they were still reliant on react router's `useParams`, and not the expected `useSearchParams`. As a result, they always behaved as though we were modifying the _default_ schedule, even when we were expecting to modify the _individual_ schedule. Honestly, I'm not 100% on how I overlooked this, given that I created and deleted a bunch of events via this same UI while working on this feature and I'm positive I made the relevant changes in create/edit dialogs previously 😕.

### 📸 Screenshots

| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| ![popup-before](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/c307257f-24ea-471a-b7f6-25511040b356) | ![popup-after](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/e5176f5d-47b2-4e43-acd1-a6ad340eef10) |
| ![create-popup-before](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/83abd01a-8e25-4978-ba58-b6d3a84f55dd) | ![create-popup-after](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/89983fc2-5ee9-4b4e-9c2e-985d89e9fd72) |


[M2-6506]: https://mindlogger.atlassian.net/browse/M2-6506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ