### PR TITLE
fix: Hide unfinished UI, part 2 (M2-6487, M2-6666)

### DIFF
--- a/src/modules/Dashboard/components/FlowGrid/FlowGrid.hooks.tsx
+++ b/src/modules/Dashboard/components/FlowGrid/FlowGrid.hooks.tsx
@@ -71,9 +71,9 @@ export function useFlowGridMenu({
       { type: MenuItemType.Divider },
       {
         'data-testid': `${testId}-flow-assign`,
-        disabled: true,
         icon: <Svg id="add" />,
         title: t('assignActivity'),
+        isDisplayed: featureFlags.enableActivityAssign,
       },
       {
         'data-testid': `${testId}-flow-take-now`,

--- a/src/modules/Dashboard/features/Participant/Activities/Activities.tsx
+++ b/src/modules/Dashboard/features/Participant/Activities/Activities.tsx
@@ -18,7 +18,6 @@ import { Activity, ActivityFlow } from 'redux/modules';
 import { StyledFlexColumn } from 'shared/styles';
 import { page } from 'resources';
 
-import { ParticipantActivitiesToolbar } from './ParticipantActivitiesToolbar';
 import { UnlockAppletPopup } from '../../Respondents/Popups/UnlockAppletPopup';
 
 const dataTestId = 'dashboard-applet-participant-activities';
@@ -133,14 +132,19 @@ export const Activities = () => {
     <StyledFlexColumn sx={{ gap: 2.4, maxHeight: '100%' }}>
       {isLoading && <Spinner />}
 
-      <ParticipantActivitiesToolbar
-        appletId={appletId}
-        data-testid={dataTestId}
-        sx={{ px: 3.2, pt: 3.2 }}
-      />
+      {/*
+        TODO: Re-enable when implementing toolbar functionality.
+        To be implemented in  M2-5530, M2-5445, and M2-5710.
+
+        <ParticipantActivitiesToolbar
+          appletId={appletId}
+          data-testid={dataTestId}
+          sx={{ px: 3.2, pt: 3.2 }}
+        />
+      */}
 
       {showContent && (
-        <StyledFlexColumn sx={{ gap: 4.8, overflow: 'auto', p: 3.2, pt: 0 }}>
+        <StyledFlexColumn sx={{ gap: 4.8, overflow: 'auto', p: 3.2 }}>
           {!!flows?.length && (
             <StyledFlexColumn component="section" sx={{ gap: 1.6 }}>
               <ActivitiesSectionHeader title={t('flows')} count={flows?.length ?? 0} />


### PR DESCRIPTION
### 📝 Description

🔗 [M2-6487](https://mindlogger.atlassian.net/browse/M2-6487): [Participant Details] Hide Placeholder Elements Not Intended for R1
🔗 [M2-6666](https://mindlogger.atlassian.net/browse/M2-6666): [Admin Panel][Activities Overview] 'Assign activity' action presents for Activity flow

This PR hides the toolbar for the Participant Details > Activities screen. None of the UI in that toolbar is functional, and is only scheduled for later releases.

I also updated the `FlowGrid` so that the action items passed to its' `FlowSummaryCard`s conditionally included the "Assign Activity" option based on the state of the `enableActivityAssign` feature flag. Previously, it was always included.

### 📸 Screenshots

| Before | After |
|-|-|
| ![localhost_3000_dashboard_fdb0c9fd-0e62-40b6-94a8-7fc6a55f4da8_participants_0052fa59-fbb9-4822-81c8-589693c49434](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/10b4b376-3bdd-475e-b060-021c1a9d291a) | ![localhost_3000_dashboard_fdb0c9fd-0e62-40b6-94a8-7fc6a55f4da8_participants_bbac6f55-9f8b-4155-a23d-cca5c60c1688 (1)](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/598a7734-e30f-405a-b69e-ddcd162e61ce) | 

### 🪤 Peer Testing

> [!TIP]
> You may want to temporarily add the line `features.enableActivityAssign = false;` prior to `return features;` in the `useFeatureFlags` hook to quickly simulate the expected UI state when this flag is not set.

1. Navigate to the **Participant Details > Activities** screen for an applet and observe that the UI has been appropriately updated. 

[M2-6487]: https://mindlogger.atlassian.net/browse/M2-6487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[M2-6666]: https://mindlogger.atlassian.net/browse/M2-6666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ