### PR TITLE
fix: Update Overview page permissions (M2-6555)

### DIFF
--- a/src/modules/Dashboard/features/Applet/Overview/Overview.tsx
+++ b/src/modules/Dashboard/features/Applet/Overview/Overview.tsx
@@ -36,7 +36,7 @@ export const Overview = () => {
     if (appletId && canAccessData) {
       return execute({ appletId, page, limit });
     }
-  });
+  }, [page, limit, appletId]);
   const showContent = !isLoading || (isLoading && data);
 
   const handlePopupClose = (shouldRefetch = false) => {

--- a/src/shared/hooks/usePermissions.test.tsx
+++ b/src/shared/hooks/usePermissions.test.tsx
@@ -24,6 +24,25 @@ describe('usePermissions hook tests', () => {
     });
   });
 
+  test('should re-call asyncFn when dependencies change', async () => {
+    jest.spyOn(workspaces, 'useData').mockReturnValue({ ownerId: mockedOwnerId } as Workspace);
+    let testDeps = [0];
+    const { rerender } = renderHook(() => usePermissions(mockAsyncFunc, testDeps));
+
+    rerender();
+
+    await waitFor(() => {
+      expect(mockAsyncFunc).toBeCalledTimes(1);
+    });
+
+    testDeps = [1];
+    rerender();
+
+    await waitFor(() => {
+      expect(mockAsyncFunc).toBeCalledTimes(2);
+    });
+  });
+
   test('should not be forbidden for successful response', async () => {
     jest.spyOn(workspaces, 'useData').mockReturnValue({ ownerId: mockedOwnerId } as Workspace);
     mockAsyncFunc.mockResolvedValue({

--- a/src/shared/hooks/usePermissions.tsx
+++ b/src/shared/hooks/usePermissions.tsx
@@ -7,7 +7,10 @@ import { getErrorMessage } from 'shared/utils/errors';
 import { ApiResponseCodes } from 'shared/api';
 import { ErrorResponseType } from 'shared/types';
 
-export const usePermissions = (asyncFunc: () => Promise<any> | undefined) => {
+export const usePermissions = (
+  asyncFunc: () => Promise<any> | undefined,
+  dependencies: unknown[] = [],
+) => {
   const { t } = useTranslation('app');
   const [isForbidden, setIsForbidden] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -38,7 +41,7 @@ export const usePermissions = (asyncFunc: () => Promise<any> | undefined) => {
       }
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ownerId]);
+  }, [ownerId, ...dependencies]);
 
   return {
     isForbidden,


### PR DESCRIPTION
### 📝 Description

🔗 [M2-6555](https://mindlogger.atlassian.net/browse/M2-6555): [FE][Overview] Applet Overview Page

This PR fixes an issue where the UI state was not being handled correctly on the Overview page, when the user viewing the Overview page was not either the owner or reviewer for the given applet.

### 📸 Screenshots

| Before | After |
|-|-|
| ![localhost_3000_dashboard_c81bee80-1da8-479f-9237-212a850e0c58_overview (1)](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/7e142c5f-960d-495f-83c8-338846983b41) | ![localhost_3000_dashboard_c81bee80-1da8-479f-9237-212a850e0c58_overview](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/3e089e3a-79ac-4af2-8a78-83562b9bc908) |


### 🪤 Peer Testing

1. View an **Applet → Overview** page as a user with `Manager`, `Owner`, `SuperAdmin`, or `Reviewer` roles.
2. Notice that you are able to view the page as expected.
3. View an **Applet → Overview** page as a user with any role not listed above.
4. Notice that you are not able to view the page, and the "You do not have permission" notice is shown.

[M2-6555]: https://mindlogger.atlassian.net/browse/M2-6555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ