### PR TITLE
fix(mi): Fix empty team table (M2-6517)

### DIFF
--- a/src/modules/Dashboard/features/Managers/Managers.tsx
+++ b/src/modules/Dashboard/features/Managers/Managers.tsx
@@ -215,9 +215,10 @@ export const Managers = () => {
 
   useEffect(() => {
     if (!ownerId) return;
+    if (!appletId) return;
 
     executeGetWorkspaceInfoApi({ ownerId });
-  }, [ownerId, executeGetWorkspaceInfoApi]);
+  }, [ownerId, appletId, executeGetWorkspaceInfoApi]);
 
   if (isForbidden) return noPermissionsComponent;
 


### PR DESCRIPTION
### 📝 Description

Skip call to `executeGetWorkspaceInfoApi` unless we're viewing an applet.

🔗 [Jira Ticket M2-6517](https://mindlogger.atlassian.net/browse/M2-6517)


### 📸 Screenshots

| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| ![CleanShot 2024-05-22 at 10 47 19@2x](https://github.com/ChildMindInstitute/mindlogger-admin/assets/2916156/8679f37c-06da-4fa2-9899-f8fd0a862582) | ![CleanShot 2024-05-22 at 10 47 07@2x](https://github.com/ChildMindInstitute/mindlogger-admin/assets/2916156/cafbe6c3-b139-4dc1-adca-def16d52971a) |

After creating an applet:
![CleanShot 2024-05-22 at 10 48 25@2x](https://github.com/ChildMindInstitute/mindlogger-admin/assets/2916156/9d71c918-3ca3-4aa6-9bbb-f9a01cbfb744)

### 🪤 Peer Testing

<!-- If peer testing is not needed, then delete this section -->
<!-- Uncomment out any of the following as needed:           -->
<!-- **Requires `npm install`**     -->

* Use a workspace without Applets or create a new account
* Navigate to Dashboard > Team/Managers tab
* The "No managers yet" empty state should appear
