### PR TITLE
fix: Item settings: Only arrow next to the item setting name is clickable instead of the whole row (M2-6363)

### DIFF
--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/Settings/ItemSettingsController/ItemSettingsGroup/ItemSettingsGroup.styles.ts
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/Settings/ItemSettingsController/ItemSettingsGroup/ItemSettingsGroup.styles.ts
@@ -43,6 +43,7 @@ export const StyledSettingInfoIcon = styled(Svg)`
 `;
 
 export const StyledItemSettingsGroupHeader = styled(StyledFlexTopCenter)`
+  cursor: pointer;
   padding-right: ${theme.spacing(1.5)};
   justify-content: space-between;
   width: 100%;
@@ -66,6 +67,7 @@ export const StyledFormControl = styled(FormControl)`
 `;
 
 export const StyledFormLabel = styled(FormLabel)`
+  cursor: pointer;
   color: ${variables.palette.on_surface};
 
   &.Mui-focused {

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/Settings/ItemSettingsController/ItemSettingsGroup/ItemSettingsGroup.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/Settings/ItemSettingsController/ItemSettingsGroup/ItemSettingsGroup.tsx
@@ -77,11 +77,10 @@ export const ItemSettingsGroup = ({
       data-testid={`builder-activity-items-item-settings-group-container-${groupName}`}
     >
       <StyledFormControl>
-        <StyledItemSettingsGroupHeader sx={{ justifyContent: 'space-between' }}>
+        <StyledItemSettingsGroupHeader onClick={toggleBooleanState(setIsExpanded)}>
           <StyledFormLabel>{t(groupName, { context: inputType })}</StyledFormLabel>
           <StyledClearedButton
             sx={{ p: theme.spacing(1) }}
-            onClick={toggleBooleanState(setIsExpanded)}
             data-testid="builder-activity-items-item-settings-group-collapse"
           >
             <Svg id={isExpanded ? 'navigate-up' : 'navigate-down'} />


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [ ] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-6363](https://mindlogger.atlassian.net/browse/M2-6363)

### 📸 Screenshots
https://www.loom.com/share/dd5a875ada7045b78600f0fac4694f95?sid=6a8e1321-625f-4676-b539-abcaf6dd327f

### ✏️ Notes

<!--
Replace this line with anything else you think may be relevant or related PRs

If there are no notes, then delete this section.
-->
