### PR TITLE
fix: Remove pagination from Overview table (M2-6555)

### DIFF
--- a/src/modules/Dashboard/components/DashboardTable/DashboardTable.styles.ts
+++ b/src/modules/Dashboard/components/DashboardTable/DashboardTable.styles.ts
@@ -29,7 +29,10 @@ export const StyledTableCell = styled(TableCell, shouldForwardProp)`
   }}
 `;
 
-export const StyledTableHead = styled(TableHead)({
-  '&& tr:nth-of-type(2) th': { padding: '1.2rem' },
-  '&& tr th:first-of-type': { paddingLeft: '2rem' },
-});
+export const StyledTableHead = styled(TableHead)(
+  ({ enablePagination = true }: { enablePagination?: boolean }) => ({
+    '&& tr:nth-of-type(2) th': { padding: '1.2rem' },
+    '&& tr th:first-of-type': { paddingLeft: '2rem' },
+    ...(enablePagination ? {} : { '&& th': { top: 0 } }),
+  }),
+);

--- a/src/modules/Dashboard/components/DashboardTable/DashboardTable.test.tsx
+++ b/src/modules/Dashboard/components/DashboardTable/DashboardTable.test.tsx
@@ -4,7 +4,7 @@ import { createArray } from 'shared/utils';
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
 
 import { DashboardTable } from './DashboardTable';
-import { DashboardTableProps } from './DashboardTable.types';
+import { DashboardTablePropsWithPagination } from './DashboardTable.types';
 
 const mockColumns = [
   {
@@ -46,7 +46,7 @@ const mockSortFn = jest.fn();
 const mockChangePageFn = jest.fn();
 const mockDataTestId = 'mockDataTestId';
 
-const getTable = (props: Partial<DashboardTableProps> = {}) => (
+const getTable = (props?: Partial<DashboardTablePropsWithPagination>) => (
   <DashboardTable
     columns={mockColumns}
     order="asc"
@@ -65,6 +65,26 @@ const getTable = (props: Partial<DashboardTableProps> = {}) => (
 describe('DashboardTable component tests', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe('When `enablePagination` is `false`', () => {
+    beforeEach(() => {
+      renderWithProviders(
+        <DashboardTable
+          data-testid={mockDataTestId}
+          columns={mockColumns}
+          rows={getMockRows()}
+          enablePagination={false}
+          handleRequestSort={() => {}}
+          order="desc"
+          orderBy=""
+        />,
+      );
+    });
+
+    test('should render without pagination controls', () => {
+      expect(screen.queryByTestId(`${mockDataTestId}-table-pagination`)).not.toBeInTheDocument();
+    });
   });
 
   test('should render empty component for empty table', () => {

--- a/src/modules/Dashboard/components/DashboardTable/DashboardTable.tsx
+++ b/src/modules/Dashboard/components/DashboardTable/DashboardTable.tsx
@@ -8,39 +8,40 @@ import { StyledEllipsisText } from 'shared/styles';
 import { DashboardTableProps } from './DashboardTable.types';
 import { StyledTableCell, StyledTableHead } from './DashboardTable.styles';
 
-export const DashboardTable = ({
-  columns,
-  rows,
-  keyExtractor = (_row: Row, index: number) => `row-${index}`,
-  maxHeight = '100%',
-  uiType = UiType.Primary,
-  className = '',
-  order,
-  orderBy,
-  emptyComponent,
-  page,
-  handleRequestSort,
-  handleChangePage,
-  count,
-  hasColFixedWidth,
-  rowsPerPage = DEFAULT_ROWS_PER_PAGE,
-  onScroll,
-  'data-testid': dataTestid,
-}: DashboardTableProps) => {
-  const tableHeader = (
-    <StyledTableCellContent uiType={uiType}>
-      <TablePagination
-        component="div"
-        count={count}
-        rowsPerPage={rowsPerPage}
-        page={page - 1}
-        onPageChange={handleChangePage}
-        labelRowsPerPage=""
-        rowsPerPageOptions={[]}
-        data-testid={`${dataTestid}-table-pagination`}
-      />
-    </StyledTableCellContent>
-  );
+export const DashboardTable = (props: DashboardTableProps) => {
+  const {
+    'data-testid': dataTestid,
+    className,
+    columns,
+    emptyComponent,
+    enablePagination = true,
+    handleRequestSort,
+    hasColFixedWidth,
+    keyExtractor = (_row: Row, index: number) => `row-${index}`,
+    maxHeight = '100%',
+    onScroll,
+    order,
+    orderBy,
+    rows = [],
+    rowsPerPage = DEFAULT_ROWS_PER_PAGE,
+    uiType = UiType.Primary,
+  } = props;
+
+  const tableHeader =
+    props.enablePagination === false ? null : (
+      <StyledTableCellContent uiType={uiType}>
+        <TablePagination
+          component="div"
+          count={props.count}
+          rowsPerPage={rowsPerPage}
+          page={(props.page ?? 1) - 1}
+          onPageChange={props.handleChangePage}
+          labelRowsPerPage=""
+          rowsPerPageOptions={[]}
+          data-testid={`${dataTestid}-table-pagination`}
+        />
+      </StyledTableCellContent>
+    );
 
   return (
     <StyledTableContainer
@@ -54,13 +55,14 @@ export const DashboardTable = ({
       {!!rows?.length && (
         <MuiTable stickyHeader data-testid={dataTestid}>
           <StyledTableHead
+            enablePagination={enablePagination}
+            hasColFixedWidth={hasColFixedWidth}
             headCells={columns}
+            onRequestSort={handleRequestSort}
             order={order}
             orderBy={orderBy}
-            onRequestSort={handleRequestSort}
             tableHeader={tableHeader}
             uiType={uiType}
-            hasColFixedWidth={hasColFixedWidth}
           />
           <TableBody>
             {rows.map((row, index) => (

--- a/src/modules/Dashboard/components/DashboardTable/DashboardTable.types.ts
+++ b/src/modules/Dashboard/components/DashboardTable/DashboardTable.types.ts
@@ -3,23 +3,39 @@ import { MouseEvent, UIEvent } from 'react';
 import { Row, UiType } from 'shared/components';
 import { HeadCell, Order } from 'shared/types';
 
-export type DashboardTableProps = {
-  uiType?: UiType;
-  maxHeight?: string;
+interface DashboardTableCommonProps {
+  'data-testid'?: string;
   className?: string;
   columns: HeadCell[];
-  rows?: Row[];
+  emptyComponent?: JSX.Element | string;
+  handleRequestSort: (event: MouseEvent<unknown>, property: string) => void;
+  hasColFixedWidth?: boolean;
   keyExtractor?: (item: Row, index: number) => string;
+  maxHeight?: string;
+  onScroll?: (event: UIEvent<HTMLDivElement>) => void;
   order: Order;
   orderBy: string;
-  handleRequestSort: (event: MouseEvent<unknown>, property: string) => void;
-  page: number;
-  count: number;
-  emptyComponent?: JSX.Element | string;
+  rows?: Row[];
   searchValue?: string;
+  uiType?: UiType;
+}
+
+export interface DashboardTablePropsWithoutPagination extends DashboardTableCommonProps {
+  count?: never;
+  enablePagination: false;
+  handleChangePage?: never;
+  page?: never;
+  rowsPerPage?: never;
+}
+
+export interface DashboardTablePropsWithPagination extends DashboardTableCommonProps {
+  count: number;
+  enablePagination?: true;
   handleChangePage: (event: unknown, newPage: number) => void;
+  page: number;
   rowsPerPage?: number;
-  hasColFixedWidth?: boolean;
-  onScroll?: (event: UIEvent<HTMLDivElement>) => void;
-  'data-testid'?: string;
-};
+}
+
+export type DashboardTableProps =
+  | DashboardTablePropsWithoutPagination
+  | DashboardTablePropsWithPagination;

--- a/src/modules/Dashboard/features/Applet/Overview/Overview.tsx
+++ b/src/modules/Dashboard/features/Applet/Overview/Overview.tsx
@@ -10,18 +10,16 @@ import { Spinner } from 'shared/components';
 import { StyledFlexColumn, StyledTitleLarge } from 'shared/styles';
 import { workspaces } from 'redux/modules';
 import { useAsync, useEncryptionStorage, usePermissions } from 'shared/hooks';
-import { DEFAULT_ROWS_PER_PAGE } from 'shared/consts';
 import { checkIfCanAccessData } from 'shared/utils';
 
 import { mapResponseToQuickStatProps, mapResponseToSubmissionsTableProps } from './Overview.utils';
 import { StyledRoot } from './Overview.styles';
 import { UnlockAppletPopup } from '../../Respondents/Popups/UnlockAppletPopup';
 
-const limit = DEFAULT_ROWS_PER_PAGE;
+const limit = 25;
 
 export const Overview = () => {
   const [addPopupOpen, setAddPopupOpen] = useState(false);
-  const [page, setPage] = useState(1);
   const [unlockAppletPopupOpen, setUnlockAppletPopupOpen] = useState(false);
   const [unlockedPath, setUnlockedPath] = useState<string>();
   const { appletId } = useParams();
@@ -35,9 +33,9 @@ export const Overview = () => {
   const canAccessData = checkIfCanAccessData(roles);
   const { isForbidden, noPermissionsComponent } = usePermissions(() => {
     if (appletId && canAccessData) {
-      return execute({ appletId, page, limit });
+      return execute({ appletId, limit });
     }
-  }, [page, limit, appletId]);
+  }, [appletId, limit]);
   const showContent = !isLoading || (isLoading && data);
 
   const handleViewSubmissionPopupOpen = useCallback(
@@ -91,16 +89,7 @@ export const Overview = () => {
           <StyledFlexColumn sx={{ gap: 1.6 }}>
             <StyledTitleLarge>{t('appletOverview.titleRecentSubmissions')}</StyledTitleLarge>
 
-            <DashboardTable
-              {...dashboardTableProps}
-              handleChangePage={(_, nextPage) => {
-                // DashboardTable passes it's `handleChangePage` prop a 0-based
-                // index value, but accepts its `page` prop as 1-based.
-                setPage(nextPage + 1);
-              }}
-              page={page}
-              rowsPerPage={limit}
-            />
+            <DashboardTable {...dashboardTableProps} enablePagination={false} />
           </StyledFlexColumn>
 
           {appletId && addPopupOpen && (

--- a/src/modules/Dashboard/features/Applet/Overview/Overview.utils.tsx
+++ b/src/modules/Dashboard/features/Applet/Overview/Overview.utils.tsx
@@ -51,7 +51,7 @@ export function mapResponseToQuickStatProps(
 }
 
 export function mapResponseToSubmissionsTableProps(
-  { submissions = [], submissionsCount = 0 }: GetAppletSubmissionsResponse,
+  { submissions = [] }: GetAppletSubmissionsResponse,
   {
     onViewSubmission,
   }: {
@@ -66,7 +66,6 @@ export function mapResponseToSubmissionsTableProps(
       { id: 'subject', label: i18n.t('appletOverview.columnSubject') },
       { id: 'submissionDate', label: i18n.t('appletOverview.columnSubmissionDate') },
     ],
-    count: submissionsCount ?? submissions?.length,
     handleRequestSort: () => {},
     order: 'desc' as const,
     orderBy: '',

--- a/src/modules/Dashboard/features/Applets/AppletsTable/AppletsTable.types.ts
+++ b/src/modules/Dashboard/features/Applets/AppletsTable/AppletsTable.types.ts
@@ -1,7 +1,7 @@
-import { DashboardTableProps } from 'modules/Dashboard/components';
+import { DashboardTablePropsWithPagination } from 'modules/Dashboard/components';
 import { Applet, Folder } from 'api';
 
-export type AppletsTableProps = Omit<DashboardTableProps, 'rows'> & {
+export type AppletsTableProps = Omit<DashboardTablePropsWithPagination, 'rows'> & {
   rows?: (Folder | Applet)[];
   headerContent: JSX.Element;
   handleReload: () => void;


### PR DESCRIPTION
### 📝 Description

🔗 [M2-6555](https://mindlogger.atlassian.net/browse/M2-6555): [FE][Overview] Applet Overview Page

This PR removes the pagination controls from the Recent Submissions table on the **Applet → Overview** screen.

Our existing table components do not support _un-paginated_ tables, and the table controls could not be previously opted out of, so I updated the `DashboardTable` to add an `enablePagination` prop which defaults to true, and updated the `DashboardTable`'s types accordingly, so that previously-required pagination-related props should be omitted when `enablePagination` is set to `false`.

### 📸 Screenshots

![localhost_3000_dashboard_c81bee80-1da8-479f-9237-212a850e0c58_overview](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/0577bff6-74b5-4860-b99e-272408a97a52)

### 🪤 Peer Testing

Have an applet, ideally with more than 25 submissions against various activities.

1. Navigate to the **Applet → Overview** screen for the applet.
2. Observe that the recent submissions table does not have any pagination controls, and older submissions cannot be viewed.

[M2-6555]: https://mindlogger.atlassian.net/browse/M2-6555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ