### PR TITLE
fix: Add links to `Applet → Overview` page's "Recent submissions" table. (M2-7002)

### DIFF
--- a/src/modules/Dashboard/api/api.types.ts
+++ b/src/modules/Dashboard/api/api.types.ts
@@ -305,14 +305,15 @@ export interface GetAppletSubmissionsParams extends AppletId {
 export interface GetAppletSubmissionsResponse {
   participantsCount?: number;
   submissions: {
+    activityId: string;
     activityName: string;
     appletId: string;
     createdAt: string;
-    sourceSubjectId: string;
     sourceNickname?: string | null;
+    sourceSubjectId: string;
     sourceSubjectTag?: ParticipantTag | null;
-    targetSubjectId: string;
     targetNickname?: string | null;
+    targetSubjectId: string;
     targetSubjectTag?: ParticipantTag | null;
     updatedAt: string;
   }[];

--- a/src/modules/Dashboard/features/Applet/Overview/Overview.tsx
+++ b/src/modules/Dashboard/features/Applet/Overview/Overview.tsx
@@ -1,5 +1,5 @@
-import { useMemo, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useCallback, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 import { GetAppletSubmissionsResponse, getAppletSubmissionsApi } from 'api';
@@ -9,27 +9,28 @@ import { QuickStats } from 'modules/Dashboard/features/Applet/Overview/QuickStat
 import { Spinner } from 'shared/components';
 import { StyledFlexColumn, StyledTitleLarge } from 'shared/styles';
 import { workspaces } from 'redux/modules';
-import { useAsync, usePermissions } from 'shared/hooks';
+import { useAsync, useEncryptionStorage, usePermissions } from 'shared/hooks';
 import { DEFAULT_ROWS_PER_PAGE } from 'shared/consts';
 import { checkIfCanAccessData } from 'shared/utils';
 
 import { mapResponseToQuickStatProps, mapResponseToSubmissionsTableProps } from './Overview.utils';
 import { StyledRoot } from './Overview.styles';
+import { UnlockAppletPopup } from '../../Respondents/Popups/UnlockAppletPopup';
 
 const limit = DEFAULT_ROWS_PER_PAGE;
 
 export const Overview = () => {
   const [addPopupOpen, setAddPopupOpen] = useState(false);
   const [page, setPage] = useState(1);
+  const [unlockAppletPopupOpen, setUnlockAppletPopupOpen] = useState(false);
+  const [unlockedPath, setUnlockedPath] = useState<string>();
   const { appletId } = useParams();
   const { data: workspaceRolesData } = workspaces.useRolesData();
   const { execute, isLoading, previousValue, value } = useAsync(getAppletSubmissionsApi);
+  const navigate = useNavigate();
   const { t } = useTranslation('app');
+  const { getAppletPrivateKey } = useEncryptionStorage();
   const { data } = value ?? previousValue ?? {};
-  const dashboardTableProps = useMemo(
-    () => mapResponseToSubmissionsTableProps(data ?? ({} as GetAppletSubmissionsResponse)),
-    [data],
-  );
   const roles = appletId ? workspaceRolesData?.[appletId] : undefined;
   const canAccessData = checkIfCanAccessData(roles);
   const { isForbidden, noPermissionsComponent } = usePermissions(() => {
@@ -39,13 +40,35 @@ export const Overview = () => {
   }, [page, limit, appletId]);
   const showContent = !isLoading || (isLoading && data);
 
-  const handlePopupClose = (shouldRefetch = false) => {
+  const handleViewSubmissionPopupOpen = useCallback(
+    ({ path }: { path: string }) => {
+      const hasEncryptionCheck = !!getAppletPrivateKey(appletId ?? '');
+
+      if (!hasEncryptionCheck) {
+        setUnlockAppletPopupOpen(true);
+        setUnlockedPath(path);
+      } else {
+        navigate(path);
+      }
+    },
+    [appletId, getAppletPrivateKey, navigate],
+  );
+
+  const handleAddPopupClose = (shouldRefetch = false) => {
     setAddPopupOpen(false);
 
     if (!!appletId && shouldRefetch) {
       execute({ appletId, limit });
     }
   };
+
+  const dashboardTableProps = useMemo(
+    () =>
+      mapResponseToSubmissionsTableProps(data ?? ({} as GetAppletSubmissionsResponse), {
+        onViewSubmission: handleViewSubmissionPopupOpen,
+      }),
+    [data, handleViewSubmissionPopupOpen],
+  );
 
   if (isForbidden || !canAccessData) {
     return noPermissionsComponent;
@@ -84,9 +107,26 @@ export const Overview = () => {
             <AddParticipantPopup
               appletId={appletId}
               popupVisible={addPopupOpen}
-              onClose={handlePopupClose}
+              onClose={handleAddPopupClose}
             />
           )}
+
+          <UnlockAppletPopup
+            appletId={appletId ?? ''}
+            popupVisible={unlockAppletPopupOpen}
+            setPopupVisible={(value) => {
+              setUnlockAppletPopupOpen(value);
+
+              if (!value) {
+                setUnlockedPath(undefined);
+              }
+            }}
+            onSubmitHandler={() => {
+              if (unlockedPath) {
+                navigate(unlockedPath);
+              }
+            }}
+          />
         </>
       )}
     </StyledRoot>

--- a/src/modules/Dashboard/features/Applet/Overview/Overview.utils.tsx
+++ b/src/modules/Dashboard/features/Applet/Overview/Overview.utils.tsx
@@ -2,6 +2,7 @@ import { PropsOf } from '@emotion/react';
 import { Button } from '@mui/material';
 import { formatDistanceStrict } from 'date-fns';
 import { enUS, fr } from 'date-fns/locale';
+import { generatePath } from 'react-router-dom';
 
 import i18n from 'i18n';
 import { GetAppletSubmissionsResponse, Languages } from 'api';
@@ -10,6 +11,7 @@ import { QuickStats } from 'modules/Dashboard/features/Applet/Overview/QuickStat
 import { Svg } from 'shared/components';
 import { StyledMaybeEmpty } from 'shared/styles/styledComponents/MaybeEmpty';
 import { StyledFlexAllCenter, theme, variables } from 'shared/styles';
+import { page } from 'resources';
 
 const locales = { en: enUS, fr };
 
@@ -48,10 +50,14 @@ export function mapResponseToQuickStatProps(
   };
 }
 
-export function mapResponseToSubmissionsTableProps({
-  submissions = [],
-  submissionsCount = 0,
-}: GetAppletSubmissionsResponse) {
+export function mapResponseToSubmissionsTableProps(
+  { submissions = [], submissionsCount = 0 }: GetAppletSubmissionsResponse,
+  {
+    onViewSubmission,
+  }: {
+    onViewSubmission: (params: { path: string }) => void;
+  },
+) {
   return {
     'data-testid': 'recent-submissions',
     columns: [
@@ -68,6 +74,8 @@ export function mapResponseToSubmissionsTableProps({
       submissions.length > 0
         ? submissions.map(
             ({
+              appletId,
+              activityId,
               activityName,
               createdAt,
               sourceSubjectId,
@@ -78,13 +86,23 @@ export function mapResponseToSubmissionsTableProps({
               targetSubjectTag,
             }) => {
               const createdAtDate = new Date(createdAt);
+              const path = generatePath(page.appletParticipantActivityDetailsDataSummary, {
+                activityId,
+                appletId,
+                subjectId: targetSubjectId,
+              });
+              const handleClick = () => {
+                onViewSubmission({ path });
+              };
 
               return {
                 activity: {
+                  onClick: handleClick,
                   content: () => <StyledMaybeEmpty>{activityName}</StyledMaybeEmpty>,
                   value: true,
                 },
                 respondent: {
+                  onClick: handleClick,
                   content: () => (
                     <StyledMaybeEmpty>
                       <ParticipantSnippet
@@ -98,6 +116,7 @@ export function mapResponseToSubmissionsTableProps({
                   value: true,
                 },
                 subject: {
+                  onClick: handleClick,
                   content: () => (
                     <StyledMaybeEmpty>
                       {sourceSubjectId === targetSubjectId ? (
@@ -115,6 +134,7 @@ export function mapResponseToSubmissionsTableProps({
                   value: true,
                 },
                 submissionDate: {
+                  onClick: handleClick,
                   content: () => (
                     <StyledMaybeEmpty>
                       {formatDistanceStrict(


### PR DESCRIPTION
### 📝 Description

> [!NOTE]
> This PR depends upon the backend changed introduced in https://github.com/ChildMindInstitute/mindlogger-backend-refactor/pull/1404, in order to obtain the Activity ID necessary for generating the redirect URL. 
>
> You should check out that branch before running this PR locally for testing purposes.

🔗 [M2-7002](https://mindlogger.atlassian.net/browse/M2-7002): [Overview] Nothing happens if select an item in the 'Recent Submissions' block

This is a quick follow-up to my recent [Applet Overview page PR](https://github.com/ChildMindInstitute/mindlogger-admin/pull/1757). The acceptance criteria had been updated after the fact to include an additional request for adding links to Overview table entries that redirect to the `/dashboard/{appletId}/participants/{subjectId}/activities/{activityId}/summary` page.

This PR adds this functionality, including the addition of the interstitial "UnlockAppletPopup" when decryption prior to viewing this page is necessary (similar to the behaviour when clicking an Activity from within the **Participant Details → Activities** screen.

### 📸 Screenshots

![linkified](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/af6097a0-041e-4ef8-a2ab-18841751bc61)

### 🪤 Peer Testing

Remember to have checked out [the above noted backend branch](https://github.com/ChildMindInstitute/mindlogger-backend-refactor/pull/1404).

For an applet with activity submissions…
1. Navigate to the **Applet → Overview** screen.
2. Press an entry in the Recent Submissions table.
3. Enter the applet password in the prompt, if necessary.
4. Observe that you have been redirected to the **Participant Details → Activities → Activity Summary** page.

[M2-6555]: https://mindlogger.atlassian.net/browse/M2-6555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[M2-7002]: https://mindlogger.atlassian.net/browse/M2-7002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ