### PR TITLE
fix(mi): Hide unfinished UI (M2-6458)

### DIFF
--- a/src/modules/Dashboard/components/DashboardTable/DashboardTable.tsx
+++ b/src/modules/Dashboard/components/DashboardTable/DashboardTable.tsx
@@ -72,7 +72,10 @@ export const DashboardTable = ({
                     align={row[key].align}
                     width={row[key].width}
                     hasColFixedWidth={hasColFixedWidth}
-                    sx={{ cursor: row[key].onClick ? 'pointer' : 'default' }}
+                    sx={{
+                      cursor: row[key].onClick ? 'pointer' : 'default',
+                      maxWidth: row[key].maxWidth,
+                    }}
                     data-testid={`${dataTestid}-${index}-cell-${key}`}
                   >
                     <StyledEllipsisText>

--- a/src/modules/Dashboard/features/Applet/Activities/Activities.tsx
+++ b/src/modules/Dashboard/features/Applet/Activities/Activities.tsx
@@ -62,10 +62,10 @@ export const Activities = () => {
     <StyledFlexColumn sx={{ gap: 2.4, height: '100%' }}>
       {isLoading && <Spinner />}
 
-      <ActivitiesToolbar appletId={appletId} data-testid={dataTestId} sx={{ px: 3.2, pt: 3.2 }} />
+      <ActivitiesToolbar appletId={appletId} data-testid={dataTestId} sx={{ p: 3.2, pb: 0 }} />
 
       {showContent && (
-        <StyledFlexColumn sx={{ gap: 4.8, overflow: 'auto', p: 3.2 }}>
+        <StyledFlexColumn sx={{ gap: 4.8, overflow: 'auto', p: 3.2, pt: 0 }}>
           {!!flows?.length && (
             <StyledFlexColumn component="section" sx={{ gap: 1.6 }}>
               <ActivitiesSectionHeader title={t('flows')} count={flows?.length ?? 0} />

--- a/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.tsx
@@ -179,9 +179,6 @@ export const AddParticipantPopup = ({
           title={t('addParticipant')}
           buttonText={t('next')}
           hasLeftBtn
-          leftBtnText={t('addViaCSV')}
-          leftBtnVariant="outlined"
-          onLeftBtnSubmit={handleAddViaCSV}
           data-testid={dataTestid}
         >
           <StyledModalWrapper>

--- a/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.tsx
@@ -62,10 +62,6 @@ export const AddParticipantPopup = ({
     onClose?.(shouldRefetch);
   };
 
-  const handleAddViaCSV = () => {
-    alert('TODO: Add via CSV');
-  };
-
   const resetForm = () => reset({ ...defaults, accountType });
 
   const {
@@ -178,7 +174,6 @@ export const AddParticipantPopup = ({
           onSubmit={handleNext}
           title={t('addParticipant')}
           buttonText={t('next')}
-          hasLeftBtn
           data-testid={dataTestid}
         >
           <StyledModalWrapper>

--- a/src/modules/Dashboard/features/Participant/Activities/Activities.tsx
+++ b/src/modules/Dashboard/features/Participant/Activities/Activities.tsx
@@ -110,7 +110,7 @@ export const Activities = () => {
       />
 
       {showContent && (
-        <StyledFlexColumn sx={{ gap: 4.8, overflow: 'auto', p: 3.2 }}>
+        <StyledFlexColumn sx={{ gap: 4.8, overflow: 'auto', p: 3.2, pt: 0 }}>
           {!!flows?.length && (
             <StyledFlexColumn component="section" sx={{ gap: 1.6 }}>
               <ActivitiesSectionHeader title={t('flows')} count={flows?.length ?? 0} />

--- a/src/modules/Dashboard/features/Participants/Participants.const.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.const.tsx
@@ -1,6 +1,7 @@
 export enum ParticipantsColumnsWidth {
   Pin = '8rem',
   Default = '28rem',
+  Id = '34.5rem',
   Schedule = '15rem',
   AccountType = '16rem',
   Menu = '7.2rem',

--- a/src/modules/Dashboard/features/Participants/Participants.const.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.const.tsx
@@ -1,7 +1,7 @@
 export enum ParticipantsColumnsWidth {
   Pin = '8rem',
   Default = '28rem',
-  Id = '34.5rem',
+  Id = '20.8rem',
   Schedule = '15rem',
   AccountType = '16rem',
   Menu = '7.2rem',

--- a/src/modules/Dashboard/features/Participants/Participants.test.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.test.tsx
@@ -2,6 +2,7 @@ import { waitFor, screen, fireEvent } from '@testing-library/react';
 import mockAxios from 'jest-mock-axios';
 import { generatePath } from 'react-router-dom';
 
+import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
 import {
   mockedApplet,
@@ -52,6 +53,12 @@ jest.mock('react-router-dom', () => ({
   useNavigate: () => mockedUseNavigate,
 }));
 
+jest.mock('shared/hooks/useFeatureFlags', () => ({
+  useFeatureFlags: jest.fn(),
+}));
+
+const mockUseFeatureFlags = useFeatureFlags as jest.Mock;
+
 const getMockedGetWithParticipants = (isAnonymousRespondent = false) => ({
   status: ApiResponseCodes.SuccessfulResponse,
   data: {
@@ -70,6 +77,12 @@ const clickActionDots = async () => {
 };
 
 describe('Participants component tests', () => {
+  beforeEach(() => {
+    mockUseFeatureFlags.mockReturnValue({
+      featureFlags: { enableActivityAssign: true },
+    });
+  });
+
   test('should render empty table', async () => {
     const successfulGetMock = {
       status: ApiResponseCodes.SuccessfulResponse,

--- a/src/modules/Dashboard/features/Participants/Participants.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.tsx
@@ -1,12 +1,10 @@
 import { useMemo, useState } from 'react';
-import { Button } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { generatePath, useNavigate, useParams } from 'react-router-dom';
 
 import { EmptyDashboardTable } from 'modules/Dashboard/components/EmptyDashboardTable';
 import {
   ActionsMenu,
-  ButtonWithMenu,
   Chip,
   MenuActionProps,
   Pin,
@@ -21,11 +19,12 @@ import { getWorkspaceRespondentsApi, updateRespondentsPinApi, updateSubjectsPinA
 import { page } from 'resources';
 import { getDateInUserTimezone, isManagerOrOwner, joinWihComma, Mixpanel } from 'shared/utils';
 import { DEFAULT_ROWS_PER_PAGE, Roles } from 'shared/consts';
-import { StyledBody, StyledFlexTopCenter, StyledFlexWrap } from 'shared/styles';
+import { StyledBody, StyledFlexWrap } from 'shared/styles';
 import { Respondent, RespondentStatus } from 'modules/Dashboard/types';
 import { StyledMaybeEmpty } from 'shared/styles/styledComponents/MaybeEmpty';
 import { AddParticipantPopup, UpgradeAccountPopup } from 'modules/Dashboard/features/Applet/Popups';
 import { ParticipantSnippetInfo, ParticipantTagChip } from 'modules/Dashboard/components';
+import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 
 import { AddParticipantButton, ParticipantsTable } from './Participants.styles';
 import {
@@ -53,6 +52,7 @@ export const Participants = () => {
   const navigate = useNavigate();
   const { t } = useTranslation('app');
   const timeAgo = useTimeAgo();
+  const { featureFlags } = useFeatureFlags();
 
   const [respondentsData, setRespondentsData] = useState<ParticipantsData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -100,7 +100,6 @@ export const Participants = () => {
     return getWorkspaceRespondents(params);
   });
 
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [addParticipantPopupVisible, setAddParticipantPopupVisible] = useState(false);
   const [dataExportPopupVisible, setDataExportPopupVisible] = useState(false);
   const [removeAccessPopupVisible, setRemoveAccessPopupVisible] = useState(false);
@@ -285,8 +284,8 @@ export const Participants = () => {
       secretIds: {
         content: () => secretId,
         value: secretId,
-        width: ParticipantsColumnsWidth.Default,
         onClick: defaultOnClick,
+        maxWidth: ParticipantsColumnsWidth.Id,
       },
       nicknames: {
         content: () => nickname,
@@ -332,6 +331,7 @@ export const Participants = () => {
               tag,
               status,
               dataTestid,
+              showAssignActivity: featureFlags.enableActivityAssign,
             })}
             data-testid={`${dataTestid}-table-actions`}
           />
@@ -410,21 +410,6 @@ export const Participants = () => {
       {isLoading && <Spinner />}
 
       <StyledFlexWrap sx={{ gap: 1.2, mb: 2.4 }}>
-        <StyledFlexTopCenter sx={{ gap: 1.2 }}>
-          <Button variant="outlined" startIcon={<Svg id="slider-rows" height={18} width={18} />}>
-            {t('filters')}
-          </Button>
-
-          <ButtonWithMenu
-            anchorEl={anchorEl}
-            label={t('sortBy')}
-            menuItems={[]}
-            setAnchorEl={setAnchorEl}
-            startIcon={<></>}
-            variant="outlined"
-          />
-        </StyledFlexTopCenter>
-
         <StyledFlexWrap sx={{ gap: 1.2, ml: 'auto' }}>
           <Search
             withDebounce

--- a/src/modules/Dashboard/features/Participants/Participants.types.ts
+++ b/src/modules/Dashboard/features/Participants/Participants.types.ts
@@ -62,6 +62,7 @@ export type GetParticipantActionsProps = {
   appletId?: string;
   status: RespondentStatus;
   dataTestid: string;
+  showAssignActivity?: boolean;
 };
 
 export type HandlePinClick = {

--- a/src/modules/Dashboard/features/Participants/Participants.utils.test.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.utils.test.tsx
@@ -62,6 +62,7 @@ const commonGetActionsProps = {
   secretId: 'test secret id',
   nickname: 'test nickname',
   tag: 'Child' as ParticipantTag,
+  showAssignActivity: true,
 };
 
 const expectedContext = {

--- a/src/modules/Dashboard/features/Participants/Participants.utils.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.utils.tsx
@@ -30,6 +30,7 @@ export const getParticipantActions = ({
   tag,
   status,
   dataTestid,
+  showAssignActivity = false,
 }: GetParticipantActionsProps) => {
   const context = { respondentId, respondentOrSubjectId, email, secretId, nickname, tag };
   const isUpgradeable = status === RespondentStatus.NotInvited;
@@ -73,14 +74,14 @@ export const getParticipantActions = ({
     },
     {
       type: MenuItemType.Divider,
-      isDisplayed: !isPending,
+      isDisplayed: showAssignActivity && !isPending,
     },
     {
       icon: <Svg id="add-users-outlined" width={24} height={24} />,
       action: assignActivity,
       title: t('assignActivity'),
       context,
-      isDisplayed: isEditable && !isPending,
+      isDisplayed: showAssignActivity && isEditable && !isPending,
       'data-testid': `${dataTestid}-assign-activity`,
     },
   ];
@@ -145,7 +146,7 @@ export const getHeadCells = (id?: string): HeadCell[] => {
       id: 'secretIds',
       label: t('secretUserId'),
       enableSort: true,
-      width: ParticipantsColumnsWidth.Default,
+      maxWidth: ParticipantsColumnsWidth.Id,
     },
     {
       id: 'nicknames',

--- a/src/shared/components/Table/Table.tsx
+++ b/src/shared/components/Table/Table.tsx
@@ -101,7 +101,7 @@ export const Table = ({
                   <TableRow key={`row-${index}`} data-testid="table-row">
                     {Object.keys(row)?.map((key) => (
                       <TableCell
-                        sx={{ height: '4.8rem' }}
+                        sx={{ height: '4.8rem', maxWidth: row[key].maxWidth }}
                         onClick={row[key].onClick}
                         scope="row"
                         key={key}

--- a/src/shared/components/Table/Table.types.ts
+++ b/src/shared/components/Table/Table.types.ts
@@ -6,6 +6,7 @@ export type RowContent = Cell & {
   content: (item?: Row) => ReactNode;
   value: string | number | boolean;
   onClick?: () => void;
+  maxWidth?: string;
   width?: string;
   contentWithTooltip?: ReactNode;
 };

--- a/src/shared/components/Table/TableHead/TableHead.tsx
+++ b/src/shared/components/Table/TableHead/TableHead.tsx
@@ -34,7 +34,7 @@ export const TableHead = ({
         </TableRow>
       )}
       <TableRow>
-        {headCells.map(({ id, label, align, enableSort, width }) => (
+        {headCells.map(({ id, label, align, enableSort, maxWidth, width }) => (
           <StyledTableCell
             uiType={uiType}
             key={id}
@@ -42,6 +42,7 @@ export const TableHead = ({
             align={align}
             sortDirection={orderBy === id ? order : false}
             hasColFixedWidth={hasColFixedWidth}
+            sx={{ maxWidth }}
           >
             {enableSort ? (
               <TableSortLabel

--- a/src/shared/types/table.ts
+++ b/src/shared/types/table.ts
@@ -2,6 +2,7 @@ export type Order = 'asc' | 'desc';
 
 export type Cell = {
   align?: 'center' | 'inherit' | 'justify' | 'left' | 'right';
+  maxWidth?: string;
   width?: string;
 };
 


### PR DESCRIPTION
### 📝 Description

🔗 [M2-6458](https://mindlogger.atlassian.net/browse/M2-6458): [Participants] Hide Placeholder Elements Not Intended for R1

This PR hides some unfinished UI not intended for the immediate upcoming release. This includes:

- Removing the "Filter & Sort" buttons on the Applet-level Participants screen. These weren't connected to anything and are just simple `Button` components, so I opted to just delete the relevant lines for now.
- Removing the "Add CSV" button on the "Add Participant" dialog on the Applet-level Participants screen. Again, this wasn't connected to anything and was being configured by a couple props passed to the Modal component, so I opted to just remove those prop values for now.
- Hid the "Assign Activity" menu item on the dropdown menu visible when clicking the Ellipsis button on table rows in the Applet-level Participants screen. I made the rendering of this option conditional on the value of the `enableAssignActivity` feature flag, which is enabled in development environments.

This ticket also additionally specified the desire to truncate excessively long IDs on the Participants table. I added support for a `maxWidth` property on cell data, in addition to the existing `width` property, and added appropriate values to set this accordingly. The cell should be wide enough to fit a generic UUID, and on screens that are otherwise too small to accommodate longer cell widths, the column will being to truncate longer ID values.

Finally, this addresses a small issue with vertical padding between elements on the Activities page, originally pointed out [here, by farmerpaul](https://github.com/ChildMindInstitute/mindlogger-admin/pull/1707#pullrequestreview-2048561941).

### 📸 Screenshots

#### Participants Table

| Before | After |
|-|-|
| ![localhost_3000_dashboard_fdb0c9fd-0e62-40b6-94a8-7fc6a55f4da8_activities (2)](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/2932aa42-be2a-449d-9ce1-e691bc757f24) | ![participants-after](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/0a4c6078-1603-4ca4-8757-936bd9b9b1a7) |

#### Participant Actions Dropdown Menu

| Before | After |
|-|-|
| ![localhost_3000_dashboard_fdb0c9fd-0e62-40b6-94a8-7fc6a55f4da8_activities (4)](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/0e500725-81d2-486c-95f1-3897e3d28f31) | ![action-menu-after](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/ab65ddae-6bc2-4e51-90e0-6fde0e0f2089) |

#### Add Participant Dialog

| Before | After |
|-|-|
| ![localhost_3000_dashboard_fdb0c9fd-0e62-40b6-94a8-7fc6a55f4da8_activities (3)](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/1f2c157e-8074-4ed3-bca9-b557a564f03b) | ![add-menu-after](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/f3d4e7a1-1b2a-4191-be07-d2cde50ffeb4) |

#### Activities Padding

| Before | After |
|-|-|
| ![localhost_3000_dashboard_fdb0c9fd-0e62-40b6-94a8-7fc6a55f4da8_activities (1)](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/9bf3fb68-09b9-4d1a-81ab-a7403c2f755c) | ![localhost_3000_dashboard_fdb0c9fd-0e62-40b6-94a8-7fc6a55f4da8_activities](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/08ce9361-8788-4a06-813a-ec33eb6fe609) |

### 🪤 Peer Testing  

1. Navigate to the **Applet > Participants** page and observe that Sort & Filter buttons are absent.
2. Observe that the ID column truncates sufficiently lengthy content.
3. Press to open a Participant's dropdown menu, and observe that the "Add Activity" option is 
absent (depending on the feature flag state).
4. Press the "Add Participant" button, and observe that the "Add via CSV" button is absent.
5. Navigate to the **Applet > Activities** page and observe that the padding between the toolbar and the Flow/Activities grid is correct.

[M2-6458]: https://mindlogger.atlassian.net/browse/M2-6458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ