### PR TITLE
fix: Use title case in Overview table header (M2-7010)

### DIFF
--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -164,7 +164,7 @@
     "columnActivity": "Activity",
     "columnRespondent": "Participant",
     "columnSubject": "Subject",
-    "columnSubmissionDate": "Submission date",
+    "columnSubmissionDate": "Submission Date",
     "labelSelf": "Self",
     "noDataYet": "No data yet",
     "statParticipants": "Total Participants",


### PR DESCRIPTION
### 📝 Description

🔗 [M2-7010](https://mindlogger.atlassian.net/browse/M2-7010): [Overview] In the title of the “Submission date” column, the word “date” should be capitalized

This PR updates one of the column headers for the "Recent Submissions" table in the **Applet → Overview** screen.

In general, we've preferred using title-case in English, and this change updates the column's title to reflect that, and maintain consistency with tables elsewhere.

### 📸 Screenshots

| Before | After |
|-|-|
| ![before](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/7b90b857-89a7-4029-b9c1-f52b369a6f0c) | ![after](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/6c8574c3-b473-4f40-832a-74a0fefe6a4a) |

### 🪤 Peer Testing

1. Open the **Applet → Overview** screen.
2. Observe the altered capitalization. 🔤

[M2-7010]: https://mindlogger.atlassian.net/browse/M2-7010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ