### PR TITLE
fix(mi): Hide stats on `ActivitySummaryCard`s (M2-6507)

### DIFF
--- a/src/modules/Dashboard/components/ActivitySummaryCard/ActivitySummaryCard.styles.ts
+++ b/src/modules/Dashboard/components/ActivitySummaryCard/ActivitySummaryCard.styles.ts
@@ -8,14 +8,17 @@ import {
   variables,
 } from 'shared/styles';
 
-export const StyledContainer = styled(StyledFlexSpaceBetween)`
-  flex-direction: column;
-  padding: ${theme.spacing(2.4)};
-  width: 30.6rem;
-  height: 44rem;
-  border: ${variables.borderWidth.md} solid ${variables.palette.surface_variant};
-  border-radius: ${variables.borderRadius.lg2};
-`;
+export const StyledContainer = styled(StyledFlexSpaceBetween)(
+  ({ showStats = false }: { showStats?: boolean }) => ({
+    flexDirection: 'column',
+    gap: theme.spacing(3.2),
+    padding: theme.spacing(2.4),
+    width: '30.6rem',
+    height: showStats ? '44rem' : undefined,
+    border: `${variables.borderWidth.md} solid ${variables.palette.surface_variant}`,
+    borderRadius: variables.borderRadius.lg2,
+  }),
+);
 
 export const StyledImageContainer = styled(StyledFlexAllCenter)`
   min-width: 8rem;

--- a/src/modules/Dashboard/components/ActivitySummaryCard/ActivitySummaryCard.test.tsx
+++ b/src/modules/Dashboard/components/ActivitySummaryCard/ActivitySummaryCard.test.tsx
@@ -16,14 +16,28 @@ const props = {
 };
 
 describe('ActivitySummaryCard', () => {
-  test('should render activity summary card props', () => {
-    render(<ActivitySummaryCard {...props} />);
+  describe('When `showStats is `true`', () => {
+    test('should render activity summary card props', () => {
+      render(<ActivitySummaryCard showStats {...props} />);
 
-    expect(screen.queryByText(props.compliance)).toBeInTheDocument();
-    expect(screen.queryByAltText(props.name)).toBeInTheDocument();
-    expect(screen.queryByText(props.name)).toBeInTheDocument();
-    expect(screen.queryByText(props.participantCount)).toBeInTheDocument();
-    expect(screen.queryByText(props.latestActivity)).toBeInTheDocument();
+      expect(screen.queryByAltText(props.name)).toBeInTheDocument();
+      expect(screen.queryByText(props.name)).toBeInTheDocument();
+      expect(screen.queryByText(props.compliance)).toBeInTheDocument();
+      expect(screen.queryByText(props.participantCount)).toBeInTheDocument();
+      expect(screen.queryByText(props.latestActivity)).toBeInTheDocument();
+    });
+  });
+
+  describe('When `showStats is `true`', () => {
+    test('should render activity summary card props', () => {
+      render(<ActivitySummaryCard showStats={false} {...props} />);
+
+      expect(screen.queryByAltText(props.name)).toBeInTheDocument();
+      expect(screen.queryByText(props.name)).toBeInTheDocument();
+      expect(screen.queryByText(props.compliance)).not.toBeInTheDocument();
+      expect(screen.queryByText(props.participantCount)).not.toBeInTheDocument();
+      expect(screen.queryByText(props.latestActivity)).not.toBeInTheDocument();
+    });
   });
 
   test('should render actions menu and run action handler when clicked', () => {

--- a/src/modules/Dashboard/components/ActivitySummaryCard/ActivitySummaryCard.tsx
+++ b/src/modules/Dashboard/components/ActivitySummaryCard/ActivitySummaryCard.tsx
@@ -20,6 +20,7 @@ export const ActivitySummaryCard = ({
   name,
   participantCount,
   latestActivity,
+  showStats = false,
   'data-testid': dataTestId,
   onClick,
 }: ActivitySummaryCardProps) => {
@@ -46,21 +47,25 @@ export const ActivitySummaryCard = ({
           <StyledActivityName>{name}</StyledActivityName>
         </StyledFlexColumn>
 
-        <Divider />
+        {showStats && (
+          <>
+            <Divider />
 
-        <StyledFlexColumn sx={{ gap: 1.6 }}>
-          <StyledFlexTopStart sx={{ gap: 2.4 }}>
-            <StatBox label={t('participants')} sx={{ flex: 1 }}>
-              {participantCount}
-            </StatBox>
+            <StyledFlexColumn sx={{ gap: 1.6 }}>
+              <StyledFlexTopStart sx={{ gap: 2.4 }}>
+                <StatBox label={t('participants')} sx={{ flex: 1 }}>
+                  {participantCount}
+                </StatBox>
 
-            <StatBox label={t('compliance')} sx={{ flex: 1 }}>
-              {compliance}
-            </StatBox>
-          </StyledFlexTopStart>
+                <StatBox label={t('compliance')} sx={{ flex: 1 }}>
+                  {compliance}
+                </StatBox>
+              </StyledFlexTopStart>
 
-          <StatBox label={t('latestActivity')}>{latestActivity}</StatBox>
-        </StyledFlexColumn>
+              <StatBox label={t('latestActivity')}>{latestActivity}</StatBox>
+            </StyledFlexColumn>
+          </>
+        )}
       </StyledFlexColumn>
     </StyledContainer>
   );

--- a/src/modules/Dashboard/components/ActivitySummaryCard/ActivitySummaryCard.types.ts
+++ b/src/modules/Dashboard/components/ActivitySummaryCard/ActivitySummaryCard.types.ts
@@ -8,6 +8,7 @@ export type ActivitySummaryCardProps = Pick<Activity, 'name' | 'image'> & {
   compliance?: ReactNode;
   participantCount?: ReactNode;
   latestActivity?: ReactNode;
+  showStats?: boolean;
   'data-testid'?: string;
   onClick?: (activityId: string) => void;
 };


### PR DESCRIPTION
### 📝 Description

🔗 [M2-6507](https://mindlogger.atlassian.net/browse/M2-6507): [Activities] Hide Activity Card elements Not Intended for R1

This PR updates the `ActivitySummaryCard` to hide the stats section of the card. This is handled via a new prop, `showStats`, which defaults to `false`, and must be opted into rendering by passing the appropriate value, which we are not doing anywhere at the moment.

The linked task contains a list of suggestions around adding discrete prop values for controlling the visibility of individual stats. Given the rationale of "we don't know what stats we want to show yet", I opted to defer on this change (in favour of this single flag) for a few reasons:

* I think supporting this degree of customization would be better handled by either passing the stats as an array that maps to the output UI, or even by just accepting generic children for that whole area of the UI. This would allow us to support conditional rendering, or rendering arbitrary content by just passing the specific content we want to render, and omitting that which we don't.
* Given the reasoning — that we don't know which stats we're rendering — it seems like the design itself is subject to change. Given how variable the layouts could be for different amounts of content beyond what's already planned for, I don't want to try and accommodate such UI scenarios until we know we need to.

### 📸 Screenshots

| Before | After |
|-|-|
| ![localhost_3000_dashboard_fdb0c9fd-0e62-40b6-94a8-7fc6a55f4da8_participants_65e2fef6-0e69-4575-ae4c-62e9bc73822b (1)](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/6cce6bc7-80ba-47f3-b422-fa0166e6f3fb) | ![localhost_3000_dashboard_fdb0c9fd-0e62-40b6-94a8-7fc6a55f4da8_participants_65e2fef6-0e69-4575-ae4c-62e9bc73822b](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/60ddb07f-8717-4223-875e-b0e0f7601345) |

### 🪤 Peer Testing

1. Navigate to the **Applet > Activities** page and observe the Activity Summary Cards.
2. Navigate to the **Applet > Participant Details > Activities** page and observe the Activity Summary Cards.


[M2-6507]: https://mindlogger.atlassian.net/browse/M2-6507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ