### PR TITLE
fix: reverse accidental `keyExtractor` regression

### DIFF
--- a/src/modules/Dashboard/components/DashboardTable/DashboardTable.tsx
+++ b/src/modules/Dashboard/components/DashboardTable/DashboardTable.tsx
@@ -64,7 +64,7 @@ export const DashboardTable = ({
           />
           <TableBody>
             {rows.map((row, index) => (
-              <TableRow key={`row-${index}`}>
+              <TableRow key={keyExtractor(row, index)}>
                 {Object.keys(row)?.map((key) => {
                   if (row[key].isHidden) {
                     return null;


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

### 📝 Description

Recent merge conflict resolution efforts caused the `keyExtractor` prop to go unused in `DashboardTable` component, causing a regression of [M2-6843](https://mindlogger.atlassian.net/browse/M2-6843). This tiny hotfix fixes that.

### 🪤 Peer Testing

- Navigate to Dashboard > Respondents screen & pin a respondent that low in the list of respondents.
    **Expected outcome:** When pinned respondent has moved to the top pinned section, its pin button has keyboard focus (as opposed to the pin button of the original row index).


[M2-6843]: https://mindlogger.atlassian.net/browse/M2-6843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ