### PR TITLE
fix: DataViz - hide edit/remove Feedback Notes for non-current user (M2-4654)

### DIFF
--- a/src/modules/Dashboard/api/api.ts
+++ b/src/modules/Dashboard/api/api.ts
@@ -489,12 +489,21 @@ export const getFlowAnswersApi = (
     },
   );
 
-export const getAnswersNotesApi = (
-  { appletId, answerId, activityId, params }: ActivityAnswerParams & GetNotesParams,
+export const getNotesApi = (
+  {
+    appletId,
+    answerId,
+    activityId,
+    submitId,
+    flowId,
+    params,
+  }: Partial<ActivityAnswerParams> & Partial<FlowAnswersParams> & GetNotesParams,
   signal?: AbortSignal,
 ) =>
   authApiClient.get<Response<FeedbackNote>>(
-    `/answers/applet/${appletId}/answers/${answerId}/activities/${activityId}/notes`,
+    answerId && activityId
+      ? `/answers/applet/${appletId}/answers/${answerId}/activities/${activityId}/notes`
+      : `/answers/applet/${appletId}/submissions/${submitId}/flows/${flowId}/notes`,
     {
       params: {
         ...params,
@@ -504,86 +513,64 @@ export const getAnswersNotesApi = (
     },
   );
 
-export const getFlowNotesApi = (
-  { appletId, submitId, flowId, params }: FlowAnswersParams & GetNotesParams,
-  signal?: AbortSignal,
-) =>
-  authApiClient.get<Response<FeedbackNote>>(
-    `/answers/applet/${appletId}/submissions/${submitId}/flows/${flowId}/notes`,
-    {
-      params: {
-        ...params,
-        limit: MAX_LIMIT,
-      },
-      signal,
-    },
-  );
-
-export const createAnswerNoteApi = (
-  { appletId, answerId, activityId, note }: ActivityAnswerParams & Note,
+export const createNoteApi = (
+  {
+    appletId,
+    answerId,
+    activityId,
+    submitId,
+    flowId,
+    note,
+  }: Partial<ActivityAnswerParams> & Partial<FlowAnswersParams> & Note,
   signal?: AbortSignal,
 ) =>
   authApiClient.post(
-    `/answers/applet/${appletId}/answers/${answerId}/activities/${activityId}/notes`,
+    answerId && activityId
+      ? `/answers/applet/${appletId}/answers/${answerId}/activities/${activityId}/notes`
+      : `/answers/applet/${appletId}/submissions/${submitId}/flows/${flowId}/notes`,
     { note },
     {
       signal,
     },
   );
 
-export const createFlowNoteApi = (
-  { appletId, submitId, flowId, note }: FlowAnswersParams & Note,
-  signal?: AbortSignal,
-) =>
-  authApiClient.post(
-    `/answers/applet/${appletId}/submissions/${submitId}/flows/${flowId}/notes`,
-    { note },
-    {
-      signal,
-    },
-  );
-
-export const editAnswerNoteApi = (
-  { appletId, answerId, noteId, activityId, note }: ActivityAnswerParams & NoteId & Note,
+export const editNoteApi = (
+  {
+    appletId,
+    answerId,
+    activityId,
+    submitId,
+    flowId,
+    noteId,
+    note,
+  }: Partial<ActivityAnswerParams> & Partial<FlowAnswersParams> & NoteId & Note,
   signal?: AbortSignal,
 ) =>
   authApiClient.put(
-    `/answers/applet/${appletId}/answers/${answerId}/activities/${activityId}/notes/${noteId}`,
+    answerId && activityId
+      ? `/answers/applet/${appletId}/answers/${answerId}/activities/${activityId}/notes/${noteId}`
+      : `/answers/applet/${appletId}/submissions/${submitId}/flows/${flowId}/notes/${noteId}`,
     { note },
     {
       signal,
     },
   );
 
-export const editFlowNoteApi = (
-  { appletId, flowId, noteId, submitId, note }: FlowAnswersParams & NoteId & Note,
-  signal?: AbortSignal,
-) =>
-  authApiClient.put(
-    `/answers/applet/${appletId}/submissions/${submitId}/flows/${flowId}/notes/${noteId}`,
-    { note },
-    {
-      signal,
-    },
-  );
-
-export const deleteAnswerNoteApi = (
-  { appletId, answerId, activityId, noteId }: ActivityAnswerParams & NoteId,
+export const deleteNoteApi = (
+  {
+    appletId,
+    answerId,
+    activityId,
+    submitId,
+    flowId,
+    noteId,
+  }: Partial<ActivityAnswerParams> & Partial<FlowAnswersParams> & NoteId,
   signal?: AbortSignal,
 ) =>
   authApiClient.delete(
-    `/answers/applet/${appletId}/answers/${answerId}/activities/${activityId}/notes/${noteId}`,
-    {
-      signal,
-    },
-  );
-
-export const deleteFlowNoteApi = (
-  { appletId, flowId, noteId, submitId }: FlowAnswersParams & NoteId,
-  signal?: AbortSignal,
-) =>
-  authApiClient.delete(
-    `/answers/applet/${appletId}/submissions/${submitId}/flows/${flowId}/notes/${noteId}`,
+    answerId && activityId
+      ? `/answers/applet/${appletId}/answers/${answerId}/activities/${activityId}/notes/${noteId}`
+      : `/answers/applet/${appletId}/submissions/${submitId}/flows/${flowId}/notes/${noteId}`,
     {
       signal,
     },

--- a/src/modules/Dashboard/api/api.types.ts
+++ b/src/modules/Dashboard/api/api.types.ts
@@ -3,6 +3,7 @@ import { Item, SingleApplet, SubscaleSetting } from 'shared/state';
 import { Roles } from 'shared/consts';
 import { RetentionPeriods, EncryptedAnswerSharedProps, ExportActivity } from 'shared/types';
 import { Encryption } from 'shared/utils';
+import { User } from 'modules/Auth/state';
 
 export type GetAppletsParams = {
   params: {
@@ -330,19 +331,13 @@ export type SaveFlowAssessmentParams = AppletId &
     assessmentVersionId: string;
   };
 
-export type Reviewer = {
-  firstName: string;
-  lastName: string;
-  id: string;
-};
-
 export type Review = {
   id: string;
   createdAt: string;
   updatedAt: string;
   items: Item[];
   itemIds: string[];
-  reviewer: Reviewer;
+  reviewer: Omit<User, 'email'>;
   /* "null" returns in case the user does not have access to the answer
   (a user with the role of reviewer only has access to their own review answers) */
   answer: string | null;
@@ -540,14 +535,9 @@ export type EncryptedFlowAnswers = {
   summary: AnswerSummary;
 };
 
-type FullName = {
-  firstName: string;
-  lastName: string;
-};
-
 export type FeedbackNote = {
   id: string;
-  user: FullName;
+  user: Omit<User, 'email'>;
   note: string;
   createdAt: string;
 };

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/FeedbackNotes/FeedbackNote/FeedbackNote.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/FeedbackNotes/FeedbackNote/FeedbackNote.tsx
@@ -41,11 +41,12 @@ export const FeedbackNote = ({
 
   const { isFeedbackOpen } = useContext(RespondentDataReviewContext);
 
+  const { id, createdAt, isCurrentUserNote, user, note: noteText } = note;
   const { control, handleSubmit, setValue } = useForm({
-    defaultValues: { noteText: note.note || '' },
+    defaultValues: { noteText },
   });
 
-  const userName = `${note.user.firstName ?? ''} ${note.user.lastName ?? ''}`;
+  const userName = `${user.firstName ?? ''} ${user.lastName ?? ''}`;
 
   const commonSvgProps = {
     width: '15',
@@ -55,22 +56,23 @@ export const FeedbackNote = ({
   const saveChanges = ({ noteText }: { noteText: string }) => {
     if (!noteText.trim()) return;
     onEdit({
-      id: note.id,
+      id,
       note: noteText,
     });
     setIsEditMode(false);
   };
 
   const handleNoteEdit = () => {
-    setValue('noteText', note.note);
+    setValue('noteText', noteText);
     setIsEditMode(true);
   };
 
   useEffect(() => {
     if (!isFeedbackOpen && isEditMode) {
-      setValue('noteText', note.note);
+      setValue('noteText', noteText);
       setIsEditMode(false);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isFeedbackOpen]);
 
   return (
@@ -83,15 +85,15 @@ export const FeedbackNote = ({
         <StyledFlexTopStart>
           <StyledAuthorLabel color={variables.palette.outline}>{userName}</StyledAuthorLabel>
           <StyledBodyMedium color={variables.palette.outline}>
-            {timeAgo.format(getDateInUserTimezone(note.createdAt))}
+            {timeAgo.format(getDateInUserTimezone(createdAt))}
           </StyledBodyMedium>
         </StyledFlexTopStart>
-        {!isEditMode && isVisibleActions && (
+        {!isEditMode && isVisibleActions && isCurrentUserNote && (
           <StyledActions>
             <StyledButton onClick={handleNoteEdit} data-testid={`${dataTestid}-edit`}>
               <Svg id="edit" {...commonSvgProps} />
             </StyledButton>
-            <StyledButton onClick={() => onDelete(note.id)} data-testid={`${dataTestid}-remove`}>
+            <StyledButton onClick={() => onDelete(id)} data-testid={`${dataTestid}-remove`}>
               <Svg id="trash" {...commonSvgProps} />
             </StyledButton>
           </StyledActions>
@@ -124,7 +126,7 @@ export const FeedbackNote = ({
         </StyledForm>
       ) : (
         <StyledNote data-testid={`${dataTestid}-note`}>
-          <StyledBodyLarge>{note.note}</StyledBodyLarge>
+          <StyledBodyLarge>{noteText}</StyledBodyLarge>
         </StyledNote>
       )}
     </Box>

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/FeedbackNotes/FeedbackNote/FeedbackNote.types.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/FeedbackNotes/FeedbackNote/FeedbackNote.types.ts
@@ -1,8 +1,8 @@
-import { FeedbackNote } from 'modules/Dashboard/api';
+import { Note } from '../FeedbackNotes.types';
 
 export type FeedbackNoteProps = {
-  note: FeedbackNote;
-  onEdit: (updatedNote: Pick<FeedbackNote, 'id' | 'note'>) => void;
+  note: Note;
+  onEdit: (updatedNote: Pick<Note, 'id' | 'note'>) => void;
   onDelete: (note: string) => void;
   'data-testid'?: string;
 };

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/FeedbackNotes/FeedbackNotes.hooks.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/FeedbackNotes/FeedbackNotes.hooks.ts
@@ -3,39 +3,34 @@ import { useFormContext } from 'react-hook-form';
 import { useParams, useSearchParams } from 'react-router-dom';
 
 import { useAsync } from 'shared/hooks/useAsync';
-import {
-  createAnswerNoteApi,
-  deleteAnswerNoteApi,
-  editAnswerNoteApi,
-  getAnswersNotesApi,
-  getFlowNotesApi,
-  deleteFlowNoteApi,
-  editFlowNoteApi,
-  createFlowNoteApi,
-  FeedbackNote as FeedbackNoteType,
-} from 'modules/Dashboard/api';
+import { getNotesApi, createNoteApi, editNoteApi, deleteNoteApi } from 'modules/Dashboard/api';
 import { FeedbackForm } from 'modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback';
+import { auth } from 'modules/Auth/state';
 
 import { RespondentDataReviewContext } from '../../RespondentDataReview.context';
-import { FeedbackNotesProps } from './FeedbackNotes.types';
+import { FeedbackNotesProps, Note } from './FeedbackNotes.types';
 
 export const useFeedbackNotes = ({ entity: { id, isFlow } }: FeedbackNotesProps) => {
-  const [notes, setNotes] = useState<FeedbackNoteType[]>([]);
+  const [notes, setNotes] = useState<Note[]>([]);
   const { appletId = '' } = useParams();
   const [searchParams] = useSearchParams();
   const answerId = searchParams.get('answerId');
   const submitId = searchParams.get('submitId');
+  const { user } = auth.useData() ?? {};
 
   const { isFeedbackOpen } = useContext(RespondentDataReviewContext);
   const { setValue, handleSubmit } = useFormContext<FeedbackForm>();
 
-  const { execute: getAnswersNotes, isLoading: notesLoading } = useAsync(
-    getAnswersNotesApi,
-    (res) => res?.data?.result && setNotes(res.data.result),
-  );
-  const { execute: getFlowNotes, isLoading: flowNotesLoading } = useAsync(
-    getFlowNotesApi,
-    (res) => res?.data?.result && setNotes(res.data.result),
+  const { execute: getNotes, isLoading: getNotesLoading } = useAsync(
+    getNotesApi,
+    (res) =>
+      res?.data?.result &&
+      setNotes(
+        res.data.result.map((note) => ({
+          ...note,
+          isCurrentUserNote: user?.id === note.user.id,
+        })),
+      ),
   );
 
   const updateListOfNotes = useCallback(() => {
@@ -44,57 +39,33 @@ export const useFeedbackNotes = ({ entity: { id, isFlow } }: FeedbackNotesProps)
     const commonParams = { appletId, params: {} };
 
     if (isFlow && submitId) {
-      getFlowNotes({ ...commonParams, submitId, flowId: id });
-
-      return;
+      getNotes({ ...commonParams, submitId, flowId: id });
+    } else if (answerId) {
+      getNotes({ ...commonParams, answerId, activityId: id });
     }
-
-    if (!answerId) return;
-
-    getAnswersNotes({ ...commonParams, answerId, activityId: id });
-  }, [appletId, id, isFlow, submitId, answerId, getFlowNotes, getAnswersNotes]);
+  }, [appletId, id, isFlow, submitId, answerId, getNotes]);
 
   const handleUpdateNote = () => {
     setValue('newNote', '');
     updateListOfNotes();
   };
 
-  const { execute: createAnswerNote, isLoading: createNoteLoading } = useAsync(
-    createAnswerNoteApi,
+  const { execute: createNote, isLoading: createNoteLoading } = useAsync(
+    createNoteApi,
     handleUpdateNote,
   );
-  const { execute: createFlowNote, isLoading: createFlowNoteLoading } = useAsync(
-    createFlowNoteApi,
-    handleUpdateNote,
-  );
-  const { execute: editAnswerNote, isLoading: editNoteLoading } = useAsync(
-    editAnswerNoteApi,
+  const { execute: editNote, isLoading: editNoteLoading } = useAsync(
+    editNoteApi,
     updateListOfNotes,
   );
-  const { execute: editFlowNote, isLoading: editFlowNoteLoading } = useAsync(
-    editFlowNoteApi,
-    updateListOfNotes,
-  );
-  const { execute: deleteAnswerNote, isLoading: deleteNoteLoading } = useAsync(
-    deleteAnswerNoteApi,
-    updateListOfNotes,
-  );
-  const { execute: deleteFlowNote, isLoading: deleteFlowNoteLoading } = useAsync(
-    deleteFlowNoteApi,
+  const { execute: deleteNote, isLoading: deleteNoteLoading } = useAsync(
+    deleteNoteApi,
     updateListOfNotes,
   );
 
-  const isLoading =
-    notesLoading ||
-    flowNotesLoading ||
-    editNoteLoading ||
-    editFlowNoteLoading ||
-    deleteNoteLoading ||
-    deleteFlowNoteLoading ||
-    createNoteLoading ||
-    createFlowNoteLoading;
+  const isLoading = getNotesLoading || editNoteLoading || deleteNoteLoading || createNoteLoading;
 
-  const handleNoteEdit = (updatedNote: Pick<FeedbackNoteType, 'id' | 'note'>) => {
+  const handleNoteEdit = (updatedNote: Pick<Note, 'id' | 'note'>) => {
     if (!appletId || !id) return;
 
     const commonParams = {
@@ -104,18 +75,14 @@ export const useFeedbackNotes = ({ entity: { id, isFlow } }: FeedbackNotesProps)
     };
 
     if (isFlow && submitId) {
-      editFlowNote({ ...commonParams, submitId, flowId: id });
-
-      return;
+      editNote({ ...commonParams, submitId, flowId: id });
+    } else if (answerId) {
+      editNote({
+        ...commonParams,
+        answerId,
+        activityId: id,
+      });
     }
-
-    if (!answerId) return;
-
-    editAnswerNote({
-      ...commonParams,
-      answerId,
-      activityId: id,
-    });
   };
 
   const handleNoteDelete = (noteId: string) => {
@@ -124,14 +91,10 @@ export const useFeedbackNotes = ({ entity: { id, isFlow } }: FeedbackNotesProps)
     const commonParams = { appletId, noteId };
 
     if (isFlow && submitId) {
-      deleteFlowNote({ ...commonParams, submitId, flowId: id });
-
-      return;
+      deleteNote({ ...commonParams, submitId, flowId: id });
+    } else if (answerId) {
+      deleteNote({ ...commonParams, answerId, activityId: id });
     }
-
-    if (!answerId) return;
-
-    deleteAnswerNote({ ...commonParams, answerId, activityId: id });
   };
 
   const addNewNote = ({ newNote }: FeedbackForm) => {
@@ -140,14 +103,10 @@ export const useFeedbackNotes = ({ entity: { id, isFlow } }: FeedbackNotesProps)
     const commonParams = { appletId, note: newNote };
 
     if (isFlow && submitId) {
-      createFlowNote({ ...commonParams, submitId, flowId: id });
-
-      return;
+      createNote({ ...commonParams, submitId, flowId: id });
+    } else if (answerId) {
+      createNote({ ...commonParams, answerId, activityId: id });
     }
-
-    if (!answerId) return;
-
-    createAnswerNote({ ...commonParams, answerId, activityId: id });
   };
 
   useEffect(() => {

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/FeedbackNotes/FeedbackNotes.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/FeedbackNotes/FeedbackNotes.test.tsx
@@ -29,6 +29,7 @@ const mockedSubmitId = 'some-submit-id';
 const routeWithAnswerId = `/dashboard/${mockedAppletId}/respondents/${mockedRespondent}/dataviz/responses?selectedDate=2023-11-27&answerId=${mockedAnswerId}`;
 const routeWithSubmitId = `/dashboard/${mockedAppletId}/respondents/${mockedRespondent}/dataviz/responses?selectedDate=2023-11-27&submitId=${mockedSubmitId}`;
 const routePath = page.appletRespondentDataReview;
+const firstUserId = 'user-id-1';
 const preloadedState = {
   workspaces: {
     workspaces: initialStateData,
@@ -51,6 +52,21 @@ const preloadedState = {
       data: { result: mockedApplet },
     },
   },
+  auth: {
+    authentication: {
+      ...initialStateData,
+      data: {
+        user: {
+          email: 'test@test.com',
+          firstName: 'John',
+          lastName: 'Doe',
+          id: firstUserId,
+        },
+      },
+    },
+    isAuthorized: true,
+    isLogoutInProgress: false,
+  },
 };
 
 const mockedActivity = {
@@ -71,6 +87,7 @@ const mockedGetWithNotes = {
         user: {
           firstName: 'John',
           lastName: 'Doe',
+          id: firstUserId,
         },
         note: 'New note',
         createdAt: '2023-11-29T12:14:58.395686',
@@ -80,6 +97,7 @@ const mockedGetWithNotes = {
         user: {
           firstName: 'Jane',
           lastName: 'Doe',
+          id: 'user-id-2',
         },
         note: 'Note 1',
         createdAt: '2023-11-28T09:01:44.861355',
@@ -279,5 +297,23 @@ describe('FeedbackNotes', () => {
     await testNoteRemoving(
       `/answers/applet/${mockedAppletId}/submissions/${mockedSubmitId}/flows/${mockedFlow.id}/notes/950fe4cc-dddb-4b5f-bdb5-4f3966dbed7e`,
     );
+  });
+
+  test('should hide remove and edit options for notes not created by the current user', async () => {
+    mockGetWithNotes();
+    renderFeedbackNotes(mockedFlow, routeWithSubmitId);
+
+    await waitFor(async () => {
+      const noteHeader = screen.queryByTestId(`${noteTestId}-1-header`) as HTMLElement;
+
+      expect(noteHeader).toBeInTheDocument();
+
+      await userEvent.hover(noteHeader);
+      const editAction = screen.queryByTestId(`${noteTestId}-1-edit`) as HTMLElement;
+      const removeAction = screen.queryByTestId(`${noteTestId}-1-remove`) as HTMLElement;
+
+      expect(editAction).not.toBeInTheDocument();
+      expect(removeAction).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/FeedbackNotes/FeedbackNotes.types.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/FeedbackNotes/FeedbackNotes.types.ts
@@ -1,3 +1,7 @@
+import { FeedbackNote } from 'modules/Dashboard/api';
+
 import { SelectedEntity } from '../Feedback.types';
 
 export type FeedbackNotesProps = { entity: SelectedEntity };
+
+export type Note = FeedbackNote & { isCurrentUserNote: boolean };

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/FeedbackReviews/FeedbackReviews.types.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/FeedbackReviews/FeedbackReviews.types.ts
@@ -1,6 +1,6 @@
 import { AssessmentActivityItem } from 'modules/Dashboard/features/RespondentData/RespondentDataReview';
 import { EncryptedAnswerSharedProps } from 'shared/types';
-import { Reviewer, Review as ReviewApi } from 'modules/Dashboard/api';
+import { Review as ReviewApi } from 'modules/Dashboard/api';
 
 export type Review = EncryptedAnswerSharedProps & ReviewData;
 
@@ -8,7 +8,7 @@ export type ReviewData = {
   reviewId: string;
   updatedAt: string;
   isCurrentUserReviewer: boolean;
-  reviewer: Reviewer;
+  reviewer: ReviewApi['reviewer'];
   review: AssessmentActivityItem[] | null;
 };
 


### PR DESCRIPTION
- [x] Tests for the changes have been added
- [x] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

🔗 [Jira Ticket M2-4654](https://mindlogger.atlassian.net/browse/M2-4654)

Changes include:
- Merged API routes for Activity answers and Flow answers Feedback Notes
- Replaced user type in Feedback Notes and Reviews with the type from auth schema 
- Hide edit and remove options for non-current user Feedback Notes
- Added test for edit and remove Feedback Notes for non-current user, corrected existing unit tests

### 📸 Screenshots

| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| <!-- Paste before image/video here --> | https://app.screencast.com/sDqlqdsODN3OS |
