### PR TITLE
feat(mi): add Team tag (M2-6481)

### DIFF
--- a/src/modules/Dashboard/components/HeaderOptions/HeaderOptions.tsx
+++ b/src/modules/Dashboard/components/HeaderOptions/HeaderOptions.tsx
@@ -25,7 +25,7 @@ export const HeaderOptions = () => {
   };
 
   return (
-    <StyledFlexTopCenter sx={{ gap: 1 }}>
+    <StyledFlexTopCenter sx={{ gap: 1, ml: 'auto' }}>
       <Button
         data-testid="header-option-export-button"
         onClick={handleOpenExport}

--- a/src/modules/Dashboard/components/ParticipantSnippet/ParticipantSnippet.styles.ts
+++ b/src/modules/Dashboard/components/ParticipantSnippet/ParticipantSnippet.styles.ts
@@ -1,5 +1,6 @@
 import { styled } from '@mui/material';
 
-import { StyledBodyLarge, ellipsisTextCss } from 'shared/styles';
+import { StyledBodyLarge, StyledHeadlineLarge, ellipsisTextCss } from 'shared/styles';
 
 export const StyledText = styled(StyledBodyLarge)(ellipsisTextCss);
+export const StyledTextLarge = styled(StyledHeadlineLarge)(ellipsisTextCss);

--- a/src/modules/Dashboard/components/ParticipantSnippet/ParticipantSnippet.test.tsx
+++ b/src/modules/Dashboard/components/ParticipantSnippet/ParticipantSnippet.test.tsx
@@ -8,7 +8,7 @@ const dataTestid = 'test-id';
 const props = {
   secretId: 'test secret id',
   nickname: 'test nickname',
-  tag: ParticipantTag.Child,
+  tag: 'Child' as ParticipantTag,
   'data-testid': dataTestid,
 };
 

--- a/src/modules/Dashboard/components/ParticipantSnippet/ParticipantSnippet.tsx
+++ b/src/modules/Dashboard/components/ParticipantSnippet/ParticipantSnippet.tsx
@@ -4,27 +4,39 @@ import { ElementType } from 'react';
 import { StyledFlexTopCenter, variables } from 'shared/styles';
 import { ParticipantTagChip } from 'modules/Dashboard/components';
 
-import { ParticipantSnippetProps } from './ParticipantSnippet.types';
-import { StyledText } from './ParticipantSnippet.styles';
+import { ParticipantSnippetProps, ParticipantSnippetVariant } from './ParticipantSnippet.types';
+import { StyledText, StyledTextLarge } from './ParticipantSnippet.styles';
 
 export const ParticipantSnippet = <T extends ElementType = BoxTypeMap['defaultComponent']>({
+  rightContent: children,
   secretId,
   nickname,
   tag,
   boxProps,
+  variant = ParticipantSnippetVariant.Default,
   'data-testid': dataTestId,
 }: ParticipantSnippetProps<T>) => {
   const { sx, ...rest } = boxProps ?? {};
+  const isDefaultVariant = variant === ParticipantSnippetVariant.Default;
+  const TextComponent = isDefaultVariant ? StyledText : StyledTextLarge;
 
   return (
-    <StyledFlexTopCenter sx={{ gap: 0.8, ...sx }} {...rest} data-testid={dataTestId}>
-      <StyledText data-testid={`${dataTestId}-secretId`}>{secretId}</StyledText>
+    <StyledFlexTopCenter
+      sx={{ gap: isDefaultVariant ? 0.8 : 1.6, ...sx }}
+      {...rest}
+      data-testid={dataTestId}
+    >
+      <TextComponent data-testid={`${dataTestId}-secretId`}>{secretId}</TextComponent>
       {!!nickname && (
-        <StyledText color={variables.palette.neutral60} data-testid={`${dataTestId}-nickname`}>
+        <TextComponent
+          color={variables.palette[isDefaultVariant ? 'neutral60' : 'outline']}
+          data-testid={`${dataTestId}-nickname`}
+        >
           {nickname}
-        </StyledText>
+        </TextComponent>
       )}
       <ParticipantTagChip tag={tag} data-testid={`${dataTestId}-tag`} />
+      {children}
     </StyledFlexTopCenter>
   );
 };

--- a/src/modules/Dashboard/components/ParticipantSnippet/ParticipantSnippet.types.ts
+++ b/src/modules/Dashboard/components/ParticipantSnippet/ParticipantSnippet.types.ts
@@ -1,4 +1,4 @@
-import { ElementType } from 'react';
+import { ElementType, ReactNode } from 'react';
 import { BoxProps } from '@mui/material';
 
 import { ParticipantTag } from 'shared/consts';
@@ -9,7 +9,14 @@ export type ParticipantSnippetInfo = {
   tag?: ParticipantTag | null;
 };
 
+export enum ParticipantSnippetVariant {
+  Default = 'Default',
+  Large = 'Large',
+}
+
 export type ParticipantSnippetProps<T extends ElementType> = ParticipantSnippetInfo & {
   boxProps?: BoxProps<T>;
+  rightContent?: ReactNode;
+  variant?: ParticipantSnippetVariant;
   'data-testid'?: string;
 };

--- a/src/modules/Dashboard/components/ParticipantTagChip/ParticipantTagChip.test.tsx
+++ b/src/modules/Dashboard/components/ParticipantTagChip/ParticipantTagChip.test.tsx
@@ -7,7 +7,7 @@ import { ParticipantTagChip } from './ParticipantTagChip';
 
 describe('ParticipantTagChip', () => {
   test('renders the translated tag name', () => {
-    const tag = ParticipantTag.Child;
+    const tag: ParticipantTag = 'Child';
     const { getByText } = render(<ParticipantTagChip tag={tag} />);
     expect(getByText('Child')).toBeInTheDocument();
   });
@@ -19,7 +19,7 @@ describe('ParticipantTagChip', () => {
   });
 
   test('returns nothing if tag is falsy', () => {
-    const { container, rerender } = render(<ParticipantTagChip tag={ParticipantTag.None} />);
+    const { container, rerender } = render(<ParticipantTagChip tag="" />);
     expect(container).toBeEmptyDOMElement();
 
     rerender(<ParticipantTagChip tag={null} />);

--- a/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantForm/AddParticipantForm.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantForm/AddParticipantForm.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { InputController, SelectController } from 'shared/components/FormComponents';
 import { Languages } from 'api';
 import { AccountType } from 'modules/Dashboard/types/Dashboard.types';
-import { PARTICIPANT_TAG_ICONS, ParticipantTag } from 'shared/consts';
+import { PARTICIPANT_TAG_ICONS, USER_SELECTABLE_PARTICIPANT_TAGS } from 'shared/consts';
 import { Svg } from 'shared/components';
 
 import { AddParticipantFormProps } from './AddParticipantForm.types';
@@ -84,7 +84,7 @@ export const AddParticipantForm = ({
             name={Fields.tag}
             withChecked
             options={[
-              ...Object.values(ParticipantTag).map((tag) => ({
+              ...USER_SELECTABLE_PARTICIPANT_TAGS.map((tag) => ({
                 labelKey: `participantTag.${tag}`,
                 value: tag,
                 icon: <Svg id={PARTICIPANT_TAG_ICONS[tag]} width={24} height={24} />,

--- a/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.const.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.const.tsx
@@ -2,7 +2,7 @@ import { t } from 'i18next';
 
 import { Svg } from 'shared/components';
 import { AccountType } from 'modules/Dashboard/types/Dashboard.types';
-import { ParticipantTag } from 'shared/consts';
+import { UserSelectableParticipantTag } from 'shared/consts';
 
 export const defaultValues = {
   accountType: AccountType.Full,
@@ -11,7 +11,7 @@ export const defaultValues = {
   nickname: '',
   email: '',
   secretUserId: '',
-  tag: ParticipantTag.None,
+  tag: '' as UserSelectableParticipantTag,
 };
 
 export const toggleButtons = [

--- a/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.schema.ts
+++ b/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.schema.ts
@@ -1,7 +1,7 @@
 import * as yup from 'yup';
 
 import i18n from 'i18n';
-import { EMAIL_REGEXP, ParticipantTag } from 'shared/consts';
+import { EMAIL_REGEXP, USER_SELECTABLE_PARTICIPANT_TAGS } from 'shared/consts';
 import { Languages } from 'api';
 import { AccountType } from 'modules/Dashboard/types/Dashboard.types';
 
@@ -33,7 +33,7 @@ export const AddParticipantPopupSchema = () => {
       lastName: yup.string().required(t('lastNameRequired')),
       nickname: yup.string(),
       secretUserId: yup.string().required(t('secretUserIdRequired')),
-      tag: yup.string().oneOf(Object.values(ParticipantTag)),
+      tag: yup.string().oneOf(USER_SELECTABLE_PARTICIPANT_TAGS),
       language: yup.string().required().oneOf(Object.values(Languages)),
     })
     .required();

--- a/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.test.tsx
@@ -30,7 +30,7 @@ const testValues = {
   firstName: 'test-first-name',
   lastName: 'test-last-name',
   secretUserId: 'test-secret-id',
-  tag: ParticipantTag.Child,
+  tag: 'Child' as ParticipantTag,
   nickname: null,
 };
 

--- a/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.types.ts
+++ b/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.types.ts
@@ -1,6 +1,6 @@
 import { Languages } from 'api';
 import { AccountType } from 'modules/Dashboard/types';
-import { ParticipantTag } from 'shared/consts';
+import { UserSelectableParticipantTag } from 'shared/consts';
 
 export type AddParticipantPopupProps = {
   popupVisible: boolean;
@@ -21,7 +21,7 @@ export type AddParticipantFormValues = {
   email?: string;
   nickname?: string;
   secretUserId: string;
-  tag?: ParticipantTag;
+  tag?: UserSelectableParticipantTag;
   language: Languages;
 };
 

--- a/src/modules/Dashboard/features/Applet/Popups/UpgradeAccountPopup/UpgradeAccountPopup.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/UpgradeAccountPopup/UpgradeAccountPopup.test.tsx
@@ -20,7 +20,7 @@ const props = {
   subjectId: mockedSubjectId1,
   secretId: 'test secret id',
   nickname: 'test nickname',
-  tag: ParticipantTag.Child,
+  tag: 'Child' as ParticipantTag,
   'data-testid': dataTestid,
 };
 

--- a/src/modules/Dashboard/features/Managers/Popups/AddManagerPopup/AddManagerForm/AddManagerForm.test.tsx
+++ b/src/modules/Dashboard/features/Managers/Popups/AddManagerPopup/AddManagerForm/AddManagerForm.test.tsx
@@ -20,7 +20,7 @@ const mockedParticipants = [mockedRespondent, mockedRespondent2].map(({ details 
     subjectId,
     secretId: respondentSecretId,
     nickname: respondentNickname,
-    tag: ParticipantTag.Child,
+    tag: 'Child' as ParticipantTag,
   };
 });
 

--- a/src/modules/Dashboard/features/Participant/Activities/Activities.test.tsx
+++ b/src/modules/Dashboard/features/Participant/Activities/Activities.test.tsx
@@ -6,7 +6,7 @@ import { PreloadedState } from '@reduxjs/toolkit';
 
 import { ApiResponseCodes } from 'api';
 import { page } from 'resources';
-import { Roles } from 'shared/consts';
+import { ParticipantTag, Roles } from 'shared/consts';
 import {
   mockedAppletData,
   mockedAppletId,
@@ -82,6 +82,7 @@ const preloadedState: PreloadedState<RootState> = {
         secretUserId: 'secretUserId',
         nickname: 'nickname',
         lastSeen: null,
+        tag: 'Child' as ParticipantTag,
       },
     }),
   },

--- a/src/modules/Dashboard/features/Participants/Participants.utils.test.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.utils.test.tsx
@@ -17,7 +17,7 @@ const applets = [
     respondentSecretId: 'janedoe',
     hasIndividualSchedule: false,
     subjectId: 'subj-1',
-    subjectTag: ParticipantTag.Child,
+    subjectTag: 'Child' as ParticipantTag,
   },
   {
     appletId: 'b7db8ff7-6d0b-40fd-8dfc-93f96e7ad788',
@@ -27,7 +27,7 @@ const applets = [
     respondentSecretId: 'janedoe',
     hasIndividualSchedule: false,
     subjectId: 'subj-2',
-    subjectTag: ParticipantTag.Child,
+    subjectTag: 'Child' as ParticipantTag,
   },
 ];
 
@@ -61,7 +61,7 @@ const commonGetActionsProps = {
   email: mockedEmail,
   secretId: 'test secret id',
   nickname: 'test nickname',
-  tag: ParticipantTag.Child,
+  tag: 'Child' as ParticipantTag,
 };
 
 const expectedContext = {

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.test.tsx
@@ -13,7 +13,7 @@ import {
   mockedRespondent2,
   mockedRespondentId,
 } from 'shared/mock';
-import { DateFormats, Roles, JEST_TEST_TIMEOUT } from 'shared/consts';
+import { DateFormats, Roles, JEST_TEST_TIMEOUT, ParticipantTag } from 'shared/consts';
 import { initialStateData } from 'shared/state';
 import { page } from 'resources';
 import * as dashboardHooks from 'modules/Dashboard/hooks';
@@ -65,6 +65,7 @@ const preloadedState = {
           nickname: 'Mocked Respondent',
           secretUserId: mockedRespondentId,
           lastSeen: '2023-12-15T23:29:36.150182',
+          tag: 'Child' as ParticipantTag,
         },
       },
     },

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewMenu/ReviewMenu.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewMenu/ReviewMenu.test.tsx
@@ -12,7 +12,7 @@ import {
   mockedRespondent2,
   mockedRespondentId,
 } from 'shared/mock';
-import { Roles } from 'shared/consts';
+import { ParticipantTag, Roles } from 'shared/consts';
 import { initialStateData } from 'shared/state';
 
 import { RespondentsDataFormValues } from '../../RespondentData.types';
@@ -57,6 +57,7 @@ const preloadedState = {
           nickname: 'Mocked Respondent',
           secretUserId: '3921968c-3903-4872-8f30-a6e6a10cef36',
           lastSeen: null,
+          tag: 'Child' as ParticipantTag,
         },
       },
     },

--- a/src/modules/Dashboard/features/Respondents/Respondents.utils.test.tsx
+++ b/src/modules/Dashboard/features/Respondents/Respondents.utils.test.tsx
@@ -14,7 +14,7 @@ const applets = [
     respondentSecretId: 'janedoe',
     hasIndividualSchedule: false,
     subjectId: 'subj-1',
-    subjectTag: ParticipantTag.Child,
+    subjectTag: 'Child' as ParticipantTag,
   },
   {
     appletId: 'b7db8ff7-6d0b-40fd-8dfc-93f96e7ad788',
@@ -24,7 +24,7 @@ const applets = [
     respondentSecretId: 'janedoe',
     hasIndividualSchedule: false,
     subjectId: 'subj-2',
-    subjectTag: ParticipantTag.Child,
+    subjectTag: 'Child' as ParticipantTag,
   },
 ];
 

--- a/src/modules/Dashboard/pages/ParticipantDetails/ParticipantDetails.tsx
+++ b/src/modules/Dashboard/pages/ParticipantDetails/ParticipantDetails.tsx
@@ -1,17 +1,16 @@
 import { useEffect } from 'react';
 import { generatePath, useNavigate, useParams } from 'react-router-dom';
-import { Box } from '@mui/material';
 
 import { HeaderOptions } from 'modules/Dashboard/components/HeaderOptions';
 import { useAppDispatch } from 'redux/store';
 import { LinkedTabs, Spinner } from 'shared/components';
 import { workspaces } from 'shared/state';
-import { StyledBody, StyledHeadlineLarge } from 'shared/styles';
+import { StyledBody } from 'shared/styles';
 import { applet as appletState } from 'shared/state';
 import { applets, users } from 'modules/Dashboard/state';
 import { getSubjectDetails } from 'modules/Dashboard/state/Users/Users.thunk';
-import { palette } from 'shared/styles/variables/palette';
 import { page } from 'resources';
+import { ParticipantSnippet, ParticipantSnippetVariant } from 'modules/Dashboard/components';
 
 import { useParticipantDetailsTabs } from './ParticipantDetails.hooks';
 
@@ -56,25 +55,17 @@ export const ParticipantDetails = () => {
       {loading && <Spinner />}
       {!loading && !!subject && (
         <>
-          <Box
-            sx={{
-              display: 'flex',
-              gap: 1.6,
-              marginBottom: 1.2,
-              marginX: 2.4,
-              placeContent: 'space-between',
-            }}
-          >
-            <Box sx={{ display: 'flex', gap: 1.6 }}>
-              <StyledHeadlineLarge>{subject?.secretUserId}</StyledHeadlineLarge>
-              <StyledHeadlineLarge color={palette.outline}>{subject?.nickname}</StyledHeadlineLarge>
-            </Box>
-
-            <HeaderOptions />
-          </Box>
+          <ParticipantSnippet
+            variant={ParticipantSnippetVariant.Large}
+            secretId={subject.secretUserId}
+            nickname={subject.nickname}
+            rightContent={<HeaderOptions />}
+            tag={subject.tag}
+            boxProps={{ sx: { mb: 1.2, mx: 2.4 } }}
+          />
 
           <LinkedTabs
-            panelProps={{ sx: { padding: 0 } }}
+            panelProps={{ sx: { p: 0 } }}
             tabs={respondentTabs}
             isCentered={false}
             deepPathCompare

--- a/src/modules/Dashboard/types/Dashboard.types.ts
+++ b/src/modules/Dashboard/types/Dashboard.types.ts
@@ -58,6 +58,7 @@ export type RespondentDetails = {
   nickname: string;
   secretUserId: string;
   lastSeen: string | null;
+  tag?: ParticipantTag | null;
 };
 
 export enum AccountType {

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -868,7 +868,8 @@
     "": "No selection",
     "Child": "Child",
     "Parent": "Parent/Guardian",
-    "Teacher": "Teacher"
+    "Teacher": "Teacher",
+    "Team": "Team"
   },
   "password": "Password",
   "passwordBlankSpaces": "Password must not contain spaces.",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -867,7 +867,8 @@
     "": "Aucune sélection",
     "Child": "Enfant",
     "Parent": "Parent/Tuteur",
-    "Teacher": "Enseignant"
+    "Teacher": "Enseignant",
+    "Team": "Équipe"
   },
   "password": "Mot de passe",
   "passwordBlankSpaces": "Le mot de passe ne doit pas contenir d'espaces.",

--- a/src/shared/components/FormComponents/TagsAutocompleteController/TagsAutocompleteController.tsx
+++ b/src/shared/components/FormComponents/TagsAutocompleteController/TagsAutocompleteController.tsx
@@ -124,10 +124,7 @@ export const TagsAutocompleteController = <
               const { children, ...restPaperProps } = paperProps;
 
               return (
-                <Paper
-                  {...restPaperProps}
-                  sx={{ maxHeight: '25.6rem' }} // Select All row + 4 rows
-                >
+                <Paper {...restPaperProps}>
                   <>
                     {options?.length ? (
                       <ListItem

--- a/src/shared/consts.tsx
+++ b/src/shared/consts.tsx
@@ -343,16 +343,16 @@ export const NON_UNIQUE_VALUE_MESSAGE = 'Non-unique value.';
 
 export const NULL_ANSWER = 'value: null';
 
-export enum ParticipantTag {
-  None = '',
-  Child = 'Child',
-  Parent = 'Parent',
-  Teacher = 'Teacher',
-}
+export const USER_SELECTABLE_PARTICIPANT_TAGS = ['', 'Child', 'Parent', 'Teacher'] as const;
+export type UserSelectableParticipantTag = (typeof USER_SELECTABLE_PARTICIPANT_TAGS)[number];
+
+export const PARTICIPANT_TAGS = [...USER_SELECTABLE_PARTICIPANT_TAGS, 'Team'] as const;
+export type ParticipantTag = (typeof PARTICIPANT_TAGS)[number];
 
 export const PARTICIPANT_TAG_ICONS: Record<ParticipantTag, Icons> = {
-  [ParticipantTag.None]: 'close',
-  [ParticipantTag.Child]: 'account',
-  [ParticipantTag.Parent]: 'users-outlined',
-  [ParticipantTag.Teacher]: 'teacher',
+  '': 'close',
+  Child: 'account',
+  Parent: 'users-outlined',
+  Teacher: 'teacher',
+  Team: 'team-outlined',
 };

--- a/src/shared/layouts/BaseLayout/components/TopBar/Breadcrumbs/Breadcrumbs.hooks.ts
+++ b/src/shared/layouts/BaseLayout/components/TopBar/Breadcrumbs/Breadcrumbs.hooks.ts
@@ -35,7 +35,10 @@ export const useBreadcrumbs = (restCrumbs?: Breadcrumb[]) => {
   const { pathname } = useLocation();
 
   const respondentLabel = useRespondentLabel({ hideNickname: !!enableMultiInformant });
-  const subjectLabel = useRespondentLabel({ isSubject: true });
+  const subjectLabel = useRespondentLabel({
+    hideNickname: !!enableMultiInformant,
+    isSubject: true,
+  });
   const { workspaceName } = workspaces.useData() ?? {};
   const { result } = applet.useAppletData() ?? {};
   const { getValues } = useFormContext() ?? {};

--- a/src/shared/mock.ts
+++ b/src/shared/mock.ts
@@ -109,7 +109,7 @@ export const mockedRespondentDetails = {
   hasIndividualSchedule: false,
   encryption: mockedEncryption,
   subjectId: mockedSubjectId1,
-  subjectTag: ParticipantTag.Child,
+  subjectTag: 'Child' as ParticipantTag,
 };
 export const mockedRespondent = {
   id: mockedRespondentId,
@@ -148,7 +148,7 @@ export const mockedRespondent2 = {
       hasIndividualSchedule: false,
       encryption: mockedEncryption,
       subjectId: mockedSubjectId2,
-      subjectTag: ParticipantTag.Child,
+      subjectTag: 'Child' as ParticipantTag,
     },
   ],
 };

--- a/src/shared/styles/theme.tsx
+++ b/src/shared/styles/theme.tsx
@@ -644,6 +644,9 @@ export const theme = createTheme({
             '.MuiCheckbox-root': {
               marginLeft: '-0.4rem',
             },
+            '.MuiAutocomplete-listbox': {
+              maxHeight: '20.8rem', // 4 rows
+            },
           },
         },
       },


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-6481](https://mindlogger.atlassian.net/browse/M2-6481)

Adds support for the Team tag that was recently supported by the BE. Now Participants whose subject corresponds to a Team Member have the "Team" tag shown wherever that participant is listed, including:
- the Participants list
- Take Now popup participants dropdown
- Add Manager > Reviewer participants dropdown
- The Participant Details screen header*
  - \* no tag had been shown here yet, and it required adding a new variant to `ParticipantSnippet`

Note that the "Team" tag is not selectable from the Participant > Add Full/Limited Account forms.

### 📸 Screenshots

#### Participants List

<img width="876" alt="Screenshot 2024-05-13 at 6 20 28 PM" src="https://github.com/ChildMindInstitute/mindlogger-admin/assets/1282772/bbecc6d7-6429-4338-8622-ec0eeba277e1">

#### Participant Details Header

<img width="938" alt="Screenshot 2024-05-13 at 6 21 05 PM" src="https://github.com/ChildMindInstitute/mindlogger-admin/assets/1282772/caa601ca-945d-4d6f-9c5e-204e4e529b52">

#### Take Now

<img width="599" alt="Screenshot 2024-05-13 at 6 48 17 PM" src="https://github.com/ChildMindInstitute/mindlogger-admin/assets/1282772/c27d9fbd-f034-434e-9f2d-7503166d110b">

#### Add Managers > Reviewer

<img width="700" alt="Screenshot 2024-05-13 at 6 44 25 PM" src="https://github.com/ChildMindInstitute/mindlogger-admin/assets/1282772/0dcc6bf0-8924-4eef-99b9-af255327b9ea">

### 🪤 Peer Testing

👉🏻 Make sure you are connected with the latest version of the `feature/multiinformant-metapod` branch on the BE.

1. Create a new applet with an activity and item.
2. Navigate to the applet's **Participants** tab.
    **Expected outcome:** The subject corresponding to the owner of the applet should be listed in the Participants list, showing the new Team tag
3. Tap the participant to open its Participant Details screen.
    **Expected outcome:** The Team tag should be shown in the header, and the breadcrumbs should be rendered [according to Figma](https://www.figma.com/file/6BNx63peNVzrHAF1FoZ78x/Multi-Informant-2024?type=design&node-id=1558-147074&mode=design&t=jAmxyXx4fsNyq22b-4).
4. Add a new team member via **Team > Add Team Member**, pick the Reviewer role, and open the Participants dropdown.
    **Expected outcome:** The owner should be listed in the dropdown with corresponding Team tag.
5. Complete and submit the form to create a new team member, then navigate to the Participants tab again.
    **Expected outcome:** The subjects corresponding to both the owner of the applet, and the team member you just created, should be listed in the Participants list, both showing the new Team tag.
6. Navigate to the Activities tab, perform Take Now on the activity, and open the dropdown.
    **Expected outcome:** Both the owner and the new team member should be listed in the dropdown, each with corresponding Team tag.

### ✏️ Notes

Also fixed a styling issue where MUI autocomplete dropdowns had a nested scrolling area within a parent scrolling area (a regression I'm responsible for 😅).