### PR TITLE
feature: Add `activity` & `subject`-specific data exports (M2-6736)

### DIFF
--- a/src/modules/Dashboard/components/ActivityGrid/ActivityGrid.hooks.tsx
+++ b/src/modules/Dashboard/components/ActivityGrid/ActivityGrid.hooks.tsx
@@ -20,7 +20,11 @@ import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 
 import { useTakeNowModal } from '../TakeNowModal/TakeNowModal';
 
-export const useActivityGrid = (dataTestId: string, activitiesData: ActivitiesData | null) => {
+export const useActivityGrid = (
+  dataTestId: string,
+  activitiesData: ActivitiesData | null,
+  onClickExportData?: (activityId: string) => void,
+) => {
   const navigate = useNavigate();
   const { appletId } = useParams();
   const workspaceRoles = workspaces.useRolesData();
@@ -53,10 +57,9 @@ export const useActivityGrid = (dataTestId: string, activitiesData: ActivitiesDa
         );
       },
       exportData: ({ context }: MenuActionProps<ActivityActionProps>) => {
-        const { activityId } = context || {};
-        // TODO: Implement export data
-        // https://mindlogger.atlassian.net/browse/M2-6039
-        alert(`TODO: Export data (${activityId})`);
+        if (context?.activityId) {
+          onClickExportData?.(context?.activityId);
+        }
       },
       assignActivity: ({ context }: MenuActionProps<ActivityActionProps>) => {
         const { activityId } = context || {};

--- a/src/modules/Dashboard/components/FlowGrid/FlowGrid.hooks.tsx
+++ b/src/modules/Dashboard/components/FlowGrid/FlowGrid.hooks.tsx
@@ -24,10 +24,12 @@ export function useFlowGridMenu({
   hasParticipants = false,
   testId = '',
   subject,
+  onClickExportData,
 }: {
   appletId?: string;
   hasParticipants?: boolean;
   testId?: string;
+  onClickExportData?: (flowId: string) => void;
   subject?: RespondentDetails;
 }) {
   const { t } = useTranslation('app');
@@ -64,11 +66,13 @@ export function useFlowGridMenu({
         title: t('editFlow'),
       },
       {
-        // TODO: Implement export data
-        // https://mindlogger.atlassian.net/browse/M2-6039
-        // https://mindlogger.atlassian.net/browse/M2-6736
         'data-testid': `${testId}-flow-export`,
-        disabled: true,
+        action: () => {
+          if (flow?.id) {
+            onClickExportData?.(flow?.id);
+          }
+        },
+        disabled: !flow?.id,
         icon: <Svg id="export" />,
         title: t('exportData'),
         isDisplayed: canAccessData,
@@ -105,7 +109,20 @@ export function useFlowGridMenu({
         title: t('takeNow.menuItem'),
       },
     ],
-    [appletId, canDoTakeNow, canEdit, navigate, openTakeNowModal, subject, t, testId],
+    [
+      appletId,
+      canAccessData,
+      canAssign,
+      canDoTakeNow,
+      canEdit,
+      navigate,
+      onClickExportData,
+      openTakeNowModal,
+      showDivider,
+      subject,
+      t,
+      testId,
+    ],
   );
 
   return {

--- a/src/modules/Dashboard/components/FlowGrid/FlowGrid.tsx
+++ b/src/modules/Dashboard/components/FlowGrid/FlowGrid.tsx
@@ -1,21 +1,30 @@
-import { StyledFlexColumn } from 'shared/styles';
+import { useCallback, useState } from 'react';
+
 import { FlowSummaryCard } from 'modules/Dashboard/components/FlowSummaryCard';
+import { DataExportPopup } from 'modules/Dashboard/features/Respondents/Popups';
 import { Activity } from 'redux/modules';
+import { StyledFlexColumn } from 'shared/styles';
 
 import { FlowGridProps } from './FlowGrid.types';
 import { useFlowGridMenu } from './FlowGrid.hooks';
 
 export const FlowGrid = ({
-  appletId,
+  applet,
   activities = [],
   flows = [],
   subject,
   ...otherProps
 }: FlowGridProps) => {
+  const [showExportPopup, setShowExportPopup] = useState(false);
+  const [flowId, setFlowId] = useState<string>();
   const { getActionsMenu, TakeNowModal } = useFlowGridMenu({
-    appletId,
+    appletId: applet?.id,
     hasParticipants: true,
     subject,
+    onClickExportData: useCallback((flowId: string) => {
+      setFlowId(flowId);
+      setShowExportPopup(true);
+    }, []),
   });
 
   return (
@@ -42,6 +51,19 @@ export const FlowGrid = ({
       </StyledFlexColumn>
 
       <TakeNowModal />
+
+      {showExportPopup && (
+        <DataExportPopup
+          chosenAppletData={applet ?? null}
+          filters={{ flowId, targetSubjectId: subject?.id }}
+          isAppletSetting
+          popupVisible={showExportPopup}
+          setPopupVisible={() => {
+            setShowExportPopup(false);
+            setFlowId(undefined);
+          }}
+        />
+      )}
     </>
   );
 };

--- a/src/modules/Dashboard/components/FlowGrid/FlowGrid.types.ts
+++ b/src/modules/Dashboard/components/FlowGrid/FlowGrid.types.ts
@@ -1,10 +1,10 @@
 import { BoxProps } from '@mui/material';
 
 import { RespondentDetails } from 'modules/Dashboard/types';
-import { Activity, ActivityFlow } from 'redux/modules';
+import { Activity, ActivityFlow, SingleApplet } from 'redux/modules';
 
 export interface FlowGridProps extends BoxProps {
-  appletId?: string;
+  applet?: SingleApplet | undefined;
   flows?: ActivityFlow[];
   activities?: Activity[];
   subject?: RespondentDetails;

--- a/src/modules/Dashboard/features/Applet/Activities/Activities.tsx
+++ b/src/modules/Dashboard/features/Applet/Activities/Activities.tsx
@@ -82,7 +82,7 @@ export const Activities = () => {
             <StyledFlexColumn component="section" sx={{ gap: 1.6 }}>
               <ActivitiesSectionHeader title={t('flows')} count={flows?.length ?? 0} />
 
-              <FlowGrid appletId={appletId} activities={flowActivities} flows={flows} />
+              <FlowGrid applet={appletData} activities={flowActivities} flows={flows} />
             </StyledFlexColumn>
           )}
 

--- a/src/modules/Dashboard/features/Participant/Activities/Activities.tsx
+++ b/src/modules/Dashboard/features/Participant/Activities/Activities.tsx
@@ -175,8 +175,8 @@ export const Activities = () => {
               <ActivitiesSectionHeader title={t('flows')} count={flows?.length ?? 0} />
 
               <FlowGrid
-                appletId={appletId}
                 activities={flowActivities}
+                applet={appletData}
                 flows={flows}
                 subject={subject?.result}
               />

--- a/src/modules/Dashboard/features/Respondents/Popups/DataExportPopup/DataExportPopup.tsx
+++ b/src/modules/Dashboard/features/Respondents/Popups/DataExportPopup/DataExportPopup.tsx
@@ -28,6 +28,7 @@ import { ChosenAppletData } from '../../Respondents.types';
 import { getExportDataSuffix } from './DataExportPopup.utils';
 
 export const DataExportPopup = ({
+  filters = {},
   popupVisible,
   isAppletSetting,
   setPopupVisible,
@@ -88,6 +89,7 @@ export const DataExportPopup = ({
         await exportDataSucceed({
           getDecryptedAnswers,
           suffix: pageLimit > 1 ? getExportDataSuffix(1) : '',
+          filters,
         })(firstPageData);
 
         if (pageLimit > 1) {
@@ -104,6 +106,7 @@ export const DataExportPopup = ({
             await exportDataSucceed({
               getDecryptedAnswers,
               suffix: getExportDataSuffix(page),
+              filters,
             })(nextPageData);
           }
         }

--- a/src/modules/Dashboard/features/Respondents/Popups/DataExportPopup/DataExportPopup.tsx
+++ b/src/modules/Dashboard/features/Respondents/Popups/DataExportPopup/DataExportPopup.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import get from 'lodash.get';
 import { useFormContext } from 'react-hook-form';
@@ -37,6 +37,7 @@ export const DataExportPopup = ({
   setChosenAppletData,
   'data-testid': dataTestid,
 }: DataExportPopupProps) => {
+  const dataExportingRef = useRef(false);
   const { getValues } = useFormContext<ExportDataFormValues>() ?? {};
   const { t } = useTranslation('app');
   const [dataIsExporting, setDataIsExporting] = useState(false);
@@ -52,7 +53,7 @@ export const DataExportPopup = ({
   const { encryption } = chosenAppletData ?? {};
 
   const handleDataExportSubmit = async () => {
-    if (dataIsExporting || !appletId) {
+    if (dataIsExporting || dataExportingRef.current || !appletId) {
       return;
     }
 
@@ -71,6 +72,7 @@ export const DataExportPopup = ({
   const executeAllPagesOfExportData = useCallback(
     async ({ appletId, targetSubjectIds }: ExecuteAllPagesOfExportData) => {
       try {
+        dataExportingRef.current = true;
         setDataIsExporting(true);
         const formFromDate = getValues?.().fromDate as Date;
         const formToDate = getValues?.().toDate as Date;
@@ -119,6 +121,7 @@ export const DataExportPopup = ({
         setActiveModal(Modals.ExportError);
         await sendLogFile({ error });
       } finally {
+        dataExportingRef.current = false;
         setDataIsExporting(false);
       }
     },

--- a/src/modules/Dashboard/features/Respondents/Popups/DataExportPopup/DataExportPopup.types.ts
+++ b/src/modules/Dashboard/features/Respondents/Popups/DataExportPopup/DataExportPopup.types.ts
@@ -2,10 +2,12 @@ import { Dispatch, SetStateAction } from 'react';
 
 import { Row } from 'shared/components';
 import { SingleApplet } from 'shared/state';
+import { ExportDataFilters } from 'shared/utils';
 
 import { ChosenAppletData } from '../../Respondents.types';
 
 export type DataExportPopupProps = {
+  filters?: ExportDataFilters;
   popupVisible: boolean;
   isAppletSetting?: boolean;
   setPopupVisible: Dispatch<SetStateAction<boolean>>;

--- a/src/shared/utils/exportData/exportDataSucceed.test.ts
+++ b/src/shared/utils/exportData/exportDataSucceed.test.ts
@@ -47,6 +47,7 @@ describe('exportDataSucceed', () => {
     expect(prepareDataUtils.prepareData).toHaveBeenCalledWith(
       mockedExportData,
       mockedGetDecryptedAnswers,
+      undefined,
     );
     expect(exportTemplateUtils.exportTemplate).toHaveBeenCalledTimes(2);
     expect(exportTemplateUtils.exportTemplate).toHaveBeenNthCalledWith(1, {

--- a/src/shared/utils/exportData/exportDataSucceed.ts
+++ b/src/shared/utils/exportData/exportDataSucceed.ts
@@ -11,15 +11,17 @@ import { exportTemplate } from '../exportTemplate';
 import { exportCsvZip } from './exportCsvZip';
 import { exportMediaZip } from './exportMediaZip';
 import { getReportZipName, ZipFile } from './getReportName';
-import { prepareData } from './prepareData';
+import { ExportDataFilters, prepareData } from './prepareData';
 
 export const exportDataSucceed =
   ({
     getDecryptedAnswers,
     suffix,
+    filters,
   }: {
     getDecryptedAnswers: ReturnType<typeof useDecryptedActivityData>;
     suffix: string;
+    filters?: ExportDataFilters;
   }) =>
   async (result: ExportDataResult) => {
     if (!result) return;
@@ -32,7 +34,7 @@ export const exportDataSucceed =
       stabilityTrackerItemsData,
       abTrailsItemsData,
       flankerItemsData,
-    } = await prepareData(result, getDecryptedAnswers);
+    } = await prepareData(result, getDecryptedAnswers, filters);
 
     await exportTemplate({
       data: reportData,


### PR DESCRIPTION
### 📝 Description

🔗 [M2-6736](https://mindlogger.atlassian.net/browse/M2-6736): [Export Data] Missing Exports for Activity and Participant data from CTA or menu

This PR implements the ability to filter entries that do not match a given `activity_id`, `activity_flow_id`, `target_subject_id`, or any combination thereof from the data to be exported when clicking an "Export Data" option.

Specifically, I've updated the "Export Data" menu items in the dropdown menus for both Flows and Activities on both the `Applet > Activities` and `Applet > Participant Detail > Activities` screens to add these filters as needed.

Now, when clicking the "Export Data" option on an activity, the resulting data set should be filtered to _only_ include data for the given activity. Additionally, if performing this action from **Participant Details**, the resulting dataset will additionally be filtered to _only_ include data for the given subject.

Finally, this PR also fixes an issue where the `DataExportPopup` would call its submit function multiple times, resulting in multiple identical files being downloaded simultaneously.

> [!Note]
> There's a number of additional changes I'd like to make here, but I prioritized attempting to  implement the necessary functionality in time for deployment tomorrow. These include:
> 1. I think it makes sense to update the `/answers/applet/{applet_id}/data` endpoint to support parameters for the necessary IDs we need to filter by, instead of applying these filters after-the-fact on the frontend. This would amount of data we need to fetch, transform, and then end up discarding. It looks like this endpoint already supports a `targetSubjectIds` parameter, which expects an array of strings, but the response did not change when I included that parameter.
> 2. There's a bunch of repetitive logic to wire up the `DataExportPopup` for activities. I think it would make sense to handle it in the `ActivityGrid` component and then re-use that, much like the `FlowGrid` component does, but this would involve refactoring a lot of unrelated functionality that I'd prefer to leave alone, given the time sensitivity of this task. It also would have introduced a lot of conflicts with https://github.com/ChildMindInstitute/mindlogger-admin/pull/1761, which was not yet merged at the time I was working on this.
> 3. My fix for multiple files being downloaded involves using a ref, which doesn't require waiting for a re-render/state update when checking if the "isExporting" flag is set. I also kept the existing state value, because the rendered UI depends on it. This should work fine, but I think it's worth investigating a more appropriate fix when I have more time, as I think having both `state` and `ref` values that are ostensibly meant to represent the same value is potentially confusing.
> 4. More thorough tests. 🫠

### 📸 Screenshots

#### Activity Exports

| All Participants | Specific Participant |
|-|-|
| ![activity](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/c2e66a39-89e2-442e-bbae-46feb2796a14) | ![subject-activity](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/3eb93f9c-29d2-4a4a-9989-a93607e8a777) |

#### Activity Flow Exports

| All Participants | Specific Participant |
|-|-|
| ![flow](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/eafdf028-93b0-4bfc-a819-d1942cb410df) | ![flow-export](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/4006b780-6916-4e57-a5cc-2a6186ba971c) |

### 🪤 Peer Testing

Given an applet with a number of activities, and participants that have completed different subsets of those activities…

1. On the **Applet > Activities** screen…
    1. Click a Flow Card's dropdown menu, and choose "Export Data".
    2. After exporting, open the resulting `.csv`, and observe that it only includes entries where the `activity_flow_id` column matches the ID of the Flow you selected.
    3. Click an Activity Card's dropdown menu, and choose "Export Data".
    4. After exporting, open the resulting `.csv`, and observe that it only includes entries where the `activity_id` column matches the ID of the Activity you selected.
1. On the **Applet > Participant Details > Activities** screen…
    1. Click an Flow Card's dropdown menu, and choose "Export Data"
    2. After exporting, open the resulting `.csv`, and observe that it only includes entries where `activity_flow_id` matches the ID of the Flow you selected, and `target_subject_id` matches the ID of the Subject you are viewing.
    3. Click an Activity Card's dropdown menu, and choose "Export Data".
    4. After exporting, open the resulting `.csv`, and observe that it only includes entries where `activity_id` matches the ID of the Activity you selected, and `target_subject_id` matches the ID of the Subject you are viewing.

[M2-6736]: https://mindlogger.atlassian.net/browse/M2-6736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ