### PR TITLE
fix: Reviewer's Assessment Activity must not be displayed in the Activity Flow Builder (M2-6852)

### DIFF
--- a/src/modules/Builder/features/Activities/Activities.tsx
+++ b/src/modules/Builder/features/Activities/Activities.tsx
@@ -17,7 +17,7 @@ import {
 import { BuilderContainer } from 'shared/features';
 import { PerfTaskType } from 'shared/consts';
 import { pluck, Mixpanel } from 'shared/utils';
-import { getUniqueName } from 'modules/Builder/utils';
+import { getUniqueName, getUpdatedActivityFlows } from 'modules/Builder/utils';
 import { useCustomFormContext } from 'modules/Builder/hooks';
 
 import { DeleteActivityModal } from './DeleteActivityModal';
@@ -113,22 +113,7 @@ export const Activities = () => {
   };
 
   const handleActivityRemove = (index: number, activityKey: string) => {
-    const newActivityFlows = activityFlows.reduce(
-      (acc: AppletFormValues['activityFlows'], flow) => {
-        if (flow.reportIncludedActivityName === activityKey) {
-          flow.reportIncludedActivityName = '';
-          flow.reportIncludedItemName = '';
-        }
-        const items = flow.items?.filter((item) => item.activityKey !== activityKey);
-        if (items && items.length > 0) {
-          acc.push({ ...flow, items });
-        }
-
-        return acc;
-      },
-      [],
-    );
-
+    const newActivityFlows = getUpdatedActivityFlows(activityFlows, activityKey);
     removeActivity(index);
     setValue('activityFlows', newActivityFlows);
   };

--- a/src/modules/Builder/features/ActivityAbout/ActivityAbout.tsx
+++ b/src/modules/Builder/features/ActivityAbout/ActivityAbout.tsx
@@ -1,4 +1,5 @@
 import { ChangeEvent } from 'react';
+import { useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { Box } from '@mui/material';
 
@@ -42,13 +43,25 @@ export const ActivityAbout = () => {
 
   useRedirectIfNoMatchedActivity();
 
-  const { control, setValue, watch } = useCustomFormContext();
+  const { control, setValue } = useCustomFormContext();
   const { fieldName, activity } = useCurrentActivity();
   const hasVariableAmongItems = useCheckIfItemsHaveVariables();
   const hasRequiredItems = useCheckIfItemsHaveRequiredItems();
 
-  const activityItems = watch(`${fieldName}.items`);
-  const activityFlows: ActivityFlowFormValues[] = watch('activityFlows');
+  const [activityItems, activityFlows, activityImage, splashScreen]: [
+    ItemFormValues[],
+    ActivityFlowFormValues[],
+    string,
+    string,
+  ] = useWatch({
+    name: [
+      `${fieldName}.items`,
+      'activityFlows',
+      `${fieldName}.image`,
+      `${fieldName}.splashScreen`,
+    ],
+  });
+
   const hasUnsupportedReviewableItemTypes = activityItems?.some(
     (item: ItemFormValues) =>
       ![...itemsForReviewableActivity, ''].includes(item.responseType as ItemResponseType),
@@ -76,7 +89,7 @@ export const ActivityAbout = () => {
         <Uploader
           {...commonUploaderProps}
           setValue={(val: string) => setValue(`${fieldName}.image`, val)}
-          getValue={() => watch(`${fieldName}.image`)}
+          getValue={() => activityImage}
           description={t('uploadImg', { size: byteFormatter(MAX_FILE_SIZE_25MB) })}
           data-testid="builder-activity-about-image"
         />
@@ -89,7 +102,7 @@ export const ActivityAbout = () => {
         <Uploader
           {...commonUploaderProps}
           setValue={(val: string) => setValue(`${fieldName}.splashScreen`, val)}
-          getValue={() => watch(`${fieldName}.splashScreen`)}
+          getValue={() => splashScreen}
           description={t('uploadImg', { size: byteFormatter(MAX_FILE_SIZE_25MB) })}
           cropRatio={CropRatio.SplashScreen}
           data-testid="builder-activity-about-splash-screen"
@@ -99,9 +112,9 @@ export const ActivityAbout = () => {
   ];
 
   const handleIsReviewableChange = (event: ChangeEvent<HTMLInputElement>) => {
-    if (!event.target.checked) return;
+    if (!event.target.checked || !activity) return;
 
-    const activityKey = getEntityKey(activity || {});
+    const activityKey = getEntityKey(activity);
 
     const newActivityFlows = getUpdatedActivityFlows(activityFlows, activityKey);
     setValue('activityFlows', newActivityFlows);

--- a/src/modules/Builder/features/ActivityFlow/ActivityFlow.tsx
+++ b/src/modules/Builder/features/ActivityFlow/ActivityFlow.tsx
@@ -13,7 +13,11 @@ import { DndDroppable, Item, ItemUiType, InsertItem } from 'modules/Builder/comp
 import { page } from 'resources';
 import { getNewActivityFlow } from 'modules/Builder/pages/BuilderApplet/BuilderApplet.utils';
 import { REACT_HOOK_FORM_KEY_NAME } from 'modules/Builder/consts';
-import { ActivityFlowFormValues, ActivityFormValues } from 'modules/Builder/types';
+import {
+  ActivityFlowFormValues,
+  ActivityFlowItem,
+  ActivityFormValues,
+} from 'modules/Builder/types';
 import { getUniqueName } from 'modules/Builder/utils';
 import { useCustomFormContext } from 'modules/Builder/hooks';
 
@@ -69,10 +73,17 @@ export const ActivityFlow = () => {
     );
 
   const handleAddActivityFlow = (positionToAdd?: number) => {
-    const flowItems = activities.map((activity) => ({
-      key: uuidv4(),
-      activityKey: getEntityKey(activity),
-    }));
+    // remove Reviewer Assessment Activity from Flow Items list
+    const flowItems = activities.reduce((acc: ActivityFlowItem[], activity) => {
+      if (!activity.isReviewable) {
+        acc.push({
+          key: uuidv4(),
+          activityKey: getEntityKey(activity),
+        });
+      }
+
+      return acc;
+    }, []);
 
     const newActivityFlow = { ...getNewActivityFlow(), items: flowItems };
 

--- a/src/modules/Builder/features/ActivityFlowBuilder/ActivityFlowBuilder.test.tsx
+++ b/src/modules/Builder/features/ActivityFlowBuilder/ActivityFlowBuilder.test.tsx
@@ -218,14 +218,14 @@ describe('Activity Flow Builder', () => {
   });
 
   test('Ensures no reviewable activities remain when adding/replacing an activity)', async () => {
+    const addActivityRegexp = new RegExp(`^${mockedActivityFlowBuilderTestid}-add-activity-\\d+$`);
+
     renderActivityFlowBuilder(mockedAppletFormDataWithReviewableActivity);
 
     const addActivity = screen.getByTestId(`${mockedActivityFlowBuilderTestid}-add`);
     await userEvent.click(addActivity);
 
-    const activitiesInAddActivity = screen.getAllByTestId(
-      new RegExp(`^${mockedActivityFlowBuilderTestid}-add-activity-\\d+$`),
-    );
+    const activitiesInAddActivity = screen.getAllByTestId(addActivityRegexp);
     expect(activitiesInAddActivity).toHaveLength(1);
     expect(screen.queryByText('Another Activity')).not.toBeInTheDocument();
 
@@ -239,9 +239,7 @@ describe('Activity Flow Builder', () => {
     });
 
     await userEvent.click(screen.getByTestId(`${mockedActivityFlowBuilderTestid}-flow-0-replace`));
-    const activitiesInReplaceActivity = screen.getAllByTestId(
-      new RegExp(`^${mockedActivityFlowBuilderTestid}-add-activity-\\d+$`),
-    );
+    const activitiesInReplaceActivity = screen.getAllByTestId(addActivityRegexp);
     expect(activitiesInReplaceActivity).toHaveLength(1);
     expect(screen.queryByText('Another Activity')).not.toBeInTheDocument();
   });

--- a/src/modules/Builder/features/ActivityFlowBuilder/ActivityFlowBuilder.tsx
+++ b/src/modules/Builder/features/ActivityFlowBuilder/ActivityFlowBuilder.tsx
@@ -1,4 +1,4 @@
-import { useState, MouseEvent } from 'react';
+import { useState, MouseEvent, useMemo } from 'react';
 import { Box } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { useFieldArray } from 'react-hook-form';
@@ -54,7 +54,10 @@ export const ActivityFlowBuilder = () => {
   });
   const formActivities: AppletFormValues['activities'] = watch('activities');
   // remove Reviewer Assessment Activity from Activities list
-  const { activities, activitiesIdsObjects } = getNonReviewableActivities(formActivities);
+  const { activities, activitiesIdsObjects } = useMemo(
+    () => getNonReviewableActivities(formActivities),
+    [formActivities],
+  );
   const dataTestid = 'builder-activity-flows-builder';
 
   const handleFlowActivityDuplicate = (index: number) => {

--- a/src/modules/Builder/features/ActivityFlowBuilder/ActivityFlowBuilder.tsx
+++ b/src/modules/Builder/features/ActivityFlowBuilder/ActivityFlowBuilder.tsx
@@ -1,7 +1,7 @@
 import { useState, MouseEvent, useMemo } from 'react';
 import { Box } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { useFieldArray } from 'react-hook-form';
+import { useFieldArray, useWatch } from 'react-hook-form';
 import { useParams } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
 import { DragDropContext, Draggable, DragDropContextProps } from 'react-beautiful-dnd';
@@ -9,7 +9,11 @@ import { DragDropContext, Draggable, DragDropContextProps } from 'react-beautifu
 import { Menu } from 'shared/components';
 import { BuilderContainer } from 'shared/features';
 import { Item, ItemUiType, DndDroppable } from 'modules/Builder/components';
-import { ActivityFlowItem, AppletFormValues } from 'modules/Builder/types';
+import {
+  ActivityFlowFormValues,
+  ActivityFlowItem,
+  ActivityFormValues,
+} from 'modules/Builder/types';
 import { useRedirectIfNoMatchedActivityFlow, useCustomFormContext } from 'modules/Builder/hooks';
 import { REACT_HOOK_FORM_KEY_NAME } from 'modules/Builder/consts';
 import { StyledTitleMedium, theme, variables } from 'shared/styles';
@@ -34,9 +38,10 @@ export const ActivityFlowBuilder = () => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [flowActivityToUpdateIndex, setFlowActivityToUpdateIndex] = useState<number | null>(null);
   const { t } = useTranslation('app');
-  const { control, watch, setValue } = useCustomFormContext();
+  const { control, setValue } = useCustomFormContext();
   const { activityFlowId } = useParams();
-  const activityFlows: AppletFormValues['activityFlows'] = watch('activityFlows');
+  const [formActivities, activityFlows]: [ActivityFormValues[], ActivityFlowFormValues[]] =
+    useWatch({ name: ['activities', 'activityFlows'] });
   const activityFlowIndex = getActivityFlowIndex(activityFlows, activityFlowId || '');
   const currentActivityFlow = activityFlows[activityFlowIndex];
   const activityFlowName = `activityFlows.${activityFlowIndex}`;
@@ -52,7 +57,6 @@ export const ActivityFlowBuilder = () => {
     name: `${activityFlowName}.items`,
     keyName: REACT_HOOK_FORM_KEY_NAME,
   });
-  const formActivities: AppletFormValues['activities'] = watch('activities');
   // remove Reviewer Assessment Activity from Activities list
   const { activities, activitiesIdsObjects } = useMemo(
     () => getNonReviewableActivities(formActivities),

--- a/src/modules/Builder/features/ActivityFlowBuilder/ActivityFlowBuilder.tsx
+++ b/src/modules/Builder/features/ActivityFlowBuilder/ActivityFlowBuilder.tsx
@@ -8,7 +8,6 @@ import { DragDropContext, Draggable, DragDropContextProps } from 'react-beautifu
 
 import { Menu } from 'shared/components';
 import { BuilderContainer } from 'shared/features';
-import { getObjectFromList } from 'shared/utils';
 import { Item, ItemUiType, DndDroppable } from 'modules/Builder/components';
 import { ActivityFlowItem, AppletFormValues } from 'modules/Builder/types';
 import { useRedirectIfNoMatchedActivityFlow, useCustomFormContext } from 'modules/Builder/hooks';
@@ -20,6 +19,7 @@ import {
   getActivityFlowIndex,
   getFlowBuilderActions,
   getMenuItems,
+  getNonReviewableActivities,
 } from './ActivityFlowBuilder.utils';
 import { ActivityFlowBuilderHeader } from './ActivityFlowBuilderHeader';
 import { GetMenuItemsType } from './ActivityFlowBuilder.types';
@@ -52,7 +52,9 @@ export const ActivityFlowBuilder = () => {
     name: `${activityFlowName}.items`,
     keyName: REACT_HOOK_FORM_KEY_NAME,
   });
-  const activities: AppletFormValues['activities'] = watch('activities');
+  const formActivities: AppletFormValues['activities'] = watch('activities');
+  // remove Reviewer Assessment Activity from Activities list
+  const { activities, activitiesIdsObjects } = getNonReviewableActivities(formActivities);
   const dataTestid = 'builder-activity-flows-builder';
 
   const handleFlowActivityDuplicate = (index: number) => {
@@ -120,8 +122,6 @@ export const ActivityFlowBuilder = () => {
     move(source.index, destination.index);
   };
 
-  const activitiesIdsObjects = getObjectFromList(activities);
-
   useRedirectIfNoMatchedActivityFlow();
 
   return (
@@ -129,6 +129,7 @@ export const ActivityFlowBuilder = () => {
       title={t('activityFlowBuilder')}
       Header={ActivityFlowBuilderHeader}
       headerProps={{
+        activities,
         clearFlowBtnDisabled: activityFlowItems?.length === 0,
         onAddFlowActivity: handleFlowActivityAdd,
         onClearFlow: handleClearFlow,

--- a/src/modules/Builder/features/ActivityFlowBuilder/ActivityFlowBuilder.types.ts
+++ b/src/modules/Builder/features/ActivityFlowBuilder/ActivityFlowBuilder.types.ts
@@ -1,6 +1,6 @@
 import { MouseEvent } from 'react';
 
-import { ActivityFlowItem, AppletFormValues } from 'modules/Builder/types';
+import { ActivityFlowItem, ActivityFormValues, AppletFormValues } from 'modules/Builder/types';
 
 export enum GetMenuItemsType {
   AddActivity,
@@ -23,4 +23,9 @@ export type GetFlowBuilderActions = {
   removeItem: () => void;
   replaceItemActionActive: boolean;
   'data-testid'?: string;
+};
+
+export type NonReviewableActivities = {
+  activities: ActivityFormValues[];
+  activitiesIdsObjects: Record<string, ActivityFormValues>;
 };

--- a/src/modules/Builder/features/ActivityFlowBuilder/ActivityFlowBuilder.utils.tsx
+++ b/src/modules/Builder/features/ActivityFlowBuilder/ActivityFlowBuilder.utils.tsx
@@ -3,9 +3,15 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { Svg } from 'shared/components/Svg';
 import { ItemType } from 'modules/Builder/components';
-import { ActivityFlowFormValues } from 'modules/Builder/types';
+import { ActivityFlowFormValues, ActivityFormValues } from 'modules/Builder/types';
+import { getEntityKey } from 'shared/utils/getEntityKey';
 
-import { GetFlowBuilderActions, GetMenuItems, GetMenuItemsType } from './ActivityFlowBuilder.types';
+import {
+  GetFlowBuilderActions,
+  GetMenuItems,
+  GetMenuItemsType,
+  NonReviewableActivities,
+} from './ActivityFlowBuilder.types';
 
 const checkOnIdOrKey = (checkId: string) => (entity: ActivityFlowFormValues) =>
   (entity.id || entity.key) === checkId;
@@ -61,3 +67,17 @@ export const getFlowBuilderActions = ({
     'data-testid': `${dataTestid}-remove`,
   },
 ];
+
+export const getNonReviewableActivities = (activities: ActivityFormValues[]) =>
+  activities.reduce(
+    (acc: NonReviewableActivities, activity) => {
+      if (!activity.isReviewable) {
+        const key = getEntityKey(activity);
+        acc.activities.push(activity);
+        acc.activitiesIdsObjects[key] = activity;
+      }
+
+      return acc;
+    },
+    { activities: [], activitiesIdsObjects: {} },
+  );

--- a/src/modules/Builder/features/ActivityFlowBuilder/ActivityFlowBuilderHeader/ActivityFlowBuilderHeader.tsx
+++ b/src/modules/Builder/features/ActivityFlowBuilder/ActivityFlowBuilderHeader/ActivityFlowBuilderHeader.tsx
@@ -5,8 +5,6 @@ import { Button } from '@mui/material';
 import { Svg, ButtonWithMenu } from 'shared/components';
 import { StyledBuilderContainerHeader } from 'shared/features';
 import { falseReturnFunc } from 'shared/utils';
-import { AppletFormValues } from 'modules/Builder/types';
-import { useCustomFormContext } from 'modules/Builder/hooks';
 import { StyledFlexTopCenter, theme } from 'shared/styles';
 
 import { ClearFlowModal } from '../ClearFlowModal';
@@ -20,11 +18,10 @@ export const ActivityFlowBuilderHeader = ({
   headerProps,
 }: ActivityFlowBuilderHeaderProps) => {
   const { t } = useTranslation('app');
-  const { watch } = useCustomFormContext();
-  const activities: AppletFormValues['activities'] = watch('activities');
   const [clearFlowModalVisible, setClearFlowModalVisible] = useState(false);
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const {
+    activities = [],
     clearFlowBtnDisabled = false,
     onAddFlowActivity = falseReturnFunc,
     onClearFlow = falseReturnFunc,

--- a/src/modules/Builder/features/ActivityFlowBuilder/ActivityFlowBuilderHeader/ActivityFlowBuilderHeader.types.ts
+++ b/src/modules/Builder/features/ActivityFlowBuilder/ActivityFlowBuilderHeader/ActivityFlowBuilderHeader.types.ts
@@ -1,9 +1,12 @@
 import { ReactNode } from 'react';
 
+import { ActivityFormValues } from 'modules/Builder/types';
+
 export type ActivityFlowBuilderHeaderProps = {
   isSticky?: boolean;
   children: ReactNode;
   headerProps?: {
+    activities?: ActivityFormValues[];
     clearFlowBtnDisabled?: boolean;
     onAddFlowActivity?: (key: string) => void;
     onClearFlow?: () => void;

--- a/src/modules/Builder/pages/BuilderApplet/BuilderApplet.types.ts
+++ b/src/modules/Builder/pages/BuilderApplet/BuilderApplet.types.ts
@@ -1,4 +1,4 @@
-import { Condition, Item, ScoreReport } from 'shared/state';
+import { Activity, ActivityFlow, Condition, Item, ScoreReport } from 'shared/state';
 
 import { flankerItems, getABTrailsItems, getGyroscopeOrTouchItems } from './BuilderApplet.utils';
 
@@ -18,3 +18,9 @@ type FlankerItemsType = typeof flankerItems;
 type GyroscopeOrTouchItemsType = ReturnType<typeof getGyroscopeOrTouchItems>;
 type ABTrailsItemsType = ReturnType<typeof getABTrailsItems>;
 export type PerformanceTaskItems = FlankerItemsType | GyroscopeOrTouchItemsType | ABTrailsItemsType;
+
+export type GetActivityFlows = {
+  activityFlows: ActivityFlow[];
+  activities: Activity[];
+  nonReviewableKeys: string[];
+};

--- a/src/modules/Builder/pages/BuilderApplet/BuilderApplet.utils.tsx
+++ b/src/modules/Builder/pages/BuilderApplet/BuilderApplet.utils.tsx
@@ -10,7 +10,6 @@ import { Svg } from 'shared/components/Svg';
 import { Theme } from 'modules/Builder/api';
 import {
   Activity,
-  ActivityFlow,
   Condition,
   ConditionalLogic,
   Config,
@@ -54,6 +53,7 @@ import {
 import {
   ABTrailsItemQuestions,
   ActivityFlowFormValues,
+  ActivityFlowItem,
   ActivityFormValues,
   AppletFormValues,
   CorrectPress,
@@ -91,7 +91,12 @@ import {
   ordinalStrings,
   SAMPLE_SIZE,
 } from './BuilderApplet.const';
-import { GetSectionConditions, GetMessageItem, PerformanceTaskItems } from './BuilderApplet.types';
+import {
+  GetSectionConditions,
+  GetMessageItem,
+  PerformanceTaskItems,
+  GetActivityFlows,
+} from './BuilderApplet.types';
 
 const { t } = i18n;
 
@@ -740,21 +745,34 @@ const getActivityItems = (items: Item[]) =>
       )
     : [];
 
-const getActivityFlows = (activityFlows: ActivityFlow[], activities: Activity[]) =>
-  // eslint-disable-next-line unused-imports/no-unused-vars
-  activityFlows.map(({ order, ...activityFlow }) => ({
+const getActivityFlows = ({ activityFlows, activities, nonReviewableKeys }: GetActivityFlows) =>
+  activityFlows.map(({ order: _order, ...activityFlow }) => ({
     ...activityFlow,
     description: getDictionaryText(activityFlow.description),
-    items: activityFlow.items?.map(({ id, activityId, activityKey, key }) => ({
-      id,
-      key,
-      activityKey: activityKey || activityId || '',
-    })),
+    items: activityFlow.items?.reduce(
+      (acc: ActivityFlowItem[], { id, activityId, activityKey, key }) => {
+        const calculatedActivityKey = activityKey || activityId;
+
+        // remove Reviewer Assessment Activity from previously saved Flow Items list
+        if (nonReviewableKeys.includes(calculatedActivityKey)) {
+          acc.push({
+            id,
+            key,
+            activityKey: calculatedActivityKey || '',
+          });
+        }
+
+        return acc;
+      },
+      [],
+    ),
     ...getEntityReportFields({
       reportActivity: activityFlow.reportIncludedActivityName ?? '',
       reportItem: activityFlow.reportIncludedItemName ?? '',
       activities,
       type: FlowReportFieldsPrepareType.NameToKey,
+      // remove Reviewer Assessment Activity from previously saved Report Config for Activity Flow
+      nonReviewableKeys,
     }),
   }));
 
@@ -971,36 +989,57 @@ const getActivitySubscaleSetting = (
   };
 };
 
+export const getActivities = (appletActivities: Activity[]) =>
+  appletActivities.reduce(
+    (
+      acc: {
+        activities: ActivityFormValues[];
+        nonReviewableKeys: string[];
+      },
+      activity,
+    ) => {
+      if (!activity.isReviewable) {
+        acc.nonReviewableKeys.push(getEntityKey(activity));
+      }
+      const items = getActivityItems(activity.items);
+
+      acc.activities.push({
+        ...activity,
+        description: getDictionaryText(activity.description),
+        items,
+        ...getEntityReportFields({
+          reportItem: activity.reportIncludedItemName,
+          activityItems: activity.items,
+          type: FlowReportFieldsPrepareType.NameToKey,
+        }),
+        conditionalLogic: getActivityConditionalLogic(activity.items),
+        scoresAndReports: getScoresAndReports(activity),
+        ...(activity.subscaleSetting && {
+          subscaleSetting: getActivitySubscaleSetting(activity.subscaleSetting, items),
+        }),
+      } as ActivityFormValues);
+
+      return acc;
+    },
+    { activities: [], nonReviewableKeys: [] },
+  );
+
 export const getDefaultValues = (appletData?: SingleApplet, defaultThemeId?: string) => {
   if (!appletData) return getNewApplet();
+
+  const { activities, nonReviewableKeys } = getActivities(appletData.activities || []);
 
   const processedApplet: AppletFormValues = {
     ...appletData,
     description: getDictionaryText(appletData.description),
     about: getDictionaryText(appletData.about),
     themeId: appletData.themeId ?? defaultThemeId ?? '',
-    activities: appletData.activities
-      ? appletData.activities.map((activity) => {
-          const items = getActivityItems(activity.items);
-
-          return {
-            ...activity,
-            description: getDictionaryText(activity.description),
-            items,
-            ...getEntityReportFields({
-              reportItem: activity.reportIncludedItemName,
-              activityItems: activity.items,
-              type: FlowReportFieldsPrepareType.NameToKey,
-            }),
-            conditionalLogic: getActivityConditionalLogic(activity.items),
-            scoresAndReports: getScoresAndReports(activity),
-            ...(activity.subscaleSetting && {
-              subscaleSetting: getActivitySubscaleSetting(activity.subscaleSetting, items),
-            }),
-          } as ActivityFormValues;
-        })
-      : [],
-    activityFlows: getActivityFlows(appletData.activityFlows, appletData.activities),
+    activities,
+    activityFlows: getActivityFlows({
+      activityFlows: appletData.activityFlows,
+      activities: appletData.activities,
+      nonReviewableKeys,
+    }),
     streamEnabled: !!appletData.streamEnabled,
   };
 

--- a/src/modules/Builder/utils/getEntityReportFields.test.ts
+++ b/src/modules/Builder/utils/getEntityReportFields.test.ts
@@ -56,4 +56,21 @@ describe('getEntityReportFields', () => {
       expect(result.reportIncludedActivityName).toBe(expected.reportIncludedActivityName);
     }
   });
+
+  test('should return empty reportIncludedActivityName and reportIncludedItemName for NameToKey type and reviewable activity', () => {
+    const nonReviewableKeys = ['activity-key-1'];
+
+    const result = getEntityReportFields({
+      reportActivity: 'Activity-2',
+      reportItem: 'Item-2',
+      activities,
+      type: Type.NameToKey,
+      nonReviewableKeys,
+    });
+
+    expect(result).toEqual({
+      reportIncludedActivityName: '',
+      reportIncludedItemName: '',
+    });
+  });
 });

--- a/src/modules/Builder/utils/getEntityReportFields.ts
+++ b/src/modules/Builder/utils/getEntityReportFields.ts
@@ -11,6 +11,7 @@ export type GetEntityReportFields<T, K> = {
   activities?: T;
   activityItems?: K;
   type: FlowReportFieldsPrepareType;
+  nonReviewableKeys?: string[];
 };
 
 export const getEntityReportFields = <
@@ -27,6 +28,7 @@ export const getEntityReportFields = <
   activities,
   activityItems,
   type,
+  nonReviewableKeys,
 }: GetEntityReportFields<T, K>) => {
   const isKeyToName = type === FlowReportFieldsPrepareType.KeyToName;
   let reportIncludedActivityName = '';
@@ -37,6 +39,16 @@ export const getEntityReportFields = <
     activities?.find(
       (activity) => (isKeyToName ? getEntityKey(activity) : activity.name) === reportActivity,
     );
+
+  if (
+    !isKeyToName &&
+    selectedReportActivity &&
+    nonReviewableKeys &&
+    !nonReviewableKeys.includes(getEntityKey(selectedReportActivity))
+  ) {
+    return { reportIncludedActivityName: '', reportIncludedItemName: '' };
+  }
+
   if (selectedReportActivity) {
     reportIncludedActivityName = isKeyToName
       ? selectedReportActivity.name

--- a/src/modules/Builder/utils/getUpdatedActivityFlows.ts
+++ b/src/modules/Builder/utils/getUpdatedActivityFlows.ts
@@ -1,0 +1,18 @@
+import { ActivityFlowFormValues } from 'modules/Builder/types';
+
+export const getUpdatedActivityFlows = (
+  activityFlows: ActivityFlowFormValues[],
+  keyToRemove: string,
+) =>
+  activityFlows.reduce((acc: ActivityFlowFormValues[], flow) => {
+    if (flow.reportIncludedActivityName === keyToRemove) {
+      flow.reportIncludedActivityName = '';
+      flow.reportIncludedItemName = '';
+    }
+    const items = flow.items?.filter((item) => item.activityKey !== keyToRemove);
+    if (items && items.length > 0) {
+      acc.push({ ...flow, items });
+    }
+
+    return acc;
+  }, []);

--- a/src/modules/Builder/utils/index.ts
+++ b/src/modules/Builder/utils/index.ts
@@ -4,3 +4,4 @@ export * from './getUniqueName';
 export * from './getUploadedMediaName';
 export * from './removeMarkdown';
 export * from './getDefaultSliderScores';
+export * from './getUpdatedActivityFlows';

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/AssessementItems/SingleSelection/SingleSelection.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/AssessementItems/SingleSelection/SingleSelection.test.tsx
@@ -67,13 +67,13 @@ describe('SingleSelection', () => {
     const tooltips = screen.queryAllByTestId(/^single-select-tooltip-\d+$/);
     expect(tooltips).toHaveLength(0);
 
-    userEvent.hover(screen.getByTestId('single-select-more-info-0'));
+    await userEvent.hover(screen.getByTestId('single-select-more-info-0'));
 
     const tooltip = await screen.findByRole('tooltip');
     expect(tooltip).toBeInTheDocument();
     expect(tooltip).toHaveTextContent('Tooltip 1');
 
-    userEvent.unhover(screen.getByTestId('single-select-more-info-0'));
+    await userEvent.unhover(screen.getByTestId('single-select-more-info-0'));
 
     await waitFor(() => {
       const tooltip = screen.queryByRole('tooltip');

--- a/src/shared/mock.ts
+++ b/src/shared/mock.ts
@@ -826,6 +826,7 @@ export const mockedAppletFormData = {
           ],
         },
       ],
+      isReviewable: false,
     },
   ],
   activityFlows: [


### PR DESCRIPTION
- [x] Tests for the changes have been added
- [x] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

🔗 [Jira Ticket M2-6852](https://mindlogger.atlassian.net/browse/M2-6852)

Changes include:

- Clearing the Activities list of isReviewable Activities in the Activity Flow Builder.
- Clearing the Activities list of isReviewable Activities while creating the Activity Flow.
- Removing isReviewable Activities from Activity Flows when the isReviewable checkbox is checked.
- Removing isReviewable Activities from previously saved Activity Flows if they were saved with isReviewable Activities.
- Added unit tests.

### 📸 [Video](https://app.screencast.com/8FUwoICUUnpMo)
