### PR TITLE
feat: DataViz: Activity Flows on the 'Summary' tab - improve performance when a lot of items with charts (M2-6674)

### DIFF
--- a/src/modules/Dashboard/features/RespondentData/RespondentData.const.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentData.const.ts
@@ -14,18 +14,7 @@ export const defaultRespondentDataFormValues = {
   filterByIdentifier: false,
   identifier: [],
   versions: [],
-  summaryActivities: [],
-  summaryFlows: [],
-  selectedEntity: null,
-  identifiers: [],
-  apiVersions: [],
-  answers: [],
-  responseOptions: null,
-  subscalesFrequency: 0,
-  flowSubmissions: [],
-  flowResponses: [],
   responseDate: null,
-  flowResponseOptionsCount: 0,
 };
 
 export const UNSUPPORTED_ITEMS = [

--- a/src/modules/Dashboard/features/RespondentData/RespondentData.const.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentData.const.ts
@@ -25,6 +25,7 @@ export const defaultRespondentDataFormValues = {
   flowSubmissions: [],
   flowResponses: [],
   responseDate: null,
+  flowResponseOptionsCount: 0,
 };
 
 export const UNSUPPORTED_ITEMS = [

--- a/src/modules/Dashboard/features/RespondentData/RespondentData.types.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentData.types.ts
@@ -1,4 +1,4 @@
-import { DatavizEntity, Version, ReviewCount } from 'modules/Dashboard/api';
+import { DatavizEntity, ReviewCount } from 'modules/Dashboard/api';
 import { AutocompleteOption } from 'shared/components/FormComponents';
 import { ActivityItemAnswer } from 'shared/types';
 import { SubscaleSetting } from 'shared/state';
@@ -177,16 +177,5 @@ export type RespondentsDataFormValues = {
   filterByIdentifier?: boolean;
   identifier?: AutocompleteOption[];
   versions: AutocompleteOption[];
-  summaryActivities: DatavizEntity[];
-  summaryFlows: DatavizEntity[];
-  selectedEntity: ActivityOrFlow | null;
-  identifiers: Identifier[];
-  apiVersions: Version[];
-  answers: ActivityCompletion[];
-  flowSubmissions: FlowSubmission[];
-  flowResponses: FlowResponses[];
-  responseOptions: ResponseOption | null;
-  subscalesFrequency: number;
   responseDate: null | Date;
-  flowResponseOptionsCount: number;
 };

--- a/src/modules/Dashboard/features/RespondentData/RespondentData.types.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentData.types.ts
@@ -188,4 +188,5 @@ export type RespondentsDataFormValues = {
   responseOptions: ResponseOption | null;
   subscalesFrequency: number;
   responseDate: null | Date;
+  flowResponseOptionsCount: number;
 };

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/FeedbackReviews/FeedbackReviews.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/FeedbackReviews/FeedbackReviews.test.tsx
@@ -303,7 +303,7 @@ const renderComponent = (
       value={getMockedContext(assessment, lastAssessment, isLastVersion, isBannerVisible)}
     >
       <FormComponent assessment={assessment}>
-        <FeedbackReviews />{' '}
+        <FeedbackReviews />
       </FormComponent>
     </RespondentDataReviewContext.Provider>,
     {

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.context.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.context.ts
@@ -1,17 +1,19 @@
 import { createContext } from 'react';
 
+import { nullReturnFunc } from 'shared/utils';
+
 import { RespondentDataReviewContextType } from './RespondentDataReview.types';
 
 export const RespondentDataReviewContext = createContext<RespondentDataReviewContextType>({
   assessment: undefined,
-  setAssessment: () => null,
+  setAssessment: nullReturnFunc,
   lastAssessment: null,
   assessmentVersions: [],
   isLastVersion: false,
-  setIsLastVersion: () => null,
+  setIsLastVersion: nullReturnFunc,
   isBannerVisible: false,
-  setIsBannerVisible: () => null,
+  setIsBannerVisible: nullReturnFunc,
   itemIds: [],
-  setItemIds: () => null,
+  setItemIds: nullReturnFunc,
   isFeedbackOpen: false,
 });

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/DataSummaryContext/DataSummaryContext.context.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/DataSummaryContext/DataSummaryContext.context.ts
@@ -1,0 +1,30 @@
+import { createContext } from 'react';
+
+import { nullReturnFunc } from 'shared/utils';
+
+import { DataSummaryContextType } from './DataSummaryContext.types';
+
+export const DataSummaryContext = createContext<DataSummaryContextType>({
+  identifiers: [],
+  setIdentifiers: nullReturnFunc,
+  apiVersions: [],
+  setApiVersions: nullReturnFunc,
+  summaryActivities: [],
+  setSummaryActivities: nullReturnFunc,
+  summaryFlows: [],
+  setSummaryFlows: nullReturnFunc,
+  selectedEntity: null,
+  setSelectedEntity: nullReturnFunc,
+  answers: [],
+  setAnswers: nullReturnFunc,
+  responseOptions: null,
+  setResponseOptions: nullReturnFunc,
+  subscalesFrequency: 0,
+  setSubscalesFrequency: nullReturnFunc,
+  flowSubmissions: [],
+  setFlowSubmissions: nullReturnFunc,
+  flowResponses: [],
+  setFlowResponses: nullReturnFunc,
+  flowResponseOptionsCount: 0,
+  setFlowResponseOptionsCount: nullReturnFunc,
+});

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/DataSummaryContext/DataSummaryContext.hooks.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/DataSummaryContext/DataSummaryContext.hooks.ts
@@ -1,0 +1,5 @@
+import { useContext } from 'react';
+
+import { DataSummaryContext } from './DataSummaryContext.context';
+
+export const useDataSummaryContext = () => useContext(DataSummaryContext);

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/DataSummaryContext/DataSummaryContext.types.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/DataSummaryContext/DataSummaryContext.types.ts
@@ -1,0 +1,38 @@
+import { Dispatch, ReactNode, SetStateAction } from 'react';
+
+import {
+  FlowSubmission,
+  FlowResponses,
+  ActivityCompletion,
+  ResponseOption,
+  ActivityOrFlow,
+  Identifier,
+} from 'modules/Dashboard/features/RespondentData/RespondentData.types';
+import { DatavizEntity, Version } from 'modules/Dashboard/api';
+
+export type DataSummaryContextType = {
+  identifiers: Identifier[];
+  setIdentifiers: Dispatch<SetStateAction<Identifier[]>>;
+  apiVersions: Version[];
+  setApiVersions: Dispatch<SetStateAction<Version[]>>;
+  selectedEntity: ActivityOrFlow | null;
+  setSelectedEntity: Dispatch<SetStateAction<ActivityOrFlow | null>>;
+  summaryActivities: DatavizEntity[];
+  setSummaryActivities: Dispatch<SetStateAction<DatavizEntity[]>>;
+  summaryFlows: DatavizEntity[];
+  setSummaryFlows: Dispatch<SetStateAction<DatavizEntity[]>>;
+  answers: ActivityCompletion[];
+  setAnswers: Dispatch<SetStateAction<ActivityCompletion[]>>;
+  responseOptions: ResponseOption | null;
+  setResponseOptions: Dispatch<SetStateAction<ResponseOption | null>>;
+  subscalesFrequency: number;
+  setSubscalesFrequency: Dispatch<SetStateAction<number>>;
+  flowSubmissions: FlowSubmission[];
+  setFlowSubmissions: Dispatch<SetStateAction<FlowSubmission[]>>;
+  flowResponses: FlowResponses[];
+  setFlowResponses: Dispatch<SetStateAction<FlowResponses[]>>;
+  flowResponseOptionsCount: number;
+  setFlowResponseOptionsCount: Dispatch<SetStateAction<number>>;
+};
+
+export type DataSummaryContextProviderProps = { children: ReactNode };

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/DataSummaryContext/DataSummaryContextProvider.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/DataSummaryContext/DataSummaryContextProvider.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+
+import {
+  FlowSubmission,
+  FlowResponses,
+  ActivityCompletion,
+  ResponseOption,
+  ActivityOrFlow,
+  Identifier,
+} from 'modules/Dashboard/features/RespondentData/RespondentData.types';
+import { DatavizEntity, Version } from 'modules/Dashboard/api';
+
+import { DataSummaryContext } from './DataSummaryContext.context';
+import { DataSummaryContextProviderProps } from './DataSummaryContext.types';
+
+export const DataSummaryContextProvider = ({ children }: DataSummaryContextProviderProps) => {
+  const [summaryActivities, setSummaryActivities] = useState<DatavizEntity[]>([]);
+  const [summaryFlows, setSummaryFlows] = useState<DatavizEntity[]>([]);
+  const [selectedEntity, setSelectedEntity] = useState<ActivityOrFlow | null>(null);
+  const [answers, setAnswers] = useState<ActivityCompletion[]>([]);
+  const [responseOptions, setResponseOptions] = useState<ResponseOption | null>(null);
+  const [subscalesFrequency, setSubscalesFrequency] = useState(0);
+  const [flowSubmissions, setFlowSubmissions] = useState<FlowSubmission[]>([]);
+  const [flowResponses, setFlowResponses] = useState<FlowResponses[]>([]);
+  const [flowResponseOptionsCount, setFlowResponseOptionsCount] = useState(0);
+  const [identifiers, setIdentifiers] = useState<Identifier[]>([]);
+  const [apiVersions, setApiVersions] = useState<Version[]>([]);
+
+  return (
+    <DataSummaryContext.Provider
+      value={{
+        flowSubmissions,
+        setFlowSubmissions,
+        flowResponses,
+        setFlowResponses,
+        selectedEntity,
+        setSelectedEntity,
+        flowResponseOptionsCount,
+        setFlowResponseOptionsCount,
+        summaryActivities,
+        setSummaryActivities,
+        summaryFlows,
+        setSummaryFlows,
+        answers,
+        setAnswers,
+        responseOptions,
+        setResponseOptions,
+        subscalesFrequency,
+        setSubscalesFrequency,
+        identifiers,
+        setIdentifiers,
+        apiVersions,
+        setApiVersions,
+      }}
+    >
+      {children}
+    </DataSummaryContext.Provider>
+  );
+};

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/DataSummaryContext/index.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/DataSummaryContext/index.ts
@@ -1,0 +1,2 @@
+export * from './DataSummaryContextProvider';
+export * from './DataSummaryContext.hooks';

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Charts/LineChart/SubscaleLineChart/SubscaleLineChart.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Charts/LineChart/SubscaleLineChart/SubscaleLineChart.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useFormContext } from 'react-hook-form';
 import { Chart as ChartJS, Tooltip, TimeScale, Legend, ScriptableTooltipContext } from 'chart.js';
 import 'chartjs-adapter-date-fns';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
@@ -11,7 +10,6 @@ import { Box } from '@mui/material';
 import { getOptionTextApi } from 'api';
 import { pluck } from 'shared/utils';
 import { useDatavizFilters } from 'modules/Dashboard/features/RespondentData/RespondentDataSummary/hooks/useDatavizFilters';
-import { RespondentsDataFormValues } from 'modules/Dashboard/features/RespondentData';
 
 import { ChartTooltipContainer } from '../../ChartTooltipContainer';
 import { getTicksData, legendMargin, setTooltipStyles } from '../../Charts.utils';
@@ -39,8 +37,7 @@ export const SubscaleLineChart = ({ data, versions }: SubscaleLineChartProps) =>
 
   const [tooltipData, setTooltipData] = useState<TooltipData[] | null>(null);
 
-  const { watch } = useFormContext<RespondentsDataFormValues>();
-  const { minDate, maxDate, filteredVersions } = useDatavizFilters(watch, versions);
+  const { minDate, maxDate, filteredVersions } = useDatavizFilters(versions);
 
   const responses = data.subscales.map((subscale) => subscale.activityCompletions);
   const scores = pluck(responses.flat(), 'score');

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Charts/LineChart/TimePickerLineChart/TimePickerLineChart.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Charts/LineChart/TimePickerLineChart/TimePickerLineChart.tsx
@@ -5,7 +5,11 @@ import 'chartjs-adapter-date-fns';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
 import { Line } from 'react-chartjs-2';
 import { ChartJSOrUndefined } from 'react-chartjs-2/dist/types';
-import { Box } from '@mui/material';
+import { Box, Skeleton } from '@mui/material';
+
+import { useStaticContent } from 'shared/hooks/useStaticContent';
+import { observerStyles } from 'shared/consts';
+import { StyledObserverTarget } from 'shared/styles';
 
 import { locales } from '../../Charts.const';
 import { ChartType } from '../../Chart.types';
@@ -23,6 +27,7 @@ export const TimePickerLineChart = ({
   maxDate,
   answers,
   versions,
+  isStaticActive,
   'data-testid': dataTestid,
 }: TimePickerLineChartProps) => {
   const { i18n } = useTranslation('app');
@@ -30,6 +35,8 @@ export const TimePickerLineChart = ({
 
   const tooltipRef = useRef<HTMLDivElement | null>(null);
   const isHovered = useRef(false);
+  const targetSelector = `${dataTestid}-target`;
+  const { isStatic } = useStaticContent({ targetSelector, isStaticActive });
 
   const [tooltipData, setTooltipData] = useState<TimePickerDataPointRaw[] | null>(null);
 
@@ -84,22 +91,29 @@ export const TimePickerLineChart = ({
         height={120}
       />
     ),
-    [answers, lang],
+    [answers, lang, color, minDate, maxDate, versions],
   );
 
   return (
     <Box sx={{ position: 'relative' }} data-testid={dataTestid}>
-      {renderChart}
-      <ChartTooltipContainer
-        ref={tooltipRef}
-        onMouseEnter={() => {
-          isHovered.current = true;
-        }}
-        onMouseLeave={hideTooltip}
-        data-testid={dataTestid}
-      >
-        <ChartTooltip data={tooltipData} data-testid={dataTestid} />
-      </ChartTooltipContainer>
+      <StyledObserverTarget className={targetSelector} sx={observerStyles} />
+      {isStatic ? (
+        <Skeleton variant="rounded" height={chartRef.current?.height} />
+      ) : (
+        <>
+          {renderChart}
+          <ChartTooltipContainer
+            ref={tooltipRef}
+            onMouseEnter={() => {
+              isHovered.current = true;
+            }}
+            onMouseLeave={hideTooltip}
+            data-testid={dataTestid}
+          >
+            <ChartTooltip data={tooltipData} data-testid={dataTestid} />
+          </ChartTooltipContainer>
+        </>
+      )}
     </Box>
   );
 };

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Charts/LineChart/TimePickerLineChart/TimePickerLineChart.types.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Charts/LineChart/TimePickerLineChart/TimePickerLineChart.types.ts
@@ -7,6 +7,7 @@ export type TimePickerLineChartProps = {
   maxDate: Date;
   answers: TimeAnswer[];
   versions: Version[];
+  isStaticActive?: boolean;
   'data-testid'?: string;
 };
 

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Charts/MultiScatterChart/MultiScatterChart.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Charts/MultiScatterChart/MultiScatterChart.tsx
@@ -94,7 +94,19 @@ export const MultiScatterChart = ({
         plugins={[ChartDataLabels]}
       />
     ),
-    [answers, lang],
+    [
+      answers,
+      lang,
+      color,
+      minDate,
+      maxDate,
+      versions,
+      maxY,
+      minY,
+      options,
+      responseType,
+      useCategory,
+    ],
   );
 
   return (

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/CompletedChart/CompletedChart.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/CompletedChart/CompletedChart.tsx
@@ -1,11 +1,9 @@
 import { useTranslation } from 'react-i18next';
-import { useFormContext } from 'react-hook-form';
 import { Box } from '@mui/material';
 
 import { Tooltip } from 'shared/components/Tooltip';
 import { StyledHeadline, StyledTitleTooltipIcon, theme, variables } from 'shared/styles';
 import { ScatterChart } from 'modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Charts';
-import { RespondentsDataFormValues } from 'modules/Dashboard/features/RespondentData/RespondentData.types';
 
 import { useDatavizFilters } from '../../hooks/useDatavizFilters';
 import { CompletedChartProps } from './CompletedChart.types';
@@ -17,9 +15,7 @@ export const CompletedChart = ({
   'data-testid': dataTestId,
 }: CompletedChartProps) => {
   const { t } = useTranslation();
-  const { watch } = useFormContext<RespondentsDataFormValues>();
-
-  const { minDate, maxDate, filteredVersions } = useDatavizFilters(watch, versions);
+  const { minDate, maxDate, filteredVersions } = useDatavizFilters(versions);
 
   return (
     <Box sx={{ mb: theme.spacing(6.4) }}>

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/EntitiyResponses/ActivityResponses/ActivityResponses.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/EntitiyResponses/ActivityResponses/ActivityResponses.tsx
@@ -8,13 +8,18 @@ export const ActivityResponses = ({
   versions,
   subscalesFrequency,
   responseOptions,
+  flowResponsesIndex,
 }: ActivityResponsesProps) => (
   <>
     {!!subscalesFrequency && (
       <Subscales answers={answers} versions={versions} subscalesFrequency={subscalesFrequency} />
     )}
     {responseOptions && !!Object.values(responseOptions).length && (
-      <ResponseOptions responseOptions={sortResponseOptions(responseOptions)} versions={versions} />
+      <ResponseOptions
+        responseOptions={sortResponseOptions(responseOptions)}
+        versions={versions}
+        flowResponsesIndex={flowResponsesIndex}
+      />
     )}
   </>
 );

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/EntitiyResponses/ActivityResponses/ActivityResponses.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/EntitiyResponses/ActivityResponses/ActivityResponses.tsx
@@ -12,7 +12,12 @@ export const ActivityResponses = ({
 }: ActivityResponsesProps) => (
   <>
     {!!subscalesFrequency && (
-      <Subscales answers={answers} versions={versions} subscalesFrequency={subscalesFrequency} />
+      <Subscales
+        answers={answers}
+        versions={versions}
+        subscalesFrequency={subscalesFrequency}
+        flowResponsesIndex={flowResponsesIndex}
+      />
     )}
     {responseOptions && !!Object.values(responseOptions).length && (
       <ResponseOptions

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/EntitiyResponses/ActivityResponses/ActivityResponses.types.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/EntitiyResponses/ActivityResponses/ActivityResponses.types.ts
@@ -9,4 +9,5 @@ export type ActivityResponsesProps = {
   versions: Version[];
   subscalesFrequency: number;
   responseOptions: Record<string, FormattedResponses[]> | null;
+  flowResponsesIndex?: number;
 };

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/EntitiyResponses/EntityResponses.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/EntitiyResponses/EntityResponses.tsx
@@ -14,11 +14,12 @@ export const EntityResponses = ({
   if (isFlow) {
     return (
       <>
-        {flowResponses.map(({ activityId, ...rest }) => (
+        {flowResponses.map(({ activityId, ...rest }, index) => (
           <FlowActivityResponses
             key={activityId}
             activityId={activityId}
             versions={versions}
+            flowResponsesIndex={index + 1}
             data-testid={`${dataTestId}-flow`}
             {...rest}
           />

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/EntitiyResponses/EntityResponses.types.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/EntitiyResponses/EntityResponses.types.ts
@@ -1,7 +1,7 @@
 import {
   FlowResponses,
   ActivityCompletion,
-  FormattedResponses,
+  ResponseOption,
 } from 'modules/Dashboard/features/RespondentData/RespondentData.types';
 import { Version } from 'modules/Dashboard/api';
 
@@ -9,7 +9,7 @@ export type EntityResponsesProps = {
   isFlow: boolean;
   flowResponses: FlowResponses[];
   answers: ActivityCompletion[];
-  responseOptions: Record<string, FormattedResponses[]> | null;
+  responseOptions: ResponseOption | null;
   subscalesFrequency: number;
   versions: Version[];
   'data-testid': string;

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/EntitiyResponses/FlowActivityResponses/FlowActivityResponses.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/EntitiyResponses/FlowActivityResponses/FlowActivityResponses.tsx
@@ -15,6 +15,7 @@ export const FlowActivityResponses = ({
   versions,
   subscalesFrequency,
   responseOptions,
+  flowResponsesIndex,
   'data-testid': dataTestId,
 }: FlowResponsesProps) => (
   <StyledFlowWrapper data-testid={dataTestId}>
@@ -34,6 +35,7 @@ export const FlowActivityResponses = ({
         versions={versions}
         subscalesFrequency={subscalesFrequency}
         responseOptions={responseOptions}
+        flowResponsesIndex={flowResponsesIndex}
         data-testid={`${dataTestId}-activity`}
       />
     )}

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/EntitiyResponses/FlowActivityResponses/FlowActivityResponses.types.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/EntitiyResponses/FlowActivityResponses/FlowActivityResponses.types.ts
@@ -12,5 +12,6 @@ export type FlowResponsesProps = {
   versions: Version[];
   subscalesFrequency: number;
   responseOptions: Record<string, FormattedResponses[]> | null;
+  flowResponsesIndex: number;
   'data-testid': string;
 };

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Report.context.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Report.context.ts
@@ -1,8 +1,10 @@
 import { createContext } from 'react';
 
+import { nullReturnFunc } from 'shared/utils';
+
 import { ReportContextType } from './Report.types';
 
 export const ReportContext = createContext<ReportContextType>({
   currentActivityCompletionData: null,
-  setCurrentActivityCompletionData: () => null,
+  setCurrentActivityCompletionData: nullReturnFunc,
 });

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Report.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Report.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Box } from '@mui/material';
-import { useWatch, useFormContext } from 'react-hook-form';
+import { useWatch } from 'react-hook-form';
 
 import { Spinner, Svg } from 'shared/components';
 import {
@@ -11,12 +11,12 @@ import {
   theme,
   variables,
 } from 'shared/styles';
+import { AutocompleteOption } from 'shared/components/FormComponents';
 
-import { RespondentsDataFormValues } from '../../RespondentData.types';
 import { getFormattedResponses } from '../utils/getFormattedResponses';
 import { ReportFilters } from './ReportFilters';
 import { StyledReport } from './Report.styles';
-import { CurrentActivityCompletionData, ReportValues } from './Report.types';
+import { CurrentActivityCompletionData } from './Report.types';
 import { CompletedChart } from './CompletedChart';
 import { getCompletions } from './Report.utils';
 import { ReportContext } from './Report.context';
@@ -24,41 +24,33 @@ import { StyledEmptyReview } from '../RespondentDataSummary.styles';
 import { ReportHeader } from './ReportHeader';
 import { NoData } from './NoData';
 import { EntityResponses } from './EntitiyResponses';
+import { useDataSummaryContext } from '../DataSummaryContext';
 
 export const Report = () => {
   const { t } = useTranslation('app');
   const containerRef = useRef<HTMLElement | null>(null);
-
-  const { setValue } = useFormContext<RespondentsDataFormValues>();
-  const [
+  const {
+    selectedEntity,
     answers,
     responseOptions,
+    setResponseOptions,
     subscalesFrequency,
-    selectedEntity,
-    identifiers,
-    apiVersions,
-    versions,
+    setSubscalesFrequency,
     flowSubmissions,
     flowResponses,
-  ]: ReportValues = useWatch({
-    name: [
-      'answers',
-      'responseOptions',
-      'subscalesFrequency',
-      'selectedEntity',
-      'identifiers',
-      'apiVersions',
-      'versions',
-      'flowSubmissions',
-      'flowResponses',
-    ],
+    identifiers,
+    apiVersions,
+  } = useDataSummaryContext();
+
+  const versions: AutocompleteOption[] = useWatch({
+    name: 'versions',
   });
 
   const [isLoading, setIsLoading] = useState(false);
   const [currentActivityCompletionData, setCurrentActivityCompletionData] =
     useState<CurrentActivityCompletionData>(null);
 
-  const { isFlow, hasAnswer } = selectedEntity;
+  const { isFlow = false, hasAnswer = false } = selectedEntity ?? {};
 
   const completions = getCompletions({ isFlow, flowSubmissions, answers });
 
@@ -86,8 +78,8 @@ export const Report = () => {
 
     const { subscalesFrequency, formattedResponses } = getFormattedResponses(responses);
 
-    setValue('subscalesFrequency', subscalesFrequency);
-    setValue('responseOptions', formattedResponses);
+    setResponseOptions(formattedResponses);
+    setSubscalesFrequency(subscalesFrequency);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentActivityCompletionData]);
 

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Report.types.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Report.types.ts
@@ -1,14 +1,6 @@
-import { AutocompleteOption } from 'shared/components/FormComponents';
-import { Version, ReviewCount } from 'modules/Dashboard/api';
+import { ReviewCount } from 'modules/Dashboard/api';
 
-import {
-  ActivityCompletion,
-  ActivityOrFlow,
-  FlowResponses,
-  FlowSubmission,
-  FormattedResponses,
-  Identifier,
-} from '../../RespondentData.types';
+import { ActivityCompletion, FlowSubmission } from '../../RespondentData.types';
 
 export type CurrentActivityCompletionData = { answerId: string; date?: number } | null;
 
@@ -30,15 +22,3 @@ export type GetCompletions = {
   flowSubmissions: FlowSubmission[];
   answers: ActivityCompletion[];
 };
-
-export type ReportValues = [
-  ActivityCompletion[],
-  Record<string, FormattedResponses[]> | null,
-  number,
-  ActivityOrFlow,
-  Identifier[],
-  Version[],
-  AutocompleteOption[],
-  FlowSubmission[],
-  FlowResponses[],
-];

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ReportFilters/ReportFilters.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ReportFilters/ReportFilters.test.tsx
@@ -13,6 +13,7 @@ import { MAX_LIMIT } from 'shared/consts';
 import { RespondentsDataFormValues } from 'modules/Dashboard/features/RespondentData/RespondentData.types';
 import { defaultRespondentDataFormValues } from 'modules/Dashboard/features/RespondentData/RespondentData.const';
 
+import { DataSummaryContext } from '../../DataSummaryContext/DataSummaryContext.context';
 import { ReportFilters } from './ReportFilters';
 
 const identifiers = [
@@ -114,7 +115,11 @@ describe('ReportFilters', () => {
 
   test('check if the startDate is greater than the endDate, then the endDate should be updated', async () => {
     await act(async () => {
-      renderWithProviders(<FormComponent />);
+      renderWithProviders(
+        <DataSummaryContext.Provider value={{ selectedEntity: mockedActivity }}>
+          <FormComponent />
+        </DataSummaryContext.Provider>,
+      );
     });
 
     const startDatePicker = screen.getByTestId(`${dataTestid}-start-date`);
@@ -164,16 +169,16 @@ describe('ReportFilters', () => {
     });
     jest
       .spyOn(reactHookForm, 'useWatch')
-      .mockReturnValue([
-        true,
-        false,
-        new Date('2024-01-04'),
-        new Date('2024-01-10'),
-        mockedActivity,
-      ]);
+      .mockReturnValue([true, false, new Date('2024-01-04'), new Date('2024-01-10')]);
 
     await act(async () => {
-      renderWithProviders(<FormComponent />, route, routePath);
+      renderWithProviders(
+        <DataSummaryContext.Provider value={{ selectedEntity: mockedActivity }}>
+          <FormComponent />
+        </DataSummaryContext.Provider>,
+        route,
+        routePath,
+      );
     });
 
     await userEvent.click(screen.getByTestId(`${dataTestid}-filter-by-identifier`));
@@ -201,9 +206,15 @@ describe('ReportFilters', () => {
   test('fetch answers on filters change when the entity is Flow', async () => {
     jest
       .spyOn(reactHookForm, 'useWatch')
-      .mockReturnValue([true, false, new Date('2024-01-04'), new Date('2024-01-10'), mockedFlow]);
+      .mockReturnValue([true, false, new Date('2024-01-04'), new Date('2024-01-10')]);
 
-    renderWithProviders(<FormComponent />, route, routePath);
+    renderWithProviders(
+      <DataSummaryContext.Provider value={{ selectedEntity: mockedFlow }}>
+        <FormComponent />
+      </DataSummaryContext.Provider>,
+      route,
+      routePath,
+    );
 
     await userEvent.click(screen.getByTestId(`${dataTestid}-filter-by-identifier`));
 

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ReportFilters/ReportFilters.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ReportFilters/ReportFilters.tsx
@@ -8,7 +8,6 @@ import { DatePicker, TimePicker } from 'shared/components';
 import { StyledBodyLarge, StyledFlexTopCenter, theme, variables } from 'shared/styles';
 import { Switch, TagsAutocompleteController } from 'shared/components/FormComponents';
 import { AutocompleteOption } from 'shared/components/FormComponents';
-import { ActivityOrFlow } from 'modules/Dashboard/features/RespondentData/RespondentData.types';
 
 import { FetchAnswers } from '../../RespondentDataSummary.types';
 import { useRespondentAnswers } from '../../hooks/useRespondentAnswers';
@@ -20,6 +19,7 @@ import {
   ReportFiltersProps,
 } from './ReportFilters.types';
 import { MIN_DATE } from './ReportFilters.const';
+import { useDataSummaryContext } from '../../DataSummaryContext';
 
 export const ReportFilters = ({
   identifiers = [],
@@ -29,15 +29,15 @@ export const ReportFilters = ({
   const { t } = useTranslation('app');
   const { control, setValue } = useFormContext();
   const { fetchAnswers } = useRespondentAnswers();
+  const { selectedEntity } = useDataSummaryContext();
 
-  const [moreFiltersVisible, filterByIdentifier, startDate, endDate, selectedEntity]: [
+  const [moreFiltersVisible, filterByIdentifier, startDate, endDate]: [
     boolean,
     boolean,
     Date,
     Date,
-    ActivityOrFlow,
   ] = useWatch({
-    name: ['moreFiltersVisible', 'filterByIdentifier', 'startDate', 'endDate', 'selectedEntity'],
+    name: ['moreFiltersVisible', 'filterByIdentifier', 'startDate', 'endDate'],
   });
 
   const versionsOptions = versions.map(({ version }) => ({ label: version, id: version }));
@@ -56,6 +56,8 @@ export const ReportFilters = ({
     identifier,
     versions,
   }: OnFiltersChangeParams) => {
+    if (!selectedEntity) return;
+
     setIsLoading(true);
     let fetchParams: FetchAnswers = { entity: selectedEntity };
 

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ResponseOptions/ResponseOptions.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ResponseOptions/ResponseOptions.test.tsx
@@ -256,14 +256,9 @@ const textTableRegExp = /response-option-\d+-\d+-table$/;
 const multiScatterChart = 'multi-scatter-chart';
 const timePickerLineChart = 'time-picker-line-chart';
 
-const mockedWatch = jest.fn();
-
 jest.mock('react-hook-form', () => ({
   ...jest.requireActual('react-hook-form'),
-  useFormContext: () => ({
-    watch: () => mockedWatch(),
-    setValue: () => jest.fn(),
-  }),
+  useWatch: () => [],
 }));
 
 jest.mock('../Charts/LineChart/TimePickerLineChart', () => ({
@@ -285,10 +280,6 @@ jest.mock('modules/Dashboard/features/RespondentData/CollapsedMdText', () => ({
 }));
 
 describe('ResponseOptions', () => {
-  beforeEach(() => {
-    mockedWatch.mockReturnValue({});
-  });
-
   test('renders component and children correctly', async () => {
     renderWithProviders(<ResponseOptions responseOptions={mockedResponseOptions} versions={[]} />);
 

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ResponseOptions/ResponseOptions.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ResponseOptions/ResponseOptions.tsx
@@ -1,5 +1,4 @@
 import { useCallback } from 'react';
-import { useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { Box } from '@mui/material';
 
@@ -19,6 +18,7 @@ import { useDatavizFilters } from '../../hooks/useDatavizFilters';
 import { COLORS } from '../Charts/Charts.const';
 import { ResponseOptionsProps } from './ResponseOptions.types';
 import { getResponseItem } from './ResponseOptions.utils';
+import { useDataSummaryContext } from '../../DataSummaryContext';
 
 export const ResponseOptions = ({
   responseOptions,
@@ -26,7 +26,7 @@ export const ResponseOptions = ({
   flowResponsesIndex,
 }: ResponseOptionsProps) => {
   const { t } = useTranslation();
-  const flowResponseOptionsCount: number = useWatch({ name: 'flowResponseOptionsCount' });
+  const { flowResponseOptionsCount } = useDataSummaryContext();
   const { minDate, maxDate, filteredVersions } = useDatavizFilters(versions);
   const isStaticActive =
     Object.values(responseOptions).length > SUMMARY_ITEMS_COUNT_TO_ACTIVATE_STATIC ||

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ResponseOptions/ResponseOptions.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ResponseOptions/ResponseOptions.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { useFormContext } from 'react-hook-form';
+import { useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { Box } from '@mui/material';
 
@@ -12,10 +12,7 @@ import {
   UNSUPPORTED_ITEMS,
   SHOW_MORE_HEIGHT,
 } from 'modules/Dashboard/features/RespondentData/RespondentData.const';
-import {
-  RespondentsDataFormValues,
-  FormattedResponses,
-} from 'modules/Dashboard/features/RespondentData/RespondentData.types';
+import { FormattedResponses } from 'modules/Dashboard/features/RespondentData/RespondentData.types';
 
 import { SUMMARY_ITEMS_COUNT_TO_ACTIVATE_STATIC } from '../../RespondentDataSummary.const';
 import { useDatavizFilters } from '../../hooks/useDatavizFilters';
@@ -23,12 +20,17 @@ import { COLORS } from '../Charts/Charts.const';
 import { ResponseOptionsProps } from './ResponseOptions.types';
 import { getResponseItem } from './ResponseOptions.utils';
 
-export const ResponseOptions = ({ responseOptions, versions = [] }: ResponseOptionsProps) => {
+export const ResponseOptions = ({
+  responseOptions,
+  versions = [],
+  flowResponsesIndex,
+}: ResponseOptionsProps) => {
   const { t } = useTranslation();
-  const { watch } = useFormContext<RespondentsDataFormValues>();
-  const { minDate, maxDate, filteredVersions } = useDatavizFilters(watch, versions);
+  const flowResponseOptionsCount: number = useWatch({ name: 'flowResponseOptionsCount' });
+  const { minDate, maxDate, filteredVersions } = useDatavizFilters(versions);
   const isStaticActive =
-    Object.values(responseOptions).length > SUMMARY_ITEMS_COUNT_TO_ACTIVATE_STATIC;
+    Object.values(responseOptions).length > SUMMARY_ITEMS_COUNT_TO_ACTIVATE_STATIC ||
+    flowResponseOptionsCount > SUMMARY_ITEMS_COUNT_TO_ACTIVATE_STATIC;
 
   const renderResponseOption = useCallback(
     (activityItemAnswer: FormattedResponses, index: number) => {
@@ -61,7 +63,9 @@ export const ResponseOptions = ({ responseOptions, versions = [] }: ResponseOpti
       </StyledHeadline>
       {Object.values(responseOptions).map((responseOption, responseOptionIndex) =>
         responseOption.map((item, index) => {
-          const dataTestid = `response-option-${responseOptionIndex}-${index}`;
+          const dataTestid = `response-option-${
+            flowResponsesIndex ? `${flowResponsesIndex}-` : ''
+          }${responseOptionIndex}-${index}`;
 
           return (
             <Box

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ResponseOptions/ResponseOptions.types.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ResponseOptions/ResponseOptions.types.ts
@@ -4,6 +4,7 @@ import { FormattedResponses } from 'modules/Dashboard/features/RespondentData/Re
 export type ResponseOptionsProps = {
   responseOptions: Record<string, FormattedResponses[]>;
   versions: Version[];
+  flowResponsesIndex?: number;
 };
 
 export type GetResponseOptionsProps = {

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ResponseOptions/ResponseOptions.utils.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ResponseOptions/ResponseOptions.utils.test.tsx
@@ -586,6 +586,7 @@ describe('ResponseOptions.utils', () => {
         { answer: { text: null, value: 139500000 }, date: '2024-03-14T16:53:24.055000' },
         { answer: { text: null, value: null }, date: '2024-03-15T13:35:27.961000' },
       ],
+      isStaticActive: false,
       'data-testid': 'response-option-4-0-time-picker-chart',
     };
     const dateItemResult = {
@@ -617,6 +618,7 @@ describe('ResponseOptions.utils', () => {
       ...sharedProps,
       activityItem: singleSelectRowsActivityItem,
       answers: singleSelectRowsAnswers,
+      isStaticActive: false,
       'data-testid': 'single-select-rows',
     };
     const {
@@ -629,6 +631,7 @@ describe('ResponseOptions.utils', () => {
       ...sharedProps,
       activityItem: multiSelectRowsActivityItem,
       answers: multiSelectRowsAnswers,
+      isStaticActive: false,
       'data-testid': 'multi-select-rows',
     };
     const sliderRowsItemResult = {
@@ -664,6 +667,7 @@ describe('ResponseOptions.utils', () => {
           { answer: { text: null, value: 8 }, date: '2024-03-27T15:44:46.674000' },
         ],
       },
+      isStaticActive: false,
       'data-testid': 'slider-rows',
     };
 

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ResponseOptions/ResponseOptions.utils.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ResponseOptions/ResponseOptions.utils.tsx
@@ -97,6 +97,7 @@ export const getResponseItem = ({
           maxDate={maxDate}
           answers={activityItemAnswer.answers as TimeAnswer[]}
           versions={versions}
+          isStaticActive={isStaticActive}
           data-testid={`${activityItemAnswer.dataTestid}-time-picker-chart`}
         />
       );
@@ -112,6 +113,7 @@ export const getResponseItem = ({
           }
           answers={activityItemAnswer.answers as SingleMultiSelectionPerRowAnswer}
           versions={versions}
+          isStaticActive={isStaticActive}
           data-testid={activityItemAnswer.dataTestid}
         />
       );
@@ -126,6 +128,7 @@ export const getResponseItem = ({
           }
           answers={activityItemAnswer.answers as SliderRowsAnswer}
           versions={versions}
+          isStaticActive={isStaticActive}
           data-testid={activityItemAnswer.dataTestid}
         />
       );

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ResponseOptions/SelectionPerRow/SelectionPerRow.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ResponseOptions/SelectionPerRow/SelectionPerRow.tsx
@@ -14,7 +14,8 @@ export const SelectionPerRow = ({
   activityItem,
   versions,
   answers = {},
-  dataTestid,
+  isStaticActive,
+  'data-testid': dataTestid,
 }: SelectionPerRowProps) => {
   const height = (activityItem?.responseValues.options?.length + 1) * TICK_HEIGHT;
 
@@ -38,8 +39,9 @@ export const SelectionPerRow = ({
             responseType={activityItem.responseType}
             answers={answers[rowName]}
             versions={versions}
-            data-testid={`${dataTestid}-multi-scatter-chart`}
             useCategory
+            isStaticActive={isStaticActive}
+            data-testid={`${dataTestid}-select-per-row-${index}-multi-scatter-chart`}
           />
         </Box>
       ))}

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ResponseOptions/SelectionPerRow/SelectionPerRow.types.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ResponseOptions/SelectionPerRow/SelectionPerRow.types.ts
@@ -12,5 +12,6 @@ export type SelectionPerRowProps = {
   activityItem: FormattedActivityItem<SingleMultiSelectionPerRowItemResponseValues>;
   answers?: SingleMultiSelectionPerRowAnswer;
   versions: Version[];
-  dataTestid?: string;
+  isStaticActive?: boolean;
+  'data-testid'?: string;
 };

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ResponseOptions/SliderRows/SliderRows.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ResponseOptions/SliderRows/SliderRows.test.tsx
@@ -70,7 +70,7 @@ describe('SliderRows component', () => {
         activityItem={mockActivityItem}
         answers={mockAnswers}
         versions={mockVersions}
-        dataTestid="test-slider-rows"
+        data-testid="test-slider-rows"
       />,
     );
 
@@ -78,7 +78,7 @@ describe('SliderRows component', () => {
     expect(rows).toHaveLength(2);
 
     rows.forEach((row, index) => {
-      const dataTestid = `test-slider-rows-row-${index}-multi-scatter-chart`;
+      const dataTestid = `test-slider-rows-slider-rows-${index}-multi-scatter-chart`;
       expect(
         within(row).getByText(mockActivityItem.responseValues.rows[index].label),
       ).toBeInTheDocument();

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ResponseOptions/SliderRows/SliderRows.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ResponseOptions/SliderRows/SliderRows.tsx
@@ -15,7 +15,8 @@ export const SliderRows = ({
   activityItem,
   versions,
   answers = {},
-  dataTestid,
+  isStaticActive,
+  'data-testid': dataTestid,
 }: SliderRowsProps) => (
   <StyledFlexColumn>
     {activityItem?.responseValues?.rows?.map((row, index) => {
@@ -43,7 +44,8 @@ export const SliderRows = ({
             responseType={activityItem.responseType}
             answers={answers[row.id]}
             versions={versions}
-            data-testid={`${dataTestid}-row-${index}-multi-scatter-chart`}
+            isStaticActive={isStaticActive}
+            data-testid={`${dataTestid}-slider-rows-${index}-multi-scatter-chart`}
           />
         </Box>
       );

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ResponseOptions/SliderRows/SliderRows.types.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ResponseOptions/SliderRows/SliderRows.types.ts
@@ -12,5 +12,6 @@ export type SliderRowsProps = {
   activityItem: FormattedActivityItem<SliderRowsItemResponseValues>;
   answers?: SliderRowsAnswer;
   versions: Version[];
-  dataTestid?: string;
+  isStaticActive?: boolean;
+  'data-testid'?: string;
 };

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Subscales/Subscale/Subscale.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Subscales/Subscale/Subscale.test.tsx
@@ -8,17 +8,6 @@ import { renderWithProviders } from 'shared/utils/renderWithProviders';
 
 import { Subscale } from './Subscale';
 
-// jest.mock('react-hook-form', () => ({
-//   ...jest.requireActual('react-hook-form'),
-//   // useWatch: () => jest.fn(),
-//   useWatch: jest
-//     .fn()
-//     .mockReturnValue([new Date('2023-01-01'), new Date('2023-12-31'), '08:00', '17:00']),
-//   // useFormContext: () => ({
-//   //   watch: () => jest.fn(),
-//   // }),
-// }));
-
 jest.mock(
   'modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ResponseOptions/ResponseOptions.utils',
   () => ({

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Subscales/Subscale/Subscale.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Subscales/Subscale/Subscale.test.tsx
@@ -2,16 +2,22 @@
 // @ts-nocheck
 import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import * as reactHookForm from 'react-hook-form';
 
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
 
 import { Subscale } from './Subscale';
-jest.mock('react-hook-form', () => ({
-  ...jest.requireActual('react-hook-form'),
-  useFormContext: () => ({
-    watch: () => jest.fn(),
-  }),
-}));
+
+// jest.mock('react-hook-form', () => ({
+//   ...jest.requireActual('react-hook-form'),
+//   // useWatch: () => jest.fn(),
+//   useWatch: jest
+//     .fn()
+//     .mockReturnValue([new Date('2023-01-01'), new Date('2023-12-31'), '08:00', '17:00']),
+//   // useFormContext: () => ({
+//   //   watch: () => jest.fn(),
+//   // }),
+// }));
 
 jest.mock(
   'modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ResponseOptions/ResponseOptions.utils',
@@ -212,6 +218,7 @@ const subscale = {
 
 describe('Subscale component', () => {
   test('renders component with correct data', async () => {
+    jest.spyOn(reactHookForm, 'useWatch').mockReturnValue([]);
     const props = {
       isNested,
       name,

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Subscales/Subscale/Subscale.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Subscales/Subscale/Subscale.tsx
@@ -1,5 +1,4 @@
 import { Fragment } from 'react';
-import { useFormContext } from 'react-hook-form';
 import { Box } from '@mui/material';
 import uniqueId from 'lodash.uniqueid';
 import { useTranslation } from 'react-i18next';
@@ -12,7 +11,6 @@ import { SingleMultiSelectionSliderFormattedResponses } from 'modules/Dashboard/
 import { UnsupportedItemResponse } from 'modules/Dashboard/features/RespondentData/UnsupportedItemResponse';
 import { getResponseItem } from 'modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ResponseOptions/ResponseOptions.utils';
 import { StyledBodyMedium, StyledTitleBoldMedium, theme, variables } from 'shared/styles';
-import { RespondentsDataFormValues } from 'modules/Dashboard/features/RespondentData';
 import {
   UNSUPPORTED_ITEMS,
   SHOW_MORE_HEIGHT,
@@ -31,10 +29,7 @@ export const Subscale = ({
   'data-testid': dataTestid,
 }: SubscaleProps) => {
   const { t } = useTranslation('app');
-
-  const { watch } = useFormContext<RespondentsDataFormValues>();
-
-  const { minDate, maxDate, filteredVersions } = useDatavizFilters(watch, versions);
+  const { minDate, maxDate, filteredVersions } = useDatavizFilters(versions);
 
   const renderChart = (
     activityItemAnswer: SingleMultiSelectionSliderFormattedResponses,

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Subscales/Subscale/Subscale.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Subscales/Subscale/Subscale.tsx
@@ -26,6 +26,7 @@ export const Subscale = ({
   name,
   subscale,
   versions,
+  flowResponsesIndex,
   'data-testid': dataTestid,
 }: SubscaleProps) => {
   const { t } = useTranslation('app');
@@ -81,16 +82,22 @@ export const Subscale = ({
             </Box>
           )}
           {!!subscale?.items?.length &&
-            subscale?.items?.map((item, index: number) => (
-              <Box key={`${item.activityItem.id}-${index}`} sx={{ m: theme.spacing(2.4, 0) }}>
-                <CollapsedMdText
-                  text={getDictionaryText(item.activityItem.question)}
-                  maxHeight={SHOW_MORE_HEIGHT}
-                  data-testid={`${dataTestid}-question-${index}`}
-                />
-                {renderChart(item, index)}
-              </Box>
-            ))}
+            subscale?.items?.map((item, index: number) => {
+              const itemTestid = `${dataTestid}-item-${
+                flowResponsesIndex ? `${flowResponsesIndex}-` : ''
+              }${index}`;
+
+              return (
+                <Box key={`${item.activityItem.id}-${index}`} sx={{ m: theme.spacing(2.4, 0) }}>
+                  <CollapsedMdText
+                    text={getDictionaryText(item.activityItem.question)}
+                    maxHeight={SHOW_MORE_HEIGHT}
+                    data-testid={`${dataTestid}-question-${index}`}
+                  />
+                  {renderChart({ ...item, dataTestid: itemTestid }, index)}
+                </Box>
+              );
+            })}
           {!!subscale?.restScores && (
             <Box sx={{ mt: theme.spacing(4.8) }}>
               {Object.keys(subscale?.restScores)?.map((restScore, index) => (

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Subscales/Subscale/Subscale.types.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Subscales/Subscale/Subscale.types.ts
@@ -8,5 +8,6 @@ export type SubscaleProps = {
   subscale: Subscale;
   versions: Version[];
   isActivityCompletionSelected?: boolean;
+  flowResponsesIndex?: number;
   'data-testid'?: string;
 };

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Subscales/Subscales.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Subscales/Subscales.tsx
@@ -23,7 +23,12 @@ import {
   formatCurrentSubscales,
 } from './Subscales.utils';
 
-export const Subscales = ({ answers, versions, subscalesFrequency }: SubscalesProps) => {
+export const Subscales = ({
+  answers,
+  versions,
+  subscalesFrequency,
+  flowResponsesIndex,
+}: SubscalesProps) => {
   const { currentActivityCompletionData } = useContext(ReportContext);
 
   const { finalScores, latestFinalScore, allSubscalesScores, allSubscalesToRender } = useMemo(
@@ -197,7 +202,7 @@ export const Subscales = ({ answers, versions, subscalesFrequency }: SubscalesPr
     );
 
     return groupSubscales(formattedSubscales, formattedSubscales);
-  }, [allSubscalesToRender, activityCompletionToRender]);
+  }, [allSubscalesToRender, activityCompletionToRender, currentActivityCompletion]);
 
   return (
     <Box sx={{ mb: theme.spacing(6.4) }}>
@@ -217,6 +222,7 @@ export const Subscales = ({ answers, versions, subscalesFrequency }: SubscalesPr
             name={name}
             subscale={subscales[name]}
             versions={versions}
+            flowResponsesIndex={flowResponsesIndex}
             isActivityCompletionSelected={!!currentActivityCompletion}
           />
         ))}

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Subscales/Subscales.types.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Subscales/Subscales.types.ts
@@ -24,6 +24,7 @@ export type SubscalesProps = {
   answers: ActivityCompletion[];
   versions: Version[];
   subscalesFrequency: number;
+  flowResponsesIndex?: number;
 };
 
 export type ParsedSubscale = {

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/ReportMenu/ReportMenu.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/ReportMenu/ReportMenu.tsx
@@ -1,5 +1,5 @@
 import { useRef } from 'react';
-import { useFormContext, useWatch } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
 import { StyledBodyLarge, variables } from 'shared/styles';
@@ -11,6 +11,7 @@ import { StyledContainer, StyledItem, StyledTitle } from './ReportMenu.styles';
 import { setDefaultFormValues } from './ReportMenu.utils';
 import { ReportMenuProps } from './ReportMenu.types';
 import { StickyHeader } from './StickyHeader';
+import { useDataSummaryContext } from '../DataSummaryContext';
 
 export const ReportMenu = ({
   activities,
@@ -22,10 +23,10 @@ export const ReportMenu = ({
   const { t } = useTranslation('app');
   const containerRef = useRef<HTMLElement | null>(null);
   const { setValue } = useFormContext<RespondentsDataFormValues>();
-  const [selectedEntity] = useWatch({ name: ['selectedEntity'] });
+  const { selectedEntity, setSelectedEntity } = useDataSummaryContext();
 
   const handleSelectEntity = async (entity: ActivityOrFlow) => {
-    setValue('selectedEntity', entity);
+    setSelectedEntity(entity);
 
     const { hasAnswer, isPerformanceTask } = entity;
     if (!hasAnswer || isPerformanceTask) return;

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/hooks/useDatavizFilters.test.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/hooks/useDatavizFilters.test.ts
@@ -1,24 +1,21 @@
 import { renderHook } from '@testing-library/react';
+import * as reactHookForm from 'react-hook-form';
 
 import { Version } from 'api';
 
 import { useDatavizFilters } from './useDatavizFilters';
 
 describe('useDatavizFilters', () => {
-  const mockWatch = jest.fn();
-  const mockSummaryFiltersForm = {
-    startDate: new Date('2023-01-10'),
-    endDate: new Date('2023-01-15'),
-    moreFiltersVisible: false,
-    startTime: '00:00',
-    endTime: '23:59',
-  };
+  const mockFormReturnValues = [new Date('2023-01-10'), new Date('2023-01-15'), '00:00', '23:59'];
+
+  beforeEach(() => {
+    jest.spyOn(reactHookForm, 'useWatch').mockReturnValue(mockFormReturnValues);
+  });
 
   test('should calculate minDate, maxDate correctly and return empty versions', () => {
     const versions: Version[] = [];
 
-    mockWatch.mockReturnValue(mockSummaryFiltersForm);
-    const { result } = renderHook(() => useDatavizFilters(mockWatch, versions));
+    const { result } = renderHook(() => useDatavizFilters(versions));
 
     expect(result.current.minDate).toEqual(new Date('2023-01-10T00:00:00'));
     expect(result.current.maxDate).toEqual(new Date('2023-01-15T23:59:00'));
@@ -35,8 +32,7 @@ describe('useDatavizFilters', () => {
       { version: '1.1.0', createdAt: '2023-01-15T20:15:00' },
     ];
 
-    mockWatch.mockReturnValue(mockSummaryFiltersForm);
-    const { result } = renderHook(() => useDatavizFilters(mockWatch, versions));
+    const { result } = renderHook(() => useDatavizFilters(versions));
 
     expect(result.current.minDate).toEqual(new Date('2023-01-10T00:00:00'));
     expect(result.current.maxDate).toEqual(new Date('2023-01-15T23:59:00'));
@@ -60,8 +56,7 @@ describe('useDatavizFilters', () => {
       { version: '1.1.0', createdAt: '2023-01-17T20:15:00' },
     ];
 
-    mockWatch.mockReturnValue(mockSummaryFiltersForm);
-    const { result } = renderHook(() => useDatavizFilters(mockWatch, versions));
+    const { result } = renderHook(() => useDatavizFilters(versions));
 
     expect(result.current.minDate).toEqual(new Date('2023-01-10T00:00:00'));
     expect(result.current.maxDate).toEqual(new Date('2023-01-15T23:59:00'));

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/hooks/useDatavizFilters.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/hooks/useDatavizFilters.ts
@@ -1,17 +1,14 @@
 import { useMemo } from 'react';
-import { UseFormWatch } from 'react-hook-form';
+import { useWatch } from 'react-hook-form';
 import { isAfter, isBefore } from 'date-fns';
 
 import { Version } from 'api';
 import { getDateTime } from 'shared/utils/getDateTime';
 
-import { RespondentsDataFormValues } from '../../RespondentData.types';
-
-export const useDatavizFilters = (
-  watch: UseFormWatch<RespondentsDataFormValues>,
-  versions: Version[],
-) => {
-  const { startDate, endDate, startTime, endTime } = watch();
+export const useDatavizFilters = (versions: Version[]) => {
+  const [startDate, endDate, startTime, endTime]: [Date, Date, string, string] = useWatch({
+    name: ['startDate', 'endDate', 'startTime', 'endTime'],
+  });
 
   const { minDate, maxDate, filteredVersions } = useMemo(() => {
     const minDate = getDateTime(startDate, startTime);

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/hooks/useDatavizSummaryRequests/useDatavizSummaryRequests.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/hooks/useDatavizSummaryRequests/useDatavizSummaryRequests.ts
@@ -13,17 +13,19 @@ import { RespondentsDataFormValues } from 'modules/Dashboard/features/Respondent
 
 import { GetIdentifiersVersions } from '../../RespondentDataSummary.types';
 import { useDecryptedIdentifiers } from '../useDecryptedIdentifiers';
+import { useDataSummaryContext } from '../../DataSummaryContext';
 
 export const useDatavizSummaryRequests = () => {
   const { appletId, respondentId } = useParams();
   const getDecryptedIdentifiers = useDecryptedIdentifiers();
   const { setValue } = useFormContext<RespondentsDataFormValues>();
+  const { setIdentifiers, setApiVersions } = useDataSummaryContext();
 
-  const setIdentifiers = async (identifiers: Identifier[]) => {
+  const setDecryptedIdentifiers = async (identifiers: Identifier[]) => {
     if (!getDecryptedIdentifiers) return;
 
     const decryptedIdentifiers = await getDecryptedIdentifiers(identifiers);
-    setValue('identifiers', decryptedIdentifiers);
+    setIdentifiers(decryptedIdentifiers);
   };
 
   const setVersions = (versions: Version[]) => {
@@ -32,7 +34,7 @@ export const useDatavizSummaryRequests = () => {
       label: version,
     }));
     setValue('versions', versionsFilter);
-    setValue('apiVersions', versions);
+    setApiVersions(versions);
   };
 
   const getIdentifiersVersions = async ({ entity }: GetIdentifiersVersions) => {
@@ -46,7 +48,7 @@ export const useDatavizSummaryRequests = () => {
           flowId,
           targetSubjectId: respondentId,
         });
-        await setIdentifiers(identifiers.data.result);
+        await setDecryptedIdentifiers(identifiers.data.result);
 
         const versions = await getFlowVersionsApi({ appletId, flowId });
         setVersions(versions.data.result);
@@ -62,7 +64,7 @@ export const useDatavizSummaryRequests = () => {
         activityId,
         targetSubjectId: respondentId,
       });
-      await setIdentifiers(identifiers.data.result);
+      await setDecryptedIdentifiers(identifiers.data.result);
 
       const versions = await getActivityVersionsApi({ appletId, activityId });
       setVersions(versions.data.result);

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/hooks/useRespondentAnswers/useRespondentAnswers.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/hooks/useRespondentAnswers/useRespondentAnswers.ts
@@ -21,11 +21,21 @@ import { getObjectFromList } from 'shared/utils/getObjectFromList';
 import { getFormattedResponses } from '../../utils/getFormattedResponses';
 import { FetchAnswers } from '../../RespondentDataSummary.types';
 import { getDateISO, getIdentifiers, processIdentifiersChange } from './useRespondentAnswers.utils';
+import { useDataSummaryContext } from '../../DataSummaryContext';
 
 export const useRespondentAnswers = () => {
   const { appletId, respondentId } = useParams();
   const getDecryptedActivityData = useDecryptedActivityData();
   const { getValues, setValue } = useFormContext<RespondentsDataFormValues>();
+  const {
+    setAnswers,
+    setResponseOptions,
+    setSubscalesFrequency,
+    setFlowResponses,
+    setFlowSubmissions,
+    setFlowResponseOptionsCount,
+    identifiers,
+  } = useDataSummaryContext();
 
   const getActivityDecryptedAnswers = async (encryptedAnswers: EncryptedActivityAnswers[]) => {
     const decryptedAnswers = await Promise.allSettled(
@@ -77,7 +87,6 @@ export const useRespondentAnswers = () => {
         identifier: formIdentifier,
         filterByIdentifier: formFilterByIdentifier,
         versions: formVersions,
-        identifiers,
       } = getValues();
       const startTime = providedStartTime ?? formStartTime;
       const endTime = providedEndTime ?? formEndTime;
@@ -205,9 +214,9 @@ export const useRespondentAnswers = () => {
           },
         );
 
-        setValue('flowSubmissions', flowSubmissions);
-        setValue('flowResponses', flowResponses);
-        setValue('flowResponseOptionsCount', responseOptionsCount);
+        setFlowSubmissions(flowSubmissions);
+        setFlowResponses(flowResponses);
+        setFlowResponseOptionsCount(responseOptionsCount);
 
         return;
       }
@@ -221,11 +230,11 @@ export const useRespondentAnswers = () => {
       });
 
       const decryptedAnswers = await getActivityDecryptedAnswers(encryptedAnswers);
-      setValue('answers', decryptedAnswers);
+      setAnswers(decryptedAnswers);
 
       const { subscalesFrequency, formattedResponses } = getFormattedResponses(decryptedAnswers);
-      setValue('responseOptions', formattedResponses);
-      setValue('subscalesFrequency', subscalesFrequency);
+      setResponseOptions(formattedResponses);
+      setSubscalesFrequency(subscalesFrequency);
     } catch (error) {
       console.warn(error);
     }

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/hooks/useRespondentAnswers/useRespondentAnswers.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/hooks/useRespondentAnswers/useRespondentAnswers.ts
@@ -190,9 +190,12 @@ export const useRespondentAnswers = () => {
           });
         }
 
+        let responseOptionsCount = 0;
+
         const flowResponses: FlowResponses[] = Array.from(activityAnswersMap.values()).map(
           (item) => {
             const { subscalesFrequency, formattedResponses } = getFormattedResponses(item.answers);
+            responseOptionsCount += Object.values(formattedResponses).length;
 
             return {
               ...item,
@@ -204,6 +207,7 @@ export const useRespondentAnswers = () => {
 
         setValue('flowSubmissions', flowSubmissions);
         setValue('flowResponses', flowResponses);
+        setValue('flowResponseOptionsCount', responseOptionsCount);
 
         return;
       }

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -40,3 +40,4 @@ export * from './expectBanner';
 export * from './testUtils';
 export * from './toggleBooleanState';
 export * from './sortItemsByOrder';
+export * from './nullReturnFunc';

--- a/src/shared/utils/nullReturnFunc.ts
+++ b/src/shared/utils/nullReturnFunc.ts
@@ -1,0 +1,1 @@
+export const nullReturnFunc = () => null;


### PR DESCRIPTION
- [x] Tests for the changes have been added
- [x] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

🔗 [Jira Ticket M2-6674](https://mindlogger.atlassian.net/browse/M2-6674)

Changes include:

- added missing skeletons for all charts
- added flowResponseOptionsCount form value to determine if activate static for Flow
- replaced watch method with useWatch hook
- minor TS types adjustments
- unit tests fixes

### 📸 Screenshots

 | After                                 |
 | ------------------------------------- |
 | https://app.screencast.com/AAYOIclW8Ugo7 |
