### PR TITLE
fix: Update button variants (M2-6071)

### DIFF
--- a/src/modules/Dashboard/features/Applet/Activities/ActivitiesToolbar/ActivitiesToolbar.tsx
+++ b/src/modules/Dashboard/features/Applet/Activities/ActivitiesToolbar/ActivitiesToolbar.tsx
@@ -68,9 +68,7 @@ export const ActivitiesToolbar = ({
                   alert('TODO: Assign activity');
                 }}
                 sx={{ minWidth: theme.spacing(10) }}
-                // TODO: Replace with missing `tonal` button variant as shown in Figma
-                // https://mindlogger.atlassian.net/browse/M2-6071
-                variant="outlined"
+                variant="tonal"
               >
                 {t('assign')}
               </Button>

--- a/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.tsx
@@ -214,10 +214,8 @@ export const AddParticipantPopup = ({
           buttonText={t(isFullAccount ? 'sendInvitation' : 'create')}
           disabledSubmit={!isValid}
           hasSecondBtn
-          // TODO: Update second button variant once 'tonal' variant added
-          // https://mindlogger.atlassian.net/browse/M2-6071
           secondBtnText={t('Reset')}
-          secondBtnVariant="outlined"
+          secondBtnVariant="tonal"
           onSecondBtnSubmit={resetForm}
           disabledSecondBtn={!isDirty}
           hasLeftBtn

--- a/src/modules/Dashboard/features/Applet/Popups/UpgradeAccountPopup/UpgradeAccountPopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/UpgradeAccountPopup/UpgradeAccountPopup.tsx
@@ -119,9 +119,7 @@ export const UpgradeAccountPopup = ({
       disabledSubmit={!isValid}
       hasLeftBtn
       leftBtnText={t('Reset')}
-      // TODO: Update left button variant once 'tonal' variant added
-      // https://mindlogger.atlassian.net/browse/M2-6071
-      leftBtnVariant="outlined"
+      leftBtnVariant="tonal"
       onLeftBtnSubmit={resetForm}
       disabledLeftBtn={!isDirty}
       data-testid={`${dataTestid}-account-form`}

--- a/src/modules/Dashboard/features/Managers/Popups/AddManagerPopup/AddManagerPopup.tsx
+++ b/src/modules/Dashboard/features/Managers/Popups/AddManagerPopup/AddManagerPopup.tsx
@@ -194,9 +194,7 @@ export const AddManagerPopup = ({
       disabledSubmit={!isValid}
       hasLeftBtn
       leftBtnText={t('Reset')}
-      // TODO: Update second button variant once 'tonal' variant added
-      // https://mindlogger.atlassian.net/browse/M2-6071
-      leftBtnVariant="outlined"
+      leftBtnVariant="tonal"
       onLeftBtnSubmit={resetForm}
       disabledLeftBtn={!isDirty}
       data-testid={`${dataTestid}-add-manager-popup`}

--- a/src/modules/Dashboard/features/Participant/Activities/Activities.test.tsx
+++ b/src/modules/Dashboard/features/Participant/Activities/Activities.test.tsx
@@ -140,21 +140,6 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
     });
   });
 
-  test('click Add Activity should navigate to Builder > Applet > Activities', async () => {
-    mockGetRequestResponses({
-      [getAppletUrl]: successfulGetAppletMock,
-      [getAppletActivitiesUrl]: successfulEmptyGetAppletActivitiesMock,
-      [getWorkspaceRespondentsUrl]: successfulEmptyHttpResponseMock,
-    });
-    renderWithProviders(<Activities />, { route, routePath, preloadedState });
-
-    const addActivityLink = screen.getByTestId(`${testId}-add-activity`);
-    expect(addActivityLink).toHaveAttribute(
-      'href',
-      generatePath(page.builderAppletActivities, { appletId: mockedAppletId }),
-    );
-  });
-
   describe('should show or hide edit ability depending on role', () => {
     test.each`
       canEdit  | role                 | description

--- a/src/modules/Dashboard/features/Participant/Activities/Activities.tsx
+++ b/src/modules/Dashboard/features/Participant/Activities/Activities.tsx
@@ -12,11 +12,12 @@ import {
 import { MenuActionProps, Spinner } from 'shared/components';
 import { FlowGrid } from 'modules/Dashboard/components/FlowGrid';
 import { OpenTakeNowModalOptions } from 'modules/Dashboard/components/TakeNowModal/TakeNowModal.types';
-import { ActivitiesToolbar } from 'modules/Dashboard/features/Applet/Activities/ActivitiesToolbar';
 import { ActivitiesSectionHeader } from 'modules/Dashboard/features/Applet/Activities/ActivitiesSectionHeader';
 import { users } from 'modules/Dashboard/state';
 import { Activity, ActivityFlow } from 'redux/modules';
 import { StyledFlexColumn } from 'shared/styles';
+
+import { ParticipantActivitiesToolbar } from './ParticipantActivitiesToolbar';
 
 const dataTestId = 'dashboard-applet-participant-activities';
 
@@ -102,7 +103,11 @@ export const Activities = () => {
     <StyledFlexColumn sx={{ gap: 2.4, maxHeight: '100%' }}>
       {isLoading && <Spinner />}
 
-      <ActivitiesToolbar appletId={appletId} data-testid={dataTestId} sx={{ px: 3.2, pt: 3.2 }} />
+      <ParticipantActivitiesToolbar
+        appletId={appletId}
+        data-testid={dataTestId}
+        sx={{ px: 3.2, pt: 3.2 }}
+      />
 
       {showContent && (
         <StyledFlexColumn sx={{ gap: 4.8, overflow: 'auto', p: 3.2 }}>

--- a/src/modules/Dashboard/features/Participant/Activities/ParticipantActivitiesToolbar/ParticipantActivitiesToolbar.tsx
+++ b/src/modules/Dashboard/features/Participant/Activities/ParticipantActivitiesToolbar/ParticipantActivitiesToolbar.tsx
@@ -1,0 +1,86 @@
+import { useState } from 'react';
+import { Button } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+
+import { ButtonWithMenu, Search, Svg } from 'shared/components';
+import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
+import { StyledFlexTopCenter, StyledFlexWrap, theme } from 'shared/styles';
+
+import { ParticipantActivitiesToolbarProps } from './ParticipantActivitiesToolbar.types';
+
+export const ParticipantActivitiesToolbar = ({
+  appletId,
+  'data-testid': dataTestId,
+  sx,
+  ...otherProps
+}: ParticipantActivitiesToolbarProps) => {
+  const { t } = useTranslation('app');
+  const { featureFlags } = useFeatureFlags();
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+
+  return (
+    <StyledFlexWrap sx={{ gap: 1.2, placeContent: 'space-between', ...sx }} {...otherProps}>
+      {appletId && (
+        <>
+          {featureFlags.enableActivityFilterSort && (
+            <StyledFlexTopCenter sx={{ gap: 1.2 }}>
+              <Button
+                data-testid={`${dataTestId}-filters`}
+                onClick={() => {
+                  // TODO: Implement filters
+                  // https://mindlogger.atlassian.net/browse/M2-5530
+                  alert('TODO: filters');
+                }}
+                startIcon={<Svg width={18} height={18} id="slider-rows" />}
+                variant="outlined"
+              >
+                {t('filters')}
+              </Button>
+
+              <ButtonWithMenu
+                anchorEl={anchorEl}
+                data-testid={`${dataTestId}-sort-by`}
+                label={t('sortBy')}
+                // TODO: Implement sorting
+                // https://mindlogger.atlassian.net/browse/M2-5445
+                menuItems={[
+                  {
+                    title: 'TODO: Sort options',
+                    action: () => {},
+                  },
+                ]}
+                setAnchorEl={setAnchorEl}
+                startIcon={<></>}
+                variant="outlined"
+              />
+            </StyledFlexTopCenter>
+          )}
+
+          <StyledFlexWrap sx={{ gap: 1.2 }}>
+            <Search
+              data-testid={`${dataTestId}-search`}
+              placeholder={t('searchActivities')}
+              sx={{ width: '32rem' }}
+              withDebounce
+            />
+
+            {featureFlags.enableActivityAssign && (
+              <Button
+                data-testid={`${dataTestId}-assign`}
+                onClick={() => {
+                  // TODO: Implement assign
+                  // https://mindlogger.atlassian.net/browse/M2-5710
+                  alert('TODO: Assign activity');
+                }}
+                sx={{ minWidth: theme.spacing(10) }}
+                variant="contained"
+              >
+                {t('assignActivity')}
+              </Button>
+            )}
+          </StyledFlexWrap>
+        </>
+      )}
+    </StyledFlexWrap>
+  );
+};

--- a/src/modules/Dashboard/features/Participant/Activities/ParticipantActivitiesToolbar/ParticipantActivitiesToolbar.types.ts
+++ b/src/modules/Dashboard/features/Participant/Activities/ParticipantActivitiesToolbar/ParticipantActivitiesToolbar.types.ts
@@ -1,0 +1,6 @@
+import { BoxProps } from '@mui/material';
+
+export interface ParticipantActivitiesToolbarProps extends BoxProps {
+  appletId?: string;
+  'data-testid'?: string;
+}

--- a/src/modules/Dashboard/features/Participant/Activities/ParticipantActivitiesToolbar/index.ts
+++ b/src/modules/Dashboard/features/Participant/Activities/ParticipantActivitiesToolbar/index.ts
@@ -1,0 +1,1 @@
+export { ParticipantActivitiesToolbar } from './ParticipantActivitiesToolbar';

--- a/src/modules/Dashboard/features/Participants/Participants.styles.ts
+++ b/src/modules/Dashboard/features/Participants/Participants.styles.ts
@@ -1,27 +1,10 @@
 import { Button, styled } from '@mui/material';
 
 import { DashboardTable } from 'modules/Dashboard/components';
-import { variables } from 'shared/styles/variables';
 
 import { ParticipantsColumnsWidth } from './Participants.const';
 
-export const StyledButton = styled(Button)`
-  && {
-    svg {
-      fill: ${variables.palette.on_surface_variant};
-    }
-  }
-`;
-
-export const FiltersButton = styled(StyledButton)`
-  color: ${variables.palette.on_surface_variant};
-`;
-
-export const SortByButton = styled(StyledButton)`
-  color: ${variables.palette.on_surface_variant};
-`;
-
-export const AddParticipantButton = styled(StyledButton)`
+export const AddParticipantButton = styled(Button)`
   min-width: 15.3rem;
 `;
 

--- a/src/modules/Dashboard/features/Participants/Participants.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.tsx
@@ -1,10 +1,12 @@
 import { useMemo, useState } from 'react';
+import { Button } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { generatePath, useNavigate, useParams } from 'react-router-dom';
 
 import { EmptyDashboardTable } from 'modules/Dashboard/components/EmptyDashboardTable';
 import {
   ActionsMenu,
+  ButtonWithMenu,
   Chip,
   MenuActionProps,
   Pin,
@@ -21,17 +23,11 @@ import { getDateInUserTimezone, isManagerOrOwner, joinWihComma, Mixpanel } from 
 import { DEFAULT_ROWS_PER_PAGE, Roles } from 'shared/consts';
 import { StyledBody, StyledFlexTopCenter, StyledFlexWrap } from 'shared/styles';
 import { Respondent, RespondentStatus } from 'modules/Dashboard/types';
-import { StyledIcon } from 'shared/components/Search/Search.styles';
 import { StyledMaybeEmpty } from 'shared/styles/styledComponents/MaybeEmpty';
 import { AddParticipantPopup, UpgradeAccountPopup } from 'modules/Dashboard/features/Applet/Popups';
 import { ParticipantSnippetInfo } from 'modules/Dashboard/components';
 
-import {
-  AddParticipantButton,
-  FiltersButton,
-  SortByButton,
-  ParticipantsTable,
-} from './Participants.styles';
+import { AddParticipantButton, ParticipantsTable } from './Participants.styles';
 import {
   getAppletsSmallTableRows,
   getHeadCells,
@@ -104,6 +100,7 @@ export const Participants = () => {
     return getWorkspaceRespondents(params);
   });
 
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [addParticipantPopupVisible, setAddParticipantPopupVisible] = useState(false);
   const [dataExportPopupVisible, setDataExportPopupVisible] = useState(false);
   const [removeAccessPopupVisible, setRemoveAccessPopupVisible] = useState(false);
@@ -416,27 +413,18 @@ export const Participants = () => {
 
       <StyledFlexWrap sx={{ gap: 1.2, mb: 2.4 }}>
         <StyledFlexTopCenter sx={{ gap: 1.2 }}>
-          <FiltersButton
-            variant="outlined"
-            startIcon={
-              <StyledIcon>
-                <Svg id="slider-rows" height="24" width="24" />
-              </StyledIcon>
-            }
-          >
+          <Button variant="outlined" startIcon={<Svg id="slider-rows" height={18} width={18} />}>
             {t('filters')}
-          </FiltersButton>
+          </Button>
 
-          <SortByButton
+          <ButtonWithMenu
+            anchorEl={anchorEl}
+            label={t('sortBy')}
+            menuItems={[]}
+            setAnchorEl={setAnchorEl}
+            startIcon={<></>}
             variant="outlined"
-            endIcon={
-              <StyledIcon>
-                <Svg id="dropdown-down-outlined" height="24" width="24" />
-              </StyledIcon>
-            }
-          >
-            {t('sortBy')}
-          </SortByButton>
+          />
         </StyledFlexTopCenter>
 
         <StyledFlexWrap sx={{ gap: 1.2, ml: 'auto' }}>

--- a/src/shared/components/ButtonWithMenu/ButtonWithMenu.tsx
+++ b/src/shared/components/ButtonWithMenu/ButtonWithMenu.tsx
@@ -1,12 +1,11 @@
 import { MouseEvent } from 'react';
+import { Button } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 
 import { Tooltip } from 'shared/components/Tooltip';
 import { Svg } from 'shared/components/Svg';
 import { Menu } from 'shared/components/Menu';
-import { variables } from 'shared/styles';
 
-import { StyledButton } from './ButtonWithMenu.styles';
 import { ButtonWithMenuProps } from './ButtonWithMenu.types';
 
 export const ButtonWithMenu = ({
@@ -33,11 +32,7 @@ export const ButtonWithMenu = ({
     <>
       <Tooltip tooltipTitle={tooltip || null}>
         <span>
-          <StyledButton
-            sx={{
-              backgroundColor:
-                openMenu && variant === 'outlined' ? variables.palette.primary_alfa12 : 'inherit',
-            }}
+          <Button
             disabled={disabled}
             variant={variant}
             aria-haspopup="true"
@@ -48,7 +43,7 @@ export const ButtonWithMenu = ({
             data-testid={dataTestid}
           >
             {t(label)}
-          </StyledButton>
+          </Button>
         </span>
       </Tooltip>
       <Menu

--- a/src/shared/styles/theme.tsx
+++ b/src/shared/styles/theme.tsx
@@ -208,81 +208,189 @@ export const theme = createTheme({
       },
     },
     MuiButton: {
-      styleOverrides: {
-        root: {
-          lineHeight: variables.font.lineHeight.md,
-          padding: '1rem 2rem',
-          minWidth: '10rem',
-          borderRadius: variables.borderRadius.xxxl,
-          textTransform: 'none',
-          height: '4.8rem',
-          letterSpacing: variables.font.letterSpacing.sm,
-          boxShadow: 'unset',
-          '&.Mui-disabled': {
-            '& svg': {
-              fill: variables.palette.disabled,
+      defaultProps: { variant: 'textNeutral' },
+      variants: [
+        {
+          props: { variant: 'contained' },
+          style: {
+            color: variables.palette.white,
+            fontWeight: variables.font.weight.bold,
+
+            '&.Mui-disabled': {
+              backgroundColor: variables.palette.on_surface_alfa12,
+              color: variables.palette.disabled,
+            },
+
+            '&:not(.Mui-disabled)': {
+              '&:hover': {
+                boxShadow: variables.boxShadow.buttonElevation1,
+              },
+
+              '&:active': {
+                boxShadow: 'none',
+              },
+
+              '&:focus, &:active': {},
             },
           },
-          '&.MuiButton-contained': {
-            fontWeight: variables.font.weight.bold,
-            '& svg': {
-              fill: variables.palette.white,
-            },
-            '&:hover': {
-              backgroundColor: blendColorsNormal(
-                variables.palette.primary,
-                variables.palette.light_alfa8,
-              ),
-              boxShadow: 'unset',
-            },
-            ...Object.assign(
-              {},
-              ...['&:focus', '&:active', '&:visited'].map((item) => ({
-                [item]: {
-                  backgroundColor: variables.palette.contained_btn_focus,
-                  boxShadow: 'unset',
-                },
-              })),
-            ),
+        },
+        {
+          props: { variant: 'outlined' },
+          style: {
+            background: variables.palette.white,
+            border: `1px solid ${variables.palette.outline}`,
+            color: variables.palette.primary,
+            fontWeight: variables.font.weight.regular,
+
             '&.Mui-disabled': {
               color: variables.palette.disabled,
-              backgroundColor: variables.palette.on_surface_alfa12,
-              '& svg': {
-                fill: variables.palette.disabled,
+              borderColor: variables.palette.outline_alfa12,
+            },
+
+            '&:not(.Mui-disabled)': {
+              '&:hover': {
+                backgroundColor: variables.palette.primary_alfa8,
+                borderColor: variables.palette.outline,
+              },
+
+              '&:focus': {
+                borderColor: 'currentColor',
+              },
+
+              '&:focus, &:active': {
+                backgroundColor: variables.palette.primary_alfa12,
               },
             },
           },
-          '&.MuiButton-outlined': {
+        },
+        {
+          props: { variant: 'text' },
+          style: {
+            background: 'transparent',
+            color: variables.palette.primary,
             fontWeight: variables.font.weight.regular,
-            borderColor: variables.palette.outline,
-            '& svg': {
-              fill: variables.palette.primary,
-            },
-            '&:hover': {
-              backgroundColor: variables.palette.primary_alfa8,
-            },
-            '&.MuiButton-outlinedError': {
-              '& svg': {
-                fill: variables.palette.semantic.error,
-              },
-            },
+
             '&.Mui-disabled': {
-              color: variables.palette.on_surface_alfa38,
-              backgroundColor: 'transparent',
-              borderColor: variables.palette.on_surface_alfa12,
-              '& svg': {
-                fill: variables.palette.disabled,
+              color: variables.palette.disabled,
+            },
+
+            '&:not(.Mui-disabled)': {
+              '&:hover': {
+                backgroundColor: variables.palette.primary_alfa8,
+                borderColor: variables.palette.outline,
+              },
+
+              '&:focus': {
+                borderColor: 'currentColor',
+              },
+
+              '&:focus, &:active': {
+                backgroundColor: variables.palette.primary_alfa12,
               },
             },
           },
-          '&.MuiButton-text': {
-            '&:hover': {
-              backgroundColor: variables.palette.primary_alfa8,
-            },
+        },
+        {
+          props: { variant: 'elevated' },
+          style: {
+            background: variables.palette.surface1,
+            color: variables.palette.primary,
+            fontWeight: variables.font.weight.bold,
+            boxShadow: variables.boxShadow.buttonElevation1,
+
             '&.Mui-disabled': {
-              color: variables.palette.on_surface_alfa38,
-              backgroundColor: 'transparent',
+              backgroundColor: variables.palette.on_surface_alfa12,
+              color: variables.palette.disabled,
             },
+
+            '&:not(.Mui-disabled)': {
+              '&:hover': {
+                backgroundColor: variables.palette.surface2,
+                boxShadow: variables.boxShadow.buttonElevation2,
+              },
+
+              '&:focus, &:active': {
+                backgroundColor: blendColorsNormal(
+                  variables.palette.surface1,
+                  variables.palette.light_alfa12,
+                ),
+                boxShadow: variables.boxShadow.buttonElevation1,
+              },
+            },
+          },
+        },
+        {
+          props: { variant: 'tonal' },
+          style: {
+            background: variables.palette.secondary_container,
+            color: variables.palette.on_secondary_container,
+            fontWeight: variables.font.weight.regular,
+
+            '&.Mui-disabled': {
+              backgroundColor: variables.palette.on_surface_alfa12,
+              color: variables.palette.disabled,
+            },
+
+            '&:not(.Mui-disabled)': {
+              '&:hover': {
+                backgroundColor: blendColorsNormal(
+                  variables.palette.secondary_container,
+                  variables.palette.on_secondary_container_alfa8,
+                ),
+                boxShadow: variables.boxShadow.buttonElevation1,
+              },
+
+              '&:active': {
+                boxShadow: 'none',
+              },
+
+              '&:focus, &:active': {
+                backgroundColor: blendColorsNormal(
+                  variables.palette.secondary_container,
+                  variables.palette.on_secondary_container_alfa12,
+                ),
+              },
+            },
+          },
+        },
+        {
+          props: { variant: 'textNeutral' },
+          style: {
+            background: 'transparent',
+            color: variables.palette.on_surface_variant,
+            fontWeight: variables.font.weight.regular,
+
+            '&.Mui-disabled': {
+              color: variables.palette.disabled,
+            },
+
+            '&:not(.Mui-disabled)': {
+              '&:hover': {
+                backgroundColor: variables.palette.on_surface_variant_alfa8,
+              },
+
+              '&:focus, &:active': {
+                backgroundColor: variables.palette.on_surface_variant_alfa12,
+              },
+            },
+          },
+        },
+      ],
+      styleOverrides: {
+        root: {
+          border: 'none',
+          borderRadius: variables.borderRadius.xxxl,
+          boxShadow: 'none',
+          fontSize: variables.font.size.md,
+          height: '4.8rem',
+          letterSpacing: variables.font.letterSpacing.sm,
+          lineHeight: variables.font.lineHeight.md,
+          minWidth: '10rem',
+          padding: '1rem 2rem',
+          textTransform: 'none',
+
+          '& svg': {
+            fill: 'currentColor',
           },
         },
       },
@@ -634,6 +742,8 @@ export const theme = createTheme({
     },
     primary: {
       main: variables.palette.primary,
+      dark: blendColorsNormal(variables.palette.primary, variables.palette.light_alfa8),
+      light: blendColorsNormal(variables.palette.primary, variables.palette.light_alfa12),
     },
     info: {
       main: variables.palette.blue,
@@ -645,9 +755,19 @@ export const theme = createTheme({
       main: variables.palette.yellow,
     },
     error: {
-      main: variables.palette.semantic.error,
+      main: variables.palette.red,
+      dark: blendColorsNormal(variables.palette.red, variables.palette.light_alfa8),
+      light: blendColorsNormal(variables.palette.red, variables.palette.light_alfa12),
     },
   },
 });
+
+declare module '@mui/material/Button' {
+  interface ButtonPropsVariantOverrides {
+    elevated: true;
+    tonal: true;
+    textNeutral: true;
+  }
+}
 
 export default theme;

--- a/src/shared/styles/variables/index.ts
+++ b/src/shared/styles/variables/index.ts
@@ -28,6 +28,8 @@ export const variables = {
     disabled: 0.38,
   },
   boxShadow: {
+    buttonElevation1: '0px 1px 3px rgba(0, 0, 0, 0.12), 0px 1px 2px rgba(0, 0, 0, 0.24)',
+    buttonElevation2: '0px 3px 6px rgba(0, 0, 0, 0.16), 0px 3px 6px rgba(0, 0, 0, 0.23)',
     light0: '0 1px 2px rgba(0, 0, 0, 0.05), 0 1px 3px 1px rgba(0, 0, 0, 0.05)',
     light1: '0 1px 2px rgba(0, 0, 0, 0.3), 0 1px 3px 1px rgba(0, 0, 0, 0.15)',
     light2: '0 1px 2px rgba(0, 0, 0, 0.3), 0 2px 6px 2px rgba(0, 0, 0, 0.15)',

--- a/src/shared/styles/variables/palette.ts
+++ b/src/shared/styles/variables/palette.ts
@@ -41,6 +41,7 @@ export const palette = {
   contained_btn_focus: '#1f79ab',
   disabled: '#979799',
   light_alfa8: 'rgba(255, 255, 255, 0.08)',
+  light_alfa12: 'rgba(255, 255, 255, 0.12)',
   surface_variant_alfa8: 'rgba(222, 227, 235, 0.08)',
   white_alfa50: 'rgb(255 255 255 / 50%)',
   dark_error_container: '#93000a',


### PR DESCRIPTION
### 📝 Description

🔗 [M2-6071](https://mindlogger.atlassian.net/browse/M2-6071): [FE] Update Button variants to align with Figma

This PR implements all of the button variants depicted [here in Figma](https://www.figma.com/file/LXl9BAJSwtgWuzkxqOqvX8/ML1-Design-System?type=design&node-id=57868-142461&mode=design&t=YolB7mwxGKCMjrvK-4), a number of which have not previously been added.

I added additional values to the MUI Button's `variant` prop, which map to the new variants added, and match the naming of the Figma variants as closely as I could. In addition to the already-provided variant values of `'contained'`, `'outlined'`, and `'text'`, we now also support `'elevated'`, `'tonal'`, and `'textNeutral'`.

I've updated the styles of some existing button variants where necessary, to match the properties in Figma more closely, particularly the hover/focus styles, and the text color of the `'outlined'` variant.

I've also set the default value of the Button's variant prop to `'textNeutral'`, which is the closest visual match for how all the buttons without an explicit `variant` prop value previously appeared. The `text` variant, which was the previous default, was updated to have a blue text color, in order to more closely match the appearance in Figma.

The Button's `color` prop is still available, and may continue to be used in combination with the `contained` variant to create an error button, as shown [here in Figma](https://www.figma.com/file/6BNx63peNVzrHAF1FoZ78x/Multi-Informant-2024?type=design&node-id=6202-193901&mode=design&t=S0nD9IF2Tt6UkCZS-4). The color prop will likely not have an effect otherwise, as all of the other variants have explicitly-defined background & text colors.

While reviewing the various screens, I noticed a discrepancy between the implementation of the toolbar for the Participant Details' Activity screen, and its appearance in Figma: In Figma, this screen has a distinct set of buttons, while in the app currently, it shares the toolbar with the Applet-level Activity screen. I took the liberty of creating a new component for this screen with appropriate buttons. None of them are wired up to any functionality, and the toolbar in its entirety will likely end up disabled for the initial release, but I figured it would be better for it to be there for when we needed it 🤷‍♀️.

### 📸 Screenshots

#### Update Account Dialog

| Before | After |
|-|-|
| ![upgrade-dialog-before](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/9a3da124-bab0-4368-84e0-d96fa88765db) | ![upgrade-dialog-after](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/0df627ae-6c92-46af-abd5-5e516df016f7) |

#### Participant Details' Activities Tab

| Before | After |
|-|-|
| ![participant-activities-before](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/57ec3770-51f6-4846-82fb-03daf6585aca) | ![participant-activities-after](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/c41f7374-044b-46a8-829c-02995617508e) |

#### Add Subject Dialog

| Before | After |
|-|-|
| ![create-account-before](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/db4c7afb-1631-469f-bd94-8ebed645133c) | ![create-account-after](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/56bcce34-edc0-465d-a8f9-7839c9414744) |

#### Applet Participants Tab

| Before | After |
|-|-|
| ![applet-participants-before](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/49ab85d3-fbe3-40cc-b2cf-f42f5fb23a8d) | ![applet-participants-after](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/ea712db5-9072-48de-9dc8-5cab8576a30a) |

#### Applet Activities Tab

| Before | After |
|-|-|
| ![applet-activities-before](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/98d7ca8d-b15d-4d92-97b5-744862c22d8a) | ![applet-activities-after](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/cbd856c5-0355-4147-af57-c6cd8d964843) |

### 🪤 Peer Testing

1. Navigate to the relevant screens, observe the updated button variants.
2. In general, observe that no buttons have changed erroneously.

[M2-6071]: https://mindlogger.atlassian.net/browse/M2-6071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ