### PR TITLE
fix(mi): Handle empty workspaces when checking permissions (M2-6903)

### DIFF
--- a/src/modules/Dashboard/features/Managers/Managers.tsx
+++ b/src/modules/Dashboard/features/Managers/Managers.tsx
@@ -33,12 +33,15 @@ export const Managers = () => {
   const { appletId } = useParams();
   const [managersData, setManagersData] = useState<ManagersData | null>(null);
   const [workspaceInfo, setWorkspaceInfo] = useState<WorkspaceInfo | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
   const dataTestId = 'dashboard-managers';
 
   const rolesData = workspaces.useRolesData();
   const { ownerId } = workspaces.useData() || {};
-  const roles = appletId ? rolesData?.data?.[appletId] : undefined;
+  const roles =
+    appletId && rolesData?.data
+      ? rolesData?.data?.[appletId]
+      : [...new Set(Object.values(rolesData.data || []).flat())];
   const canViewTeam = checkIfFullAccess(roles);
 
   const { execute } = useAsync(
@@ -226,7 +229,9 @@ export const Managers = () => {
     executeGetWorkspaceInfoApi({ ownerId });
   }, [ownerId, appletId, executeGetWorkspaceInfoApi]);
 
-  if (isForbidden || !canViewTeam) return noPermissionsComponent;
+  // If there are no roles available we're looking at our own empty workspace
+  const showsForbiddenComponent = isForbidden || (roles.length && !canViewTeam);
+  if (showsForbiddenComponent) return noPermissionsComponent;
 
   return (
     <StyledBody sx={{ p: 3.2 }}>


### PR DESCRIPTION
- [x] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description


🔗 [Jira Ticket M2-6903](https://mindlogger.atlassian.net/browse/M2-6903)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Changes include:

- Changed `isLoading` default value to `false` in Respondents and Managers components
- Group all applet's roles for role check validations, and handle empty applet list

### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

**Looking at your own applet's Team tab resulted in "No permission"**
| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| ![CleanShot 2024-06-04 at 10 55 21](https://github.com/ChildMindInstitute/mindlogger-admin/assets/2916156/7f95ab63-224d-4b20-a77c-d1910a607fdb) | ![CleanShot 2024-06-04 at 10 54 31](https://github.com/ChildMindInstitute/mindlogger-admin/assets/2916156/621f4d69-6713-4661-9ac9-7f625fcfc6c7) |

**Looking at the Respondents tab resulted in "No permission" modal, replaced with `ForbiddenComponent`**
| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| ![CleanShot 2024-06-04 at 10 56 11](https://github.com/ChildMindInstitute/mindlogger-admin/assets/2916156/70648bba-518e-4c32-8051-38d078f06dbe) | ![CleanShot 2024-06-04 at 11 01 27](https://github.com/ChildMindInstitute/mindlogger-admin/assets/2916156/215d09b9-ada6-4ac1-9f87-c34bfd56339e) |

### 🪤 Peer Testing

* Using an empty workspace (no participants, no applets) navigate to the Team and Respondents tab
* The text should say "No Managers yet" or "No Respondents yet"

If the account is a member of another workspace, navigating to the Dashboard of the shared workspace should result in the correct view depending on the role:

| Role | View Team | View Respondents |
| ------------- | ------------- | ------------- |
| Owner/Manager | ✅ | ✅ |
| Coordinator | ❌ | ✅ |
| Reviewer | ❌ | ✅ |
| Editor | ❌ | ❌ |

