### PR TITLE
fix: Update dashboard participant redirect (M2-6898)

### DIFF
--- a/src/modules/Dashboard/features/Respondents/Popups/ScheduleSetupPopup/ScheduleSetupPopup.test.tsx
+++ b/src/modules/Dashboard/features/Respondents/Popups/ScheduleSetupPopup/ScheduleSetupPopup.test.tsx
@@ -77,7 +77,7 @@ describe('ScheduleSetupPopup', () => {
     );
     await waitFor(() =>
       expect(mockedUseNavigate).toBeCalledWith(
-        `/dashboard/2e46fa32-ea7c-4a76-b49b-1c97d795bb9a/schedule/${mockedRespondentId}`,
+        `/dashboard/${mockedAppletId}/participants/${mockedSubjectId1}/schedule`,
       ),
     );
   });
@@ -100,7 +100,7 @@ describe('ScheduleSetupPopup', () => {
 
     expect(setChosenAppletDataMock).toBeCalledWith(chosenAppletDataMock);
     expect(mockedUseNavigate).toBeCalledWith(
-      `/dashboard/2e46fa32-ea7c-4a76-b49b-1c97d795bb9a/schedule/${mockedRespondentId}`,
+      `/dashboard/${mockedAppletId}/participants/${mockedSubjectId1}/schedule`,
     );
   });
 });


### PR DESCRIPTION
### 📝 Description

🔗 [M2-6898](https://mindlogger.atlassian.net/browse/M2-6898): [Dashboard] Redirect to Participant Details Schedule from Dashboard

This PR updates the redirect to a Participant's Individual Schedule, when clicking "View Individual Calendar" from the top-level **Respondents** page. Previously, this would link to the **Applet → Schedule** page, which is now only capable of viewing the Default Schedule for the applet.

Clicking this button now results in a redirect to the **Participant Details → Schedule** page.

### 📸 Screenshots

| For a respondent on the Default Schedule | For a respondent with an Individual Schedule |
|-|-|
| ![from-default-schedule](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/7951942c-9f97-4df2-82c2-229dd2f85582) | ![from-individual-schedule](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/ba0dc396-1583-404f-8632-c143321f2f6e) |

### 🪤 Peer Testing

From the **Respondents** page, while having an applet with participants…

For a participant with an _Individual Schedule_
1. Open the dropdown menu, and press "View Individual Schedule".
2. Press the relevant applet in the resulting popup. 
3. Notice that you have been redirected to that Applet & Participant's **Participant Details → Schedule** page.

For a participant with the _Default Schedule_
1. Open the dropdown menu, and press "View Individual Schedule".
2. Press the relevant applet in the resulting popup. Press to confirm the creation of an Individual Schedule.
3. Notice that you have been redirected to that Applet & Participant's **Participant Details → Schedule** page.


[M2-6898]: https://mindlogger.atlassian.net/browse/M2-6898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ