### PR TITLE
Undo changes to LabeledUserDropdown

### DIFF
--- a/src/modules/Dashboard/components/FlowGrid/FlowGrid.hooks.tsx
+++ b/src/modules/Dashboard/components/FlowGrid/FlowGrid.hooks.tsx
@@ -86,7 +86,6 @@ export function useFlowGridMenu({
                   targetSubject: {
                     ...subject,
                     secretId: subject.secretUserId,
-                    userId: subject.userId,
                   },
                 }
               : undefined;

--- a/src/modules/Dashboard/components/TakeNowModal/LabeledDropdown/LabeledUserDropdown.test.tsx
+++ b/src/modules/Dashboard/components/TakeNowModal/LabeledDropdown/LabeledUserDropdown.test.tsx
@@ -62,12 +62,7 @@ describe('LabeledUserDropdown', () => {
   });
 
   test('Uses value if provided', () => {
-    const testValue = {
-      id: 'id',
-      nickname: 'nickname',
-      secretId: 'secretId',
-      isLimitedAccount: true,
-    };
+    const testValue = { id: 'id', nickname: 'nickname', secretId: 'secretId' };
 
     const { queryByDisplayValue } = renderWithProviders(
       <LabeledUserDropdown
@@ -88,7 +83,7 @@ describe('LabeledUserDropdown', () => {
   });
 
   test('Renders value correctly without nickname', () => {
-    const testValue = { id: 'id', secretId: 'secretId', isLimitedAccount: true };
+    const testValue = { id: 'id', secretId: 'secretId' };
 
     const { queryByDisplayValue } = renderWithProviders(
       <LabeledUserDropdown

--- a/src/modules/Dashboard/components/TakeNowModal/LabeledDropdown/LabeledUserDropdown.types.ts
+++ b/src/modules/Dashboard/components/TakeNowModal/LabeledDropdown/LabeledUserDropdown.types.ts
@@ -1,15 +1,9 @@
 import { AutocompleteProps } from '@mui/material/Autocomplete/Autocomplete';
-import { SxProps, Theme } from '@mui/system';
 
 import { ParticipantSnippetInfo } from 'modules/Dashboard/components/ParticipantSnippet';
 
 export type ParticipantDropdownOption = ParticipantSnippetInfo & {
-  /**
-   * Subject ID
-   */
   id: string;
-
-  userId?: string | null;
 };
 
 export type LabeledUserDropdownProps = Omit<
@@ -18,7 +12,7 @@ export type LabeledUserDropdownProps = Omit<
 > & {
   label: string;
   name: string;
-  tooltip?: string;
+  tooltip: string;
   placeholder: string;
   options: ParticipantDropdownOption[];
   value: ParticipantDropdownOption | null;
@@ -27,8 +21,5 @@ export type LabeledUserDropdownProps = Omit<
     search: string,
   ) => ParticipantDropdownOption[] | Promise<ParticipantDropdownOption[]>;
   debounce?: number;
-  canShowWarningMessage?: boolean;
   'data-testid'?: string;
-  sx?: SxProps<Theme>;
-  showGroups?: boolean;
 };

--- a/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.tsx
+++ b/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.tsx
@@ -44,7 +44,6 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
 
       return {
         id: participant.details[0].subjectId,
-        userId: participant.id,
         secretId: stringSecretIds,
         nickname: stringNicknames,
         tag: participant.details[0].subjectTag,
@@ -77,8 +76,7 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
   );
 
   const filterTeamMembers = useCallback(
-    (option: ParticipantDropdownOption): boolean =>
-      allowedTeamMembers.some((manager) => manager.id === option.userId),
+    (option: ParticipantDropdownOption): boolean => true,
     [allowedTeamMembers],
   );
 
@@ -161,9 +159,7 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
       defaultSourceSubject,
     );
     const [isSelfReporting, setIsSelfReporting] = useState<boolean>(true);
-    const [loggedInUser, setLoggedInUser] = useState<ParticipantDropdownOption | null>(
-      defaultSourceSubject?.userId ? defaultSourceSubject : null,
-    );
+    const [loggedInUser, setLoggedInUser] = useState<ParticipantDropdownOption | null>(null);
 
     const handleSubmit = useCallback(() => {
       if (targetSubject && sourceSubject && (isSelfReporting || loggedInUser) && activity?.id) {
@@ -171,14 +167,6 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
         url.searchParams.set('startActivityOrFlow', activity.id);
         url.searchParams.set('sourceSubjectId', sourceSubject.id);
         url.searchParams.set('targetSubjectId', targetSubject.id);
-
-        // This conditional shouldn't be necessary, but TS is unable to propagate the type information from
-        // (isSelfReporting || loggedInUser), so we have to check them again (or use the forbidden non-null assertion)
-        if (isSelfReporting && sourceSubject.userId) {
-          url.searchParams.set('respondentId', sourceSubject.userId);
-        } else if (!isSelfReporting && loggedInUser && loggedInUser.userId) {
-          url.searchParams.set('respondentId', loggedInUser.userId);
-        }
 
         // TODO: Remove once the web app is updated to process `targetSubjectId` instead of `subjectId`
         url.searchParams.set('subjectId', targetSubject.id);
@@ -236,25 +224,24 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
                 <LabeledUserDropdown
                   label={t('takeNow.modal.sourceSubjectLabel')}
                   name={'participant'}
+                  tooltip=""
                   placeholder={t('takeNow.modal.sourceSubjectPlaceholder')}
                   value={sourceSubject}
                   options={participantsAndTeamMembers}
                   onChange={(option) => {
                     setSourceSubject(option);
                     if (option) {
-                      setIsSelfReporting(!!option.userId);
+                      setIsSelfReporting(true);
                     }
                   }}
                   data-testid={`${dataTestId}-take-now-modal-participant-dropdown`}
-                  canShowWarningMessage={true}
-                  showGroups={true}
                 />
                 <FormControlLabel
                   control={<Checkbox sx={{ margin: 0, width: 48, height: 48 }} />}
                   sx={{ gap: 0.4 }}
                   checked={isSelfReporting}
                   onChange={(_e, checked) => setIsSelfReporting(checked)}
-                  disabled={!sourceSubject?.userId}
+                  disabled={false}
                   label={t('takeNow.modal.sourceSubjectCheckboxLabel')}
                 />
               </StyledFlexColumn>
@@ -262,6 +249,7 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
                 <LabeledUserDropdown
                   label={t('takeNow.modal.loggedInUserLabel')}
                   name={'loggedInUser'}
+                  tooltip=""
                   sx={{ gap: 1, pl: 5.2 }}
                   placeholder={t('takeNow.modal.loggedInUserPlaceholder')}
                   value={loggedInUser}
@@ -269,13 +257,13 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
                   onChange={setLoggedInUser}
                   data-testid={`${dataTestId}-take-now-modal-subject-dropdown`}
                   handleSearch={handleSearch}
-                  showGroups={true}
                 />
               </RenderIf>
             </StyledFlexColumn>
             <LabeledUserDropdown
               label={t('takeNow.modal.targetSubjectLabel')}
               name={'subject'}
+              tooltip=""
               placeholder={t('takeNow.modal.targetSubjectPlaceholder')}
               value={targetSubject}
               options={participants}

--- a/src/modules/Dashboard/features/Participant/Activities/Activities.tsx
+++ b/src/modules/Dashboard/features/Participant/Activities/Activities.tsx
@@ -91,7 +91,6 @@ export const Activities = () => {
               if (subjectId && subject) {
                 options.targetSubject = {
                   id: subjectId,
-                  userId: subject.result.userId,
                   secretId: subject.result.secretUserId,
                   nickname: subject.result.nickname,
                   tag: subject.result.tag,

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataHeader/RespondentDataHeader.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataHeader/RespondentDataHeader.tsx
@@ -57,7 +57,6 @@ export const RespondentDataHeader = ({
     openTakeNowModal(activity, {
       targetSubject: {
         id: subject.id,
-        userId: subject.userId,
         secretId: subject.secretUserId,
         nickname: subject.nickname,
       },


### PR DESCRIPTION
A PR to help investigate why builds on this branch are failing. Changes to these files have been reverted:
- `src/modules/Dashboard/components/TakeNowModal/LabeledDropdown/LabeledUserDropdown.test.tsx`
- `src/modules/Dashboard/components/TakeNowModal/LabeledDropdown/LabeledUserDropdown.tsx`
- `src/modules/Dashboard/components/TakeNowModal/LabeledDropdown/LabeledUserDropdown.types.ts`

Consequently, these files had to be updated:
- `src/modules/Dashboard/components/FlowGrid/FlowGrid.hooks.tsx`
- `src/modules/Dashboard/components/TakeNowModal/TakeNowModal.tsx`
- `src/modules/Dashboard/features/Participant/Activities/Activities.tsx`
- `src/modules/Dashboard/features/RespondentData/RespondentDataHeader/RespondentDataHeader.tsx`