### PR TITLE
fix(mi): Add `/add-user` redirect (M2-6737)

### DIFF
--- a/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
+import { Button } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { Controller, useForm, useWatch } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 
 import { Modal, Spinner, ToggleButtonGroup, ToggleButtonVariants } from 'shared/components';
-import { StyledErrorText, StyledModalWrapper } from 'shared/styles';
+import { StyledErrorText, StyledFlexEnd, StyledModalWrapper } from 'shared/styles';
 import { useFormError } from 'modules/Dashboard/hooks';
 import { NON_UNIQUE_VALUE_MESSAGE, Roles } from 'shared/consts';
 import { Mixpanel, getErrorMessage } from 'shared/utils';
@@ -173,13 +174,19 @@ export const AddParticipantPopup = ({
       return (
         <>
           <Modal
+            hasActions={false}
             open={popupVisible && !publicLinkDialogOpen}
             width="73.6"
             onClose={() => handleClose(refetchOnClose)}
             onBackdropClick={null}
-            onSubmit={handleNext}
+            footer={
+              <StyledFlexEnd sx={{ width: '100%' }}>
+                <Button onClick={handleNext} variant="contained">
+                  {t('next')}
+                </Button>
+              </StyledFlexEnd>
+            }
             title={t('addParticipant')}
-            buttonText={t('next')}
             data-testid={dataTestid}
           >
             <StyledModalWrapper sx={{ display: 'flex', flexDirection: 'column', gap: 2.6 }}>

--- a/src/modules/Dashboard/features/Participants/Participants.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { generatePath, useNavigate, useParams } from 'react-router-dom';
+import { generatePath, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 
 import { EmptyDashboardTable } from 'modules/Dashboard/components/EmptyDashboardTable';
 import {
@@ -49,6 +49,8 @@ import { DataExportPopup, EditRespondentPopup, RemoveRespondentPopup } from '../
 
 export const Participants = () => {
   const { appletId } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const showAddParticipant = !!searchParams.get('showAddParticipant');
   const navigate = useNavigate();
   const { t } = useTranslation('app');
   const timeAgo = useTimeAgo();
@@ -59,6 +61,21 @@ export const Participants = () => {
 
   const rolesData = workspaces.useRolesData();
   const { ownerId } = workspaces.useData() || {};
+
+  const handleToggleAddParticipant = () => {
+    setSearchParams(
+      (params) => {
+        if (showAddParticipant) {
+          params.delete('showAddParticipant');
+
+          return params;
+        }
+
+        return { ...params, showAddParticipant: true };
+      },
+      { replace: true },
+    );
+  };
 
   const { execute: getWorkspaceRespondents } = useAsync(
     getWorkspaceRespondentsApi,
@@ -100,7 +117,6 @@ export const Participants = () => {
     return getWorkspaceRespondents(params);
   });
 
-  const [addParticipantPopupVisible, setAddParticipantPopupVisible] = useState(false);
   const [dataExportPopupVisible, setDataExportPopupVisible] = useState(false);
   const [removeAccessPopupVisible, setRemoveAccessPopupVisible] = useState(false);
   const [editRespondentPopupVisible, setEditRespondentPopupVisible] = useState(false);
@@ -208,7 +224,7 @@ export const Participants = () => {
   };
 
   const addParticipantOnClose = (shouldRefetch: boolean) => {
-    setAddParticipantPopupVisible(false);
+    handleToggleAddParticipant();
     setChosenAppletData(null);
     shouldRefetch && handleReload();
   };
@@ -421,7 +437,7 @@ export const Participants = () => {
           {appletId && (
             <AddParticipantButton
               variant="contained"
-              onClick={() => setAddParticipantPopupVisible(true)}
+              onClick={handleToggleAddParticipant}
               data-testid={`${dataTestid}-add`}
             >
               {t('addParticipant')}
@@ -439,10 +455,7 @@ export const Participants = () => {
               {appletId ? (
                 <>
                   {t('noParticipantsForApplet')}
-                  <AddParticipantButton
-                    onClick={() => setAddParticipantPopupVisible(true)}
-                    variant="contained"
-                  >
+                  <AddParticipantButton onClick={handleToggleAddParticipant} variant="contained">
                     {t('addParticipant')}
                   </AddParticipantButton>
                 </>
@@ -456,9 +469,9 @@ export const Participants = () => {
         data-testid={`${dataTestid}-table`}
         {...tableProps}
       />
-      {appletId && addParticipantPopupVisible && (
+      {appletId && showAddParticipant && (
         <AddParticipantPopup
-          popupVisible={addParticipantPopupVisible}
+          popupVisible={showAddParticipant}
           appletId={appletId}
           onClose={addParticipantOnClose}
         />


### PR DESCRIPTION
### 📝 Description

🔗 [M2-6737](https://mindlogger.atlassian.net/browse/M2-6737): [FE][Router] - Forward existing `/add-user` to Add Participant dialog

This PR updates route handling for the `dashboard/${appletId}/add-user` route. Because (when the `enableMultiInformant` feature flag is set) this route is no longer represented by a distinct tab on the Applet's Dashboard, and because the relevant functionality has been migrated to the "Add Participant" popup, we now redirect to `dashboard/${appletID}/participants`, with the "Add Participant" popup visible as part of the initial state.

To support this change, I swapped the state value for controlling the visibility of the "Add Participant" popup to instead use query parameters via React Router's `useSearchParams` hook.

### 🪤 Peer Testing

With the `enableMultiInformant` feature flag **set**…

1. Attempt to navigate to the `/add-user` route. For example, from `/dashboard/${appletId}/participants`, edit the URL bar in your browser to replace `/participants` with `/add-user`.
2. Observe that you have been redirected to `/dashboard/${appletId}/participants`, and the "Add Participant" popup is open.

With the `enableMultiInformant` feature flag **unset**…

1. Attempt to navigate to the `/add-user` route. For example, select the "Add Users" tab from the Applet Dashboard's list of tabs.
2. Observe that you can navigate to this page normally.


[M2-6737]: https://mindlogger.atlassian.net/browse/M2-6737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ