### PR TITLE
fix: Export participant-specific data from Participant Details "Export Data" button (M2-6743)

### DIFF
--- a/src/modules/Dashboard/components/HeaderOptions/HeaderOptions.tsx
+++ b/src/modules/Dashboard/components/HeaderOptions/HeaderOptions.tsx
@@ -10,7 +10,9 @@ import { StyledFlexTopCenter, variables } from 'shared/styles';
 import { Mixpanel, checkIfCanAccessData, checkIfCanEdit } from 'shared/utils';
 import { workspaces } from 'shared/state';
 
-export const HeaderOptions = () => {
+import { HeaderOptionsProps } from './HeaderOptions.types';
+
+export const HeaderOptions = ({ exportFilters, sx, ...otherProps }: HeaderOptionsProps) => {
   const [isExportOpen, setIsExportOpen] = useState(false);
   const { t } = useTranslation('app');
   const { appletId } = useParams();
@@ -31,7 +33,7 @@ export const HeaderOptions = () => {
   const canEdit = checkIfCanEdit(roles);
 
   return canEdit || canAccessData ? (
-    <StyledFlexTopCenter sx={{ gap: 1, ml: 'auto' }}>
+    <StyledFlexTopCenter sx={{ gap: 1, ml: 'auto', ...sx }} {...otherProps}>
       {canAccessData && (
         <Button
           data-testid="header-option-export-button"
@@ -57,6 +59,7 @@ export const HeaderOptions = () => {
       <ExportDataSetting
         isExportSettingsOpen={isExportOpen}
         onExportSettingsClose={handleCloseExport}
+        filters={exportFilters}
       />
     </StyledFlexTopCenter>
   ) : null;

--- a/src/modules/Dashboard/components/HeaderOptions/HeaderOptions.types.ts
+++ b/src/modules/Dashboard/components/HeaderOptions/HeaderOptions.types.ts
@@ -1,0 +1,7 @@
+import { BoxProps } from '@mui/material';
+
+import { ExportDataFilters } from 'shared/utils';
+
+export interface HeaderOptionsProps extends BoxProps {
+  exportFilters?: ExportDataFilters;
+}

--- a/src/modules/Dashboard/features/Respondents/Popups/DataExportPopup/DataExportPopup.tsx
+++ b/src/modules/Dashboard/features/Respondents/Popups/DataExportPopup/DataExportPopup.tsx
@@ -13,7 +13,7 @@ import {
   theme,
   variables,
 } from 'shared/styles';
-import { exportDataSucceed, Mixpanel, sendLogFile } from 'shared/utils';
+import { ExportDataFilters, exportDataSucceed, Mixpanel, sendLogFile } from 'shared/utils';
 import { useSetupEnterAppletPassword } from 'shared/hooks';
 import { getExportDataApi } from 'api';
 import { useDecryptedActivityData } from 'modules/Dashboard/hooks';
@@ -51,13 +51,17 @@ export const DataExportPopup = ({
   const appletId = get(chosenAppletData, isAppletSetting ? 'id' : 'appletId');
   const subjectId = isAppletSetting ? undefined : (chosenAppletData as ChosenAppletData)?.subjectId;
   const { encryption } = chosenAppletData ?? {};
+  const { targetSubjectId: subjectIdFilter, ...otherFilters } = filters ?? {};
 
   const handleDataExportSubmit = async () => {
     if (dataIsExporting || dataExportingRef.current || !appletId) {
       return;
     }
 
-    await executeAllPagesOfExportData({ appletId, targetSubjectIds: subjectId });
+    await executeAllPagesOfExportData({
+      appletId,
+      targetSubjectIds: subjectId ?? subjectIdFilter,
+    });
   };
 
   const hasEncryptionCheck = useCheckIfHasEncryption({
@@ -91,7 +95,7 @@ export const DataExportPopup = ({
         await exportDataSucceed({
           getDecryptedAnswers,
           suffix: pageLimit > 1 ? getExportDataSuffix(1) : '',
-          filters,
+          filters: otherFilters as ExportDataFilters,
         })(firstPageData);
 
         if (pageLimit > 1) {

--- a/src/modules/Dashboard/pages/ParticipantDetails/ParticipantDetails.tsx
+++ b/src/modules/Dashboard/pages/ParticipantDetails/ParticipantDetails.tsx
@@ -59,7 +59,7 @@ export const ParticipantDetails = () => {
             variant={ParticipantSnippetVariant.Large}
             secretId={subject.secretUserId}
             nickname={subject.nickname}
-            rightContent={<HeaderOptions />}
+            rightContent={<HeaderOptions exportFilters={{ targetSubjectId: subjectId }} />}
             tag={subject.tag}
             boxProps={{ sx: { mb: 1.2, mx: 2.4 } }}
           />

--- a/src/shared/features/AppletSettings/ExportDataSetting/ExportDataSetting.tsx
+++ b/src/shared/features/AppletSettings/ExportDataSetting/ExportDataSetting.tsx
@@ -17,6 +17,7 @@ import { exportDataSettingSchema } from './ExportDataSetting.schema';
 import { ExportSettingsPopup } from './Popups/ExportSettingsPopup/ExportSettingsPopup';
 
 export const ExportDataSetting = ({
+  filters,
   isExportSettingsOpen,
   onExportSettingsClose,
 }: ExportDataSettingProps) => {
@@ -51,6 +52,7 @@ export const ExportDataSetting = ({
       )}
       {dataIsExporting && (
         <DataExportPopup
+          filters={filters}
           isAppletSetting
           popupVisible={dataIsExporting}
           setPopupVisible={setDataIsExporting}

--- a/src/shared/features/AppletSettings/ExportDataSetting/ExportDataSetting.types.ts
+++ b/src/shared/features/AppletSettings/ExportDataSetting/ExportDataSetting.types.ts
@@ -1,3 +1,5 @@
+import { ExportDataFilters } from 'shared/utils';
+
 export const enum ExportDateType {
   AllTime = 'allTime',
   Last24h = 'last24h',
@@ -13,6 +15,7 @@ export type ExportDataFormValues = {
 };
 
 export type ExportDataSettingProps = {
+  filters?: ExportDataFilters;
   isExportSettingsOpen: boolean;
   onExportSettingsClose: () => void;
 };


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [M2-6743](https://mindlogger.atlassian.net/browse/M2-6743): [Export Data] Data is exported for all participants from single participant view

This PR fixes an issue where the "Export Data" button in the header of the Participant Details screens exported data for the entire applet, rather than the specific subject represented by the Participant Details screen.

It uses the same [updated prop interface (ie, `filters`) I added in my previous PR](https://github.com/ChildMindInstitute/mindlogger-admin/pull/1774), and allows passing these filters from the `HeaderOptions` component, where they will be passed to the ExportDataPopup. When modifying the prop interface for HeaderOptions, I went ahead and additionally allowed for a full spread of `BoxProps` as well, in case we ever need to modify styles for that component on specific screens.

I also made one small tweak to the existing behaviour for filters as part of this change — I'm passing the `targetSubjectId` filter value as the `targetSubjectIds` parameter for the relevant API endpoint. This will be used whenever the subject ID cannot be derived from the given applet data, or when the `isAppletSetting` prop is set. This should help reduce the overall size of requested data for export, which should in turn reduce the number of checks for the other filter settings.

### 📸 Screenshots

![data-export-details](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/befa0fbb-65a9-4a43-bb1f-6accb76f0b92)

### 🪤 Peer Testing

Given an applet with a number of activities, and participants that have completed different subsets of those activities…

1. On the Applet > Participant Details > Activities screen…
    1. Click "Export" in the header area on any tab.
    2. After exporting, open the resulting .csv, and observe that it only includes entries where the `target_subject_id` matches the ID of the Subject you are viewing.

It may also be worthwhile to try some of the other data export options, and ensure that there haven't been any regressions.

[M2-6743]: https://mindlogger.atlassian.net/browse/M2-6743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ