### PR TITLE
fix: disable commit message linting (M2-6542)

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,7 +1,0 @@
-#!/bin/sh
-current_branch=$(git branch --show-current)
-
-if ! [[ $current_branch =~ ^((feature|fix|tests)/M2-[0-9])|(release|develop)+ ]]; then
-  echo "The branch name should follow the format 'fix/M2-xxx', 'feature/M2-xxx' or 'tests/M2-xxx', xxx - ticket number"
-  exit 1
-fi


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-6542](https://mindlogger.atlassian.net/browse/M2-6542)

Remove commit message linting from the admin repo.

### 🪤 Peer Testing

1. Check out this branch into your local dev env
2. Create a test commit that has an arbitrary message format
    **Expected outcome:** You can successfully commit code without adhering to the M2-XXXX format.
