### PR TITLE
feature(mi): Add ability to edit subject tags (M2-6331)

### DIFF
--- a/src/modules/Dashboard/api/api.types.ts
+++ b/src/modules/Dashboard/api/api.types.ts
@@ -1,6 +1,6 @@
 import { AppletId } from 'shared/api';
 import { Item, SingleApplet } from 'shared/state';
-import { Roles } from 'shared/consts';
+import { ParticipantTag, Roles } from 'shared/consts';
 import { RetentionPeriods, EncryptedAnswerSharedProps, ExportActivity } from 'shared/types';
 import { Encryption } from 'shared/utils';
 
@@ -175,6 +175,7 @@ export type EditSubject = SubjectId & {
   values: {
     secretUserId: string;
     nickname?: string;
+    tag?: ParticipantTag;
   };
 };
 

--- a/src/modules/Dashboard/features/Participants/Participants.types.ts
+++ b/src/modules/Dashboard/features/Participants/Participants.types.ts
@@ -31,6 +31,7 @@ export type ChosenAppletData = {
   encryption?: Encryption;
   ownerId: string;
   subjectId: string;
+  subjectTag?: ParticipantTag | null;
 };
 
 export enum FilteredAppletsKey {

--- a/src/modules/Dashboard/features/Respondents/Popups/EditRespondentPopup/EditRespondentPopup.schema.ts
+++ b/src/modules/Dashboard/features/Respondents/Popups/EditRespondentPopup/EditRespondentPopup.schema.ts
@@ -1,6 +1,7 @@
 import * as yup from 'yup';
 
 import i18n from 'i18n';
+import { PARTICIPANT_TAGS } from 'shared/consts';
 
 export const editRespondentFormSchema = () => {
   const { t } = i18n;
@@ -10,6 +11,7 @@ export const editRespondentFormSchema = () => {
     .object({
       secretUserId: yup.string().required(requiredField),
       nickname: yup.string(),
+      tag: yup.string().oneOf(PARTICIPANT_TAGS),
     })
     .required();
 };

--- a/src/modules/Dashboard/features/Respondents/Popups/EditRespondentPopup/EditRespondentPopup.tsx
+++ b/src/modules/Dashboard/features/Respondents/Popups/EditRespondentPopup/EditRespondentPopup.tsx
@@ -67,7 +67,7 @@ export const EditRespondentPopup = ({
       values: {
         secretUserId: secretUserId.trim(),
         nickname: nickname?.trim(),
-        ...(tag ? { tag } : {}),
+        ...(tag && { tag }),
       },
       subjectId,
     });
@@ -84,15 +84,16 @@ export const EditRespondentPopup = ({
   return (
     <Modal
       open={popupVisible}
-      onClose={onCloseHandler}
+      onClose={() => onCloseHandler(false)}
       onSubmit={handleSubmit(submitForm)}
       disabledSubmit={isLoading}
       title={t('editParticipant')}
       buttonText={t('save')}
-      hasSecondBtn
-      onSecondBtnSubmit={onCloseHandler}
-      secondBtnText={t('cancel')}
+      hasLeftBtn
+      onLeftBtnSubmit={() => onCloseHandler(false)}
+      leftBtnText={t('cancel')}
       data-testid={dataTestid}
+      width="56"
     >
       <>
         {isLoading && <Spinner uiType={SpinnerUiType.Secondary} noBackground />}

--- a/src/modules/Dashboard/features/Respondents/Popups/EditRespondentPopup/EditRespondentPopup.tsx
+++ b/src/modules/Dashboard/features/Respondents/Popups/EditRespondentPopup/EditRespondentPopup.tsx
@@ -1,11 +1,13 @@
-import { useEffect, useState, ChangeEvent } from 'react';
+import { useState, ChangeEvent } from 'react';
+import { Box } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 
-import { Modal, Spinner, SpinnerUiType } from 'shared/components';
+import { Modal, Spinner, SpinnerUiType, Svg } from 'shared/components';
+import { PARTICIPANT_TAG_ICONS, USER_SELECTABLE_PARTICIPANT_TAGS } from 'shared/consts';
 import { StyledErrorText, StyledModalWrapper } from 'shared/styles';
-import { InputController } from 'shared/components/FormComponents';
+import { InputController, SelectController } from 'shared/components/FormComponents';
 import { useAsync } from 'shared/hooks/useAsync';
 import { editSubjectApi } from 'api';
 import { falseReturnFunc, getErrorMessage } from 'shared/utils';
@@ -14,7 +16,6 @@ import { banners } from 'redux/modules';
 
 import { EditRespondentForm, EditRespondentPopupProps } from './EditRespondentPopup.types';
 import { editRespondentFormSchema } from './EditRespondentPopup.schema';
-import { StyledController } from './EditRespondentsPopup.styles';
 
 export const EditRespondentPopup = ({
   popupVisible,
@@ -23,6 +24,7 @@ export const EditRespondentPopup = ({
 }: EditRespondentPopupProps) => {
   const { t } = useTranslation('app');
   const dispatch = useAppDispatch();
+  const isTeamMember = chosenAppletData?.subjectTag === 'Team';
 
   const [isServerErrorVisible, setIsServerErrorVisible] = useState(true);
 
@@ -30,7 +32,11 @@ export const EditRespondentPopup = ({
 
   const { handleSubmit, control, setValue, getValues, trigger } = useForm<EditRespondentForm>({
     resolver: yupResolver(editRespondentFormSchema()),
-    defaultValues: { secretUserId: '', nickname: '' },
+    defaultValues: {
+      secretUserId: chosenAppletData?.respondentSecretId ?? '',
+      nickname: chosenAppletData?.respondentNickname ?? '',
+      tag: chosenAppletData?.subjectTag ?? ('' as const),
+    },
   });
 
   const dataTestid = 'dashboard-respondents-edit-popup';
@@ -54,13 +60,14 @@ export const EditRespondentPopup = ({
   const submitForm = () => {
     if (!chosenAppletData) return;
 
-    const { secretUserId, nickname } = getValues();
+    const { secretUserId, nickname, tag } = getValues();
     const { subjectId } = chosenAppletData;
 
     editRespondent({
       values: {
         secretUserId: secretUserId.trim(),
         nickname: nickname?.trim(),
+        ...(tag ? { tag } : {}),
       },
       subjectId,
     });
@@ -72,12 +79,6 @@ export const EditRespondentPopup = ({
     trigger('secretUserId');
   };
 
-  useEffect(() => {
-    const { respondentNickname, respondentSecretId = '' } = chosenAppletData || {};
-    setValue('secretUserId', respondentSecretId);
-    setValue('nickname', respondentNickname || '');
-  }, [chosenAppletData]);
-
   const hasServerError = error && isServerErrorVisible;
 
   return (
@@ -86,7 +87,7 @@ export const EditRespondentPopup = ({
       onClose={onCloseHandler}
       onSubmit={handleSubmit(submitForm)}
       disabledSubmit={isLoading}
-      title={t('editRespondent')}
+      title={t('editParticipant')}
       buttonText={t('save')}
       hasSecondBtn
       onSecondBtnSubmit={onCloseHandler}
@@ -96,29 +97,59 @@ export const EditRespondentPopup = ({
       <>
         {isLoading && <Spinner uiType={SpinnerUiType.Secondary} noBackground />}
         <StyledModalWrapper>
-          <form onSubmit={handleSubmit(submitForm)} noValidate>
-            <StyledController>
-              <InputController
-                fullWidth
-                name="nickname"
-                control={control}
-                label={t('nickname')}
-                data-testid={`${dataTestid}-nickname`}
-              />
-            </StyledController>
-            <StyledController>
-              <InputController
-                fullWidth
-                name="secretUserId"
-                control={control}
-                label={t('secretUserId')}
-                onChange={handleChangeSecretId}
-                error={!!hasServerError}
-                data-testid={`${dataTestid}-secret-user-id`}
-              />
-            </StyledController>
-          </form>
-          {hasServerError && <StyledErrorText>{getErrorMessage(error)}</StyledErrorText>}
+          <Box
+            component="form"
+            sx={{ display: 'flex', flexDirection: 'column', gap: 2.4 }}
+            onSubmit={handleSubmit(submitForm)}
+            noValidate
+          >
+            <InputController
+              fullWidth
+              name="nickname"
+              control={control}
+              label={t('nickname')}
+              data-testid={`${dataTestid}-nickname`}
+            />
+
+            <InputController
+              fullWidth
+              name="secretUserId"
+              control={control}
+              label={t('secretUserId')}
+              onChange={handleChangeSecretId}
+              error={!!hasServerError}
+              data-testid={`${dataTestid}-secret-user-id`}
+            />
+
+            <SelectController
+              InputLabelProps={{ shrink: true }}
+              control={control}
+              disabled={isTeamMember}
+              data-testid={`${dataTestid}-tag`}
+              fullWidth
+              label={t('tag')}
+              name="tag"
+              options={
+                isTeamMember
+                  ? [
+                      {
+                        labelKey: `participantTag.Team`,
+                        value: 'Team',
+                        icon: <Svg id="team-outlined" width={24} height={24} />,
+                      },
+                    ]
+                  : USER_SELECTABLE_PARTICIPANT_TAGS.map((tag) => ({
+                      labelKey: `participantTag.${tag}`,
+                      value: tag,
+                      icon: <Svg id={PARTICIPANT_TAG_ICONS[tag]} width={24} height={24} />,
+                    }))
+              }
+              placeholder={t('selectOne')}
+              withChecked
+            />
+
+            {hasServerError && <StyledErrorText>{getErrorMessage(error)}</StyledErrorText>}
+          </Box>
         </StyledModalWrapper>
       </>
     </Modal>

--- a/src/modules/Dashboard/features/Respondents/Popups/EditRespondentPopup/EditRespondentPopup.types.ts
+++ b/src/modules/Dashboard/features/Respondents/Popups/EditRespondentPopup/EditRespondentPopup.types.ts
@@ -1,8 +1,11 @@
+import { ParticipantTag } from 'shared/consts';
+
 import { ChosenAppletData } from '../../Respondents.types';
 
 export type EditRespondentForm = {
   secretUserId: string;
   nickname?: string;
+  tag?: ParticipantTag;
 };
 
 export type EditRespondentPopupProps = {

--- a/src/modules/Dashboard/features/Respondents/Respondents.types.ts
+++ b/src/modules/Dashboard/features/Respondents/Respondents.types.ts
@@ -1,6 +1,7 @@
 import { Respondent, RespondentDetail } from 'modules/Dashboard/types';
 import { Encryption } from 'shared/utils';
 import { MenuActionProps } from 'shared/components';
+import { ParticipantTag } from 'shared/consts';
 
 export type RespondentActionProps = {
   respondentId: string | null;
@@ -28,6 +29,7 @@ export type ChosenAppletData = {
   encryption?: Encryption;
   ownerId: string;
   subjectId: string;
+  subjectTag?: ParticipantTag | null;
 };
 
 export enum FilteredAppletsKey {

--- a/src/modules/Dashboard/types/Dashboard.types.ts
+++ b/src/modules/Dashboard/types/Dashboard.types.ts
@@ -31,7 +31,7 @@ export type RespondentDetail = {
   respondentSecretId: string;
   hasIndividualSchedule: boolean;
   subjectId: string;
-  subjectTag: ParticipantTag | null;
+  subjectTag?: ParticipantTag | null;
 };
 
 export enum RespondentStatus {


### PR DESCRIPTION
### 📝 Description

🔗 [M2-6331](https://mindlogger.atlassian.net/browse/M2-6331): [Participant Overview] Edit Participant - Add Tag Field

> [!NOTE]  
> This PR includes a commit that updates related types authored by @farmerpaul in [M2-6481](https://github.com/ChildMindInstitute/mindlogger-admin/pull/1719). I recommend reviewing by viewing only the last two commits, the change set for which can be seen [here](https://github.com/ChildMindInstitute/mindlogger-admin/pull/1714/files/50f7fbff2109f0da40e5e7098dec10407bd95744..8476e8bde18ba6aee6aa10c44396b78d92f69afa).

This PR updates the "EditRespondantPopup" dialog, in order to support the updating of a given subject's tag value. It adds a similar dropdown component to the one added in the "AddParticipantPopup" component, in https://github.com/ChildMindInstitute/mindlogger-admin/pull/1706. The prop interface has also been tweaked to allow for pre-populating the field with a subject's pre-existing tag value.

If the given subject has a tag of "Team", then the field is disabled, with the "Team" value represented within it.

### 📸 Screenshots

| Non-team member | Team member |
|-|-|
| ![localhost_3000_dashboard_fdb0c9fd-0e62-40b6-94a8-7fc6a55f4da8_participants (2)](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/1058c6b1-aeed-406d-ac2b-0f226c8a9afc) | ![localhost_3000_dashboard_fdb0c9fd-0e62-40b6-94a8-7fc6a55f4da8_participants (3)](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/7de9340d-2dd7-486d-9609-4c9a3b77edeb) |


### 🪤 Peer Testing

1. Navigate to the **Applet > Participants** screen.
2. For a *non-team member* participant...
    1. Proceed to the "Edit Participant" dialog via the "More actions" menu.
    2. Observe the presence of a new Tag selection field. Select a new Tag value and submit.
    4. Observe that the tag has been updated for the given subject.
3. For *team member* participant...
    1. Proceed to the "Edit Participant" dialog via the "More actions" menu.
    2. Observe the presence of a new Tag selection field. It should be disabled, and the tag value cannot be changed.

[M2-6331]: https://mindlogger.atlassian.net/browse/M2-6331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[M2-6481]: https://mindlogger.atlassian.net/browse/M2-6481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ