### PR TITLE
[M2-6472] Hide CTA's not intended for R1

### DIFF
--- a/src/modules/Dashboard/components/ActivityGrid/ActivityGrid.tsx
+++ b/src/modules/Dashboard/components/ActivityGrid/ActivityGrid.tsx
@@ -6,6 +6,7 @@ import { ButtonWithMenu, EmptyState, Spinner, Svg } from 'shared/components';
 import { StyledBody, StyledFlexTopCenter, StyledFlexWrap } from 'shared/styles';
 import { page } from 'resources';
 import { ActivitySummaryCard } from 'modules/Dashboard/components';
+import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 
 import { StyledButton } from './ActivityGrid.styles';
 import { ActivityGridProps } from './ActivityGrid.types';
@@ -19,6 +20,7 @@ export const ActivityGrid = ({
   const navigate = useNavigate();
   const { t } = useTranslation('app');
   const { appletId } = useParams();
+  const { featureFlags } = useFeatureFlags();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
   const isEmpty = !rows?.length && !isLoading;
@@ -36,49 +38,53 @@ export const ActivityGrid = ({
       <StyledFlexWrap sx={{ gap: 1.2, mb: 2.4 }}>
         {appletId && (
           <>
-            <StyledFlexTopCenter sx={{ gap: 1.2 }}>
-              <StyledButton
-                variant="outlined"
-                startIcon={<Svg width={18} height={18} id="slider-rows" />}
-                // TODO: Implement filters
-                // https://mindlogger.atlassian.net/browse/M2-5530
-                onClick={() => alert('TODO: filters')}
-                data-testid={`${dataTestId}-filters`}
-              >
-                {t('filters')}
-              </StyledButton>
+            {featureFlags.enableActivityFilterSort && (
+              <StyledFlexTopCenter sx={{ gap: 1.2 }}>
+                <StyledButton
+                  variant="outlined"
+                  startIcon={<Svg width={18} height={18} id="slider-rows" />}
+                  // TODO: Implement filters
+                  // https://mindlogger.atlassian.net/browse/M2-5530
+                  onClick={() => alert('TODO: filters')}
+                  data-testid={`${dataTestId}-filters`}
+                >
+                  {t('filters')}
+                </StyledButton>
 
-              <ButtonWithMenu
-                variant="outlined"
-                label={t('sortBy')}
-                anchorEl={anchorEl}
-                setAnchorEl={setAnchorEl}
-                // TODO: Implement sorting
-                // https://mindlogger.atlassian.net/browse/M2-5445
-                menuItems={[
-                  {
-                    title: 'TODO: Sort options',
-                    action: () => alert('TODO: Sort options'),
-                  },
-                ]}
-                startIcon={<></>}
-                data-testid={`${dataTestId}-sort-by`}
-              />
-            </StyledFlexTopCenter>
+                <ButtonWithMenu
+                  variant="outlined"
+                  label={t('sortBy')}
+                  anchorEl={anchorEl}
+                  setAnchorEl={setAnchorEl}
+                  // TODO: Implement sorting
+                  // https://mindlogger.atlassian.net/browse/M2-5445
+                  menuItems={[
+                    {
+                      title: 'TODO: Sort options',
+                      action: () => alert('TODO: Sort options'),
+                    },
+                  ]}
+                  startIcon={<></>}
+                  data-testid={`${dataTestId}-sort-by`}
+                />
+              </StyledFlexTopCenter>
+            )}
 
             <StyledFlexWrap sx={{ gap: 1.2, ml: 'auto' }}>
-              <StyledButton
-                // TODO: Replace with missing `tonal` button variant as shown in Figma
-                // https://mindlogger.atlassian.net/browse/M2-6071
-                variant="outlined"
-                // TODO: Implement assign
-                // https://mindlogger.atlassian.net/browse/M2-5710
-                onClick={() => alert('TODO: Assign activity')}
-                data-testid={`${dataTestId}-assign`}
-                sx={{ minWidth: '10rem' }}
-              >
-                {t('assign')}
-              </StyledButton>
+              {featureFlags.enableActivityAssign && (
+                <StyledButton
+                  // TODO: Replace with missing `tonal` button variant as shown in Figma
+                  // https://mindlogger.atlassian.net/browse/M2-6071
+                  variant="outlined"
+                  // TODO: Implement assign
+                  // https://mindlogger.atlassian.net/browse/M2-5710
+                  onClick={() => alert('TODO: Assign activity')}
+                  data-testid={`${dataTestId}-assign`}
+                  sx={{ minWidth: '10rem' }}
+                >
+                  {t('assign')}
+                </StyledButton>
+              )}
 
               <StyledButton
                 variant="contained"

--- a/src/modules/Dashboard/components/ActivityGrid/ActivityGrid.utils.test.ts
+++ b/src/modules/Dashboard/components/ActivityGrid/ActivityGrid.utils.test.ts
@@ -76,6 +76,8 @@ describe('getActivityActions', () => {
     featureFlags: {
       enableMultiInformant: true,
       enableMultiInformantTakeNow: true,
+      enableActivityAssign: true,
+      enableActivityFilterSort: true,
     },
     hasParticipants: true,
   };
@@ -199,5 +201,22 @@ describe('getActivityActions', () => {
     expectMenuItemIsDisplayed(menuItems, 'exportData', true);
     expectMenuItemIsDisplayed(menuItems, 'assignActivity', true);
     expectMenuItemIsDisplayed(menuItems, 'takeNow', false);
+  });
+
+  test('Assign Activity menu item is not displayed when feature flag is disabled', () => {
+    const menuItems = getActivityActions({
+      ...defaultArgs,
+      roles: [Roles.Manager],
+      featureFlags: {
+        ...defaultArgs.featureFlags,
+        enableActivityAssign: false,
+      },
+    });
+
+    expectAllMenuItemsAreReturned(menuItems);
+    expectMenuItemIsDisplayed(menuItems, 'editActivity', true);
+    expectMenuItemIsDisplayed(menuItems, 'exportData', true);
+    expectMenuItemIsDisplayed(menuItems, 'assignActivity', false);
+    expectMenuItemIsDisplayed(menuItems, 'takeNow', true);
   });
 });

--- a/src/modules/Dashboard/components/ActivityGrid/ActivityGrid.utils.tsx
+++ b/src/modules/Dashboard/components/ActivityGrid/ActivityGrid.utils.tsx
@@ -28,6 +28,10 @@ export const getActivityActions = ({
       roles?.includes(Roles.Coordinator) ||
       roles?.includes(Roles.SuperAdmin));
 
+  const canAssignActivity = featureFlags.enableActivityAssign;
+
+  const showDivider = canDoTakeNow || canAssignActivity;
+
   return [
     {
       icon: <Svg id="edit" />,
@@ -45,13 +49,13 @@ export const getActivityActions = ({
       isDisplayed: true,
       'data-testid': `${dataTestId}-activity-export`,
     },
-    { type: MenuItemType.Divider },
+    { type: MenuItemType.Divider, isDisplayed: showDivider },
     {
       icon: <Svg id="add" />,
       action: assignActivity,
       title: t('assignActivity'),
       context: { appletId, activityId },
-      isDisplayed: true,
+      isDisplayed: canAssignActivity,
       'data-testid': `${dataTestId}-activity-assign`,
     },
     {

--- a/src/modules/Dashboard/pages/ParticipantDetails/ParticipantDetails.hooks.tsx
+++ b/src/modules/Dashboard/pages/ParticipantDetails/ParticipantDetails.hooks.tsx
@@ -2,9 +2,12 @@ import { generatePath, useParams } from 'react-router-dom';
 
 import { page } from 'resources';
 import { Svg } from 'shared/components';
+import { Tab } from 'shared/components/Tabs/Tabs.types';
+import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 
 export const useParticipantDetailsTabs = () => {
   const { appletId, subjectId } = useParams();
+  const { featureFlags } = useFeatureFlags();
 
   return [
     {
@@ -18,17 +21,19 @@ export const useParticipantDetailsTabs = () => {
       }),
       'data-testid': 'participant-activities',
     },
-    {
-      labelKey: 'connections',
-      id: 'participant-connections',
-      icon: <Svg id="respondent-circle" />,
-      activeIcon: <Svg id="respondent-circle-filled" />,
-      path: generatePath(page.appletParticipantConnections, {
-        appletId,
-        subjectId,
-      }),
-      'data-testid': 'participant-connections',
-    },
+    featureFlags.enableParticipantConnections
+      ? {
+          labelKey: 'connections',
+          id: 'participant-connections',
+          icon: <Svg id="respondent-circle" />,
+          activeIcon: <Svg id="respondent-circle-filled" />,
+          path: generatePath(page.appletParticipantConnections, {
+            appletId,
+            subjectId,
+          }),
+          'data-testid': 'participant-connections',
+        }
+      : undefined,
     {
       labelKey: 'schedule',
       id: 'participant-schedule',
@@ -40,5 +45,5 @@ export const useParticipantDetailsTabs = () => {
       }),
       'data-testid': 'participant-schedule',
     },
-  ];
+  ].filter(Boolean) as Tab[];
 };

--- a/src/shared/hooks/useFeatureFlags.ts
+++ b/src/shared/hooks/useFeatureFlags.ts
@@ -1,4 +1,4 @@
-import { useFlags, useLDClient } from 'launchdarkly-react-client-sdk';
+import { useFlags } from 'launchdarkly-react-client-sdk';
 
 import { FeatureFlags, FeatureFlagsKeys } from 'shared/types/featureFlags';
 
@@ -6,18 +6,7 @@ import { FeatureFlags, FeatureFlagsKeys } from 'shared/types/featureFlags';
  * Internal wrapper for LaunchDarkly's hooks and flags.
  */
 export const useFeatureFlags = () => {
-  const ldClient = useLDClient();
   const flags = useFlags();
-
-  /**
-   * Resets the active context back to an anonymous user account.
-   */
-  const resetLDContext = () => {
-    ldClient?.identify({
-      kind: 'user',
-      anonymous: true,
-    });
-  };
 
   const featureFlags = () => {
     const keys = Object.keys(FeatureFlagsKeys) as (keyof typeof FeatureFlagsKeys)[];
@@ -27,5 +16,5 @@ export const useFeatureFlags = () => {
     return features;
   };
 
-  return { resetLDContext, featureFlags: featureFlags() };
+  return { featureFlags: featureFlags() };
 };

--- a/src/shared/types/featureFlags.ts
+++ b/src/shared/types/featureFlags.ts
@@ -9,6 +9,8 @@ export const FeatureFlagsKeys = {
   enableActivityFilterSort: 'enableActivityFilterSort',
   // TODO: https://mindlogger.atlassian.net/browse/M2-6518 Assign Activity flag cleanup
   enableActivityAssign: 'enableActivityAssign',
+  // TODO: https://mindlogger.atlassian.net/browse/M2-6523 Participant Connections flag cleanup
+  enableParticipantConnections: 'enableParticipantConnections',
 };
 
 export type FeatureFlags = Partial<Record<keyof typeof FeatureFlagsKeys, LDFlagValue>>;

--- a/src/shared/types/featureFlags.ts
+++ b/src/shared/types/featureFlags.ts
@@ -5,6 +5,10 @@ import { LDFlagValue } from 'launchdarkly-react-client-sdk';
 export const FeatureFlagsKeys = {
   enableMultiInformant: 'enableMultiInformant',
   enableMultiInformantTakeNow: 'enableMultiInformantTakeNow',
+  // TODO: M2-6519 Activity Filter Sort flag cleanup
+  enableActivityFilterSort: 'enableActivityFilterSort',
+  // TODO: M2-6518 Assign Activity flag cleanup
+  enableActivityAssign: 'enableActivityAssign',
 };
 
 export type FeatureFlags = Partial<Record<keyof typeof FeatureFlagsKeys, LDFlagValue>>;

--- a/src/shared/types/featureFlags.ts
+++ b/src/shared/types/featureFlags.ts
@@ -7,7 +7,7 @@ export const FeatureFlagsKeys = {
   enableMultiInformantTakeNow: 'enableMultiInformantTakeNow',
   // TODO: https://mindlogger.atlassian.net/browse/M2-6519 Activity Filter Sort flag cleanup
   enableActivityFilterSort: 'enableActivityFilterSort',
-  // TODO: M2-6518 Assign Activity flag cleanup
+  // TODO: https://mindlogger.atlassian.net/browse/M2-6518 Assign Activity flag cleanup
   enableActivityAssign: 'enableActivityAssign',
 };
 

--- a/src/shared/types/featureFlags.ts
+++ b/src/shared/types/featureFlags.ts
@@ -5,7 +5,7 @@ import { LDFlagValue } from 'launchdarkly-react-client-sdk';
 export const FeatureFlagsKeys = {
   enableMultiInformant: 'enableMultiInformant',
   enableMultiInformantTakeNow: 'enableMultiInformantTakeNow',
-  // TODO: M2-6519 Activity Filter Sort flag cleanup
+  // TODO: https://mindlogger.atlassian.net/browse/M2-6519 Activity Filter Sort flag cleanup
   enableActivityFilterSort: 'enableActivityFilterSort',
   // TODO: M2-6518 Assign Activity flag cleanup
   enableActivityAssign: 'enableActivityAssign',


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-6472](https://mindlogger.atlassian.net/browse/M2-6472)
🔗 [Jira Ticket M2-6496](https://mindlogger.atlassian.net/browse/M2-6496)

Changes include:

- Added `enableActivityFilterSort` feature flag
- Added `enableActivityAssign` feature flag
- Added `enableParticipantConnections` feature flag
- Removed unused `resetLDContext` missing from M2-6462

### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| ![CleanShot 2024-05-03 at 11 49 49](https://github.com/ChildMindInstitute/mindlogger-admin/assets/2916156/a263ec03-a0ca-435b-aa12-de95d45d2218) | ![CleanShot 2024-05-03 at 11 49 30](https://github.com/ChildMindInstitute/mindlogger-admin/assets/2916156/54451330-b2fc-435e-ba66-d25414c413c4) |

### 🪤 Peer Testing

> [!NOTE]
> These new feature flags will be **`True`** for the `DEV` environment to allow for continued development, make sure to manually disable the flag or change environments to test functionality.

- Navigate to the activities overview, the Filters, Sort and Add Activity items should be displayed. 
- Navigate to a Participants Details page and use the overflow menu, the "Assign Activity" menu item should be visible.
- Update `.env` with `REACT_APP_LAUNCHDARKLY_CLIENT_ID` to use the `TEST` or `PROD` ID (Check [Confluence](https://mindlogger.atlassian.net/wiki/spaces/MINDLOGGER1/pages/487227432/Using+LaunchDarkly+with+MindLogger#Keys) for IDs).
- Restart the app
- Navigate to the activities overview and observe the missing elements.
