### PR TITLE
fix: Conditionally pass user ID to schedule-related components (M2-6775)

### DIFF
--- a/src/modules/Dashboard/features/Applet/Schedule/CreateEventPopup/CreateEventPopup.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/CreateEventPopup/CreateEventPopup.test.tsx
@@ -28,6 +28,8 @@ export const preloadedState = {
     },
   },
   calendarEvents: {
+    alwaysAvailableVisible: { data: true },
+    scheduledVisible: { data: true },
     createEventsData: {
       data: [
         {

--- a/src/modules/Dashboard/features/Applet/Schedule/Legend/Legend.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/Legend/Legend.tsx
@@ -215,7 +215,7 @@ export const Legend = ({
           name={respondentName}
           onClose={() => setClearScheduledEventsPopupVisible(false)}
           open={clearScheduledEventsPopupVisible}
-          userId={userId}
+          userId={hasIndividualSchedule && userId ? userId : undefined}
         />
       )}
 
@@ -224,7 +224,7 @@ export const Legend = ({
         defaultStartDate={new Date()}
         open={createEventPopupVisible}
         setCreateEventPopupVisible={setCreateEventPopupVisible}
-        userId={userId}
+        userId={hasIndividualSchedule && userId ? userId : undefined}
       />
     </StyledLegend>
   );

--- a/src/modules/Dashboard/features/Participant/Schedule/Schedule.tsx
+++ b/src/modules/Dashboard/features/Participant/Schedule/Schedule.tsx
@@ -84,7 +84,7 @@ export const ParticipantSchedule = () => {
               width: theme.spacing(32),
             }}
           />
-          <Calendar userId={userId ?? undefined} />
+          <Calendar userId={hasIndividualSchedule && userId ? userId : undefined} />
         </>
       )}
     </Box>


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

🔗 [M2-6775](https://mindlogger.atlassian.net/browse/M2-6775): [Admin Panel] It is possible to update Default schedule from the particular participant's individual schedule page

This PR addresses an issue with the Schedule page, where attempts to update the _default_ schedule from the Participant Details page for a subject with a default schedule would attempt to modify events as if they were on an _individual_ schedule.

This was because we were unconditionally passing the subject's User ID if available (i.e. if the subject was a _Full_ participant), instead of only if they were actively on an individual schedule.

### 📸 Screenshots

#### Create/Edit Event

| Before | After |
|-|-|
| ![create-edit-before](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/58cc9eee-7257-4c38-9034-7c15d4f48591) | ![create-edit-after](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/19887a6d-3a10-4467-8936-e24b219574d0) |

#### Clear Scheduled Events

| Before | After |
|-|-|
| ![clear-before](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/c3fce227-8992-42d3-97a3-ee87c8077ec2) | ![clear-after](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/0ddea8d8-f4d6-44cd-a8b9-2f70aa6d4e2b) |


### 🪤 Peer Testing

From the **Participant Details > Schedule** page for a *full* participant on the *default* schedule…
1. Press the "Create Event" button. Proceed to create an event.
2. Notice that the event has been created and applied to the default schedule.
3. Refresh the page. Notice that the subject is still on the default schedule, and changes to the schedule have persisted.
4. Press the "Clear Scheduled Events" button. Confirm your choice in the resulting dialog.
5. Notice that scheduled events have been removed from the default schedule.
6. Refresh the page. Notice that the subject is still on the default schedule, and changes to the schedule have persisted.

From the **Participant Details > Schedule** page for a *full* participant on the *individual* schedule…
1. Press the "Create Event" button. Proceed to create an event.
2. Notice that the event has been created and applied to the individual schedule.
3. Refresh the page. Notice that the subject is still on the individual schedule, and changes to the schedule have persisted.
4. Press the "Clear Scheduled Events" button. Confirm your choice in the resulting dialog.
5. Notice that scheduled events have been removed from the individual schedule.
6. Refresh the page. Notice that the subject is still on the individual schedule, and changes to the schedule have persisted.

[M2-6775]: https://mindlogger.atlassian.net/browse/M2-6775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ