### PR TITLE
fix(mi): Activities tab button alignment (M2-6620)

### DIFF
--- a/src/modules/Dashboard/features/Applet/Activities/ActivitiesToolbar/ActivitiesToolbar.tsx
+++ b/src/modules/Dashboard/features/Applet/Activities/ActivitiesToolbar/ActivitiesToolbar.tsx
@@ -21,7 +21,7 @@ export const ActivitiesToolbar = ({
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
   return (
-    <StyledFlexWrap sx={{ gap: 1.2, placeContent: 'space-between', ...sx }} {...otherProps}>
+    <StyledFlexWrap sx={{ gap: 1.2, ...sx }} {...otherProps}>
       {appletId && (
         <>
           {featureFlags.enableActivityFilterSort && (
@@ -58,7 +58,7 @@ export const ActivitiesToolbar = ({
             </StyledFlexTopCenter>
           )}
 
-          <StyledFlexWrap sx={{ gap: 1.2 }}>
+          <StyledFlexWrap sx={{ ml: 'auto', gap: 1.2 }}>
             {featureFlags.enableActivityAssign && (
               <Button
                 data-testid={`${dataTestId}-assign`}


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-6620](https://mindlogger.atlassian.net/browse/M2-6620)

Makes sure Activities header right button alignment remains right-aligned when `enableActivityFilterSort` feature flag is turned off.

### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

| Before                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| <img width="1174" alt="Screenshot 2024-05-16 at 2 22 22 PM" src="https://github.com/ChildMindInstitute/mindlogger-admin/assets/1282772/37d8d961-b7eb-4b0e-ab99-1530c126ba0d"> | <img width="1172" alt="Screenshot 2024-05-16 at 2 21 52 PM" src="https://github.com/ChildMindInstitute/mindlogger-admin/assets/1282772/1c8fe134-5d60-4d26-8ad2-2935e570f3ed"> |

### 🪤 Peer Testing

- Add the line `features.enableActivityFilterSort = false;` to just before the `return` statement of `useFeatureFlags.ts`
- Navigate to Applet > Activities
    **Expected outcome:** Header buttons should be correctly right-aligned.
