### PR TITLE
fix: Update "Manager" breadcrumbs (M2-6528)

### DIFF
--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -739,7 +739,7 @@
   "lv6Heading": "Lv6 Heading",
   "male": "Male",
   "manager": "Manager",
-  "managers": "Managers",
+  "managers": "Team",
   "mar": "March",
   "mark": "Mark",
   "matrixSelect": "Matrix Select",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -738,7 +738,7 @@
   "loadingEllipsis": "Chargement...",
   "male": "Homme",
   "manager": "Gestionnaire",
-  "managers": "Gestionnaires",
+  "managers": "Équipe",
   "mar": "Mars",
   "mark": "Marquer",
   "matrixSelect": "Sélection de Matrice",

--- a/src/shared/layouts/BaseLayout/components/TopBar/Breadcrumbs/Breadcrumbs.hooks.ts
+++ b/src/shared/layouts/BaseLayout/components/TopBar/Breadcrumbs/Breadcrumbs.hooks.ts
@@ -121,13 +121,12 @@ export const useBreadcrumbs = (restCrumbs?: Breadcrumb[]) => {
         navPath: page.dashboardApplets,
       });
     }
-    if (pathname.includes('managers')) {
+
+    if (pathname.includes('managers') && !appletId) {
       newBreadcrumbs.push({
         icon: 'manager-outlined',
         label: t('managers'),
-        navPath: appletId
-          ? generatePath(page.appletManagers, { appletId })
-          : page.dashboardManagers,
+        navPath: page.dashboardManagers,
       });
     }
 


### PR DESCRIPTION
### 📝 Description

🔗 [M2-6528](https://mindlogger.atlassian.net/browse/M2-6528): [FE][Team] Remove or replace 'Managers' from various nav items

This PR replaces the term "Managers" in the top-level Dashboard with "Team", and removes the "Managers" breadcrumb previously visible on the Applet > Teams page.

### 📸 Screenshots

| Before | After |
|-|-|
| ![localhost_3000_dashboard_fdb0c9fd-0e62-40b6-94a8-7fc6a55f4da8_managers](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/1bd1bb13-5ab6-4a98-8f76-d7e78ce082f0) | ![localhost_3000_auth (1)](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/1aa62725-8037-4d45-8c32-b4eb6661ca00) |
| ![localhost_3000_dashboard_fdb0c9fd-0e62-40b6-94a8-7fc6a55f4da8_managers (1)](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/c580034e-32eb-4d42-8bf3-2f3398cd4a4a) | ![localhost_3000_auth](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/c5b2ffad-a4e3-40c1-875c-bbf5ea90e397) |


[M2-6528]: https://mindlogger.atlassian.net/browse/M2-6528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ