### PR TITLE
chore: remove linting for the commit message (M2-6558)

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -5,17 +5,3 @@ if ! [[ $current_branch =~ ^((feature|fix|tests)/M2-[0-9])|(release|develop)+ ]]
   echo "The branch name should follow the format 'fix/M2-xxx', 'feature/M2-xxx' or 'tests/M2-xxx', xxx - ticket number"
   exit 1
 fi
-
-
-if [ -e ./commit_msg_check_flag ]; then
-    rm ./commit_msg_check_flag
-    exit 0
-fi
-
-commit_msg_file=$1
-commit_msg=$(cat $commit_msg_file)
-
-if ! [[ $commit_msg =~ ^(M2-[0-9]+:|Merge)+ ]]; then
-  echo "Сommit message should follow the format 'M2-xxx:', xxx - ticket number"
-  exit 1
-fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,0 @@
-#!/bin/bash
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-npm run test:related

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,9 +1,0 @@
-#!/bin/sh
-commit_source=$2
-
-if [ "${commit_source}" = merge ]; then
-    if [ ! -e ./commit_msg_check_flag ]; then
-        echo "1" > ./commit_msg_check_flag
-    fi
-    exit 0
-fi


### PR DESCRIPTION
- [x] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

🔗 [Jira Ticket M2-6558](https://mindlogger.atlassian.net/browse/M2-6558)
