### PR TITLE
M2-6348: [FE][Take Now] Remove Coordinator Permissions for Initiating Take Now

### DIFF
--- a/src/modules/Dashboard/components/ActivityGrid/ActivityGrid.utils.test.ts
+++ b/src/modules/Dashboard/components/ActivityGrid/ActivityGrid.utils.test.ts
@@ -116,7 +116,7 @@ describe('getActivityActions', () => {
     expectMenuItemIsDisplayed(menuItems, 'editActivity', false);
     expectMenuItemIsDisplayed(menuItems, 'exportData', true);
     expectMenuItemIsDisplayed(menuItems, 'assignActivity', true);
-    expectMenuItemIsDisplayed(menuItems, 'takeNow', true);
+    expectMenuItemIsDisplayed(menuItems, 'takeNow', false);
   });
 
   test('Correct menu items are displayed when user is an editor', () => {

--- a/src/modules/Dashboard/components/ActivityGrid/ActivityGrid.utils.tsx
+++ b/src/modules/Dashboard/components/ActivityGrid/ActivityGrid.utils.tsx
@@ -24,9 +24,7 @@ export const getActivityActions = ({
   const canDoTakeNow =
     featureFlags.enableMultiInformantTakeNow &&
     hasParticipants &&
-    (isManagerOrOwner(roles?.[0]) ||
-      roles?.includes(Roles.Coordinator) ||
-      roles?.includes(Roles.SuperAdmin));
+    (isManagerOrOwner(roles?.[0]) || roles?.includes(Roles.SuperAdmin));
 
   return [
     {

--- a/src/modules/Dashboard/features/Applet/Activities/Activities.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Activities/Activities.test.tsx
@@ -184,7 +184,7 @@ describe('Dashboard > Applet > Activities screen', () => {
         ${true}      | ${Roles.Manager}     | ${'Take Now for Manager'}
         ${true}      | ${Roles.SuperAdmin}  | ${'Take Now for SuperAdmin'}
         ${true}      | ${Roles.Owner}       | ${'Take Now for Owner'}
-        ${true}      | ${Roles.Coordinator} | ${'Take Now for Coordinator'}
+        ${false}     | ${Roles.Coordinator} | ${'Take Now for Coordinator'}
         ${false}     | ${Roles.Editor}      | ${'Take Now for Editor'}
         ${false}     | ${Roles.Respondent}  | ${'Take Now for Respondent'}
         ${false}     | ${Roles.Reviewer}    | ${'Take Now for Reviewer'}

--- a/src/modules/Dashboard/features/Participant/Activities/Activities.test.tsx
+++ b/src/modules/Dashboard/features/Participant/Activities/Activities.test.tsx
@@ -195,7 +195,7 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
         ${true}      | ${Roles.Manager}     | ${'Take Now for Manager'}
         ${true}      | ${Roles.SuperAdmin}  | ${'Take Now for SuperAdmin'}
         ${true}      | ${Roles.Owner}       | ${'Take Now for Owner'}
-        ${true}      | ${Roles.Coordinator} | ${'Take Now for Coordinator'}
+        ${false}     | ${Roles.Coordinator} | ${'Take Now for Coordinator'}
         ${false}     | ${Roles.Editor}      | ${'Take Now for Editor'}
         ${false}     | ${Roles.Respondent}  | ${'Take Now for Respondent'}
         ${false}     | ${Roles.Reviewer}    | ${'Take Now for Reviewer'}


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-6348](https://mindlogger.atlassian.net/browse/M2-6348)

This is a one-liner to remove `Coordinator` from the list of roles with access to the Take Now menu item in the activity context menu. Other roles remain unaffected

### 📸 Screenshots

| Before                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| <img width="307" alt="image" src="https://github.com/ChildMindInstitute/mindlogger-admin/assets/14842108/17434327-cfc9-4098-b372-2ff79fbce6db"> | <img width="307" alt="image" src="https://github.com/ChildMindInstitute/mindlogger-admin/assets/14842108/9a4020dc-64d3-48f3-8ebf-4b981c6f098f"> |

### 🪤 Peer Testing

#### Pre-requisites:
- A workspace with an applet having a coordinator
- At least one activity

#### Steps

- Log in as the coordinator user
- Switch to the workspace where you are a coordinator
- Navigate to Dashboard > Applet > Activities tab
- Access the context menu for an activity
- Confirm that the take now menu item is not present

### ✏️ Notes

This does not prevent a coordinator from initiating take now using a manually constructed URL. That scenario is handled in the [respondent web app](https://github.com/ChildMindInstitute/mindlogger-web-refactor/pull/438)
