### PR TITLE
feat(mi): Include full account participants in take now (M2-6533)

### DIFF
--- a/src/modules/Dashboard/components/TakeNowModal/LabeledDropdown/LabeledUserDropdown.test.tsx
+++ b/src/modules/Dashboard/components/TakeNowModal/LabeledDropdown/LabeledUserDropdown.test.tsx
@@ -3,9 +3,24 @@ import userEvent from '@testing-library/user-event';
 
 import { LabeledUserDropdown } from 'modules/Dashboard/components/TakeNowModal/LabeledDropdown/LabeledUserDropdown';
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
+import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
+
+import { ParticipantDropdownOption } from './LabeledUserDropdown.types';
+
+jest.mock('shared/hooks/useFeatureFlags');
+
+const mockUseFeatureFlags = jest.mocked(useFeatureFlags);
 
 describe('LabeledUserDropdown', () => {
   const dataTestId = 'test';
+
+  beforeEach(() => {
+    mockUseFeatureFlags.mockReturnValue({
+      featureFlags: {
+        enableParticipantMultiInformant: false,
+      },
+    });
+  });
 
   test('Shows label', () => {
     const { queryByText } = renderWithProviders(
@@ -104,5 +119,221 @@ describe('LabeledUserDropdown', () => {
     );
 
     expect(queryByDisplayValue(testValue.secretId)).toBeInTheDocument();
+  });
+
+  test('Does not show warning message when the value is not present', () => {
+    const { queryByTestId } = renderWithProviders(
+      <LabeledUserDropdown
+        label="Test Label"
+        tooltip="Test Tooltip"
+        name="test"
+        options={[]}
+        value={null}
+        placeholder=""
+        onChange={jest.fn()}
+        data-testid={dataTestId}
+        canShowWarningMessage={true}
+      />,
+    );
+
+    expect(queryByTestId(`${dataTestId}-warning-message`)).not.toBeInTheDocument();
+  });
+
+  test('Does not show warning for team members', () => {
+    const option: ParticipantDropdownOption = {
+      id: 'subject-id',
+      userId: 'user-id',
+      tag: 'Team',
+    };
+
+    const { queryByTestId } = renderWithProviders(
+      <LabeledUserDropdown
+        label="Test Label"
+        tooltip="Test Tooltip"
+        name="test"
+        options={[option]}
+        value={option}
+        placeholder=""
+        onChange={jest.fn()}
+        data-testid={dataTestId}
+        canShowWarningMessage={true}
+      />,
+    );
+
+    expect(queryByTestId(`${dataTestId}-warning-message`)).not.toBeInTheDocument();
+  });
+
+  test('Shows warning for full account participants', () => {
+    const option: ParticipantDropdownOption = {
+      id: 'subject-id',
+      userId: 'user-id',
+      tag: 'Teacher',
+    };
+
+    const { queryByTestId } = renderWithProviders(
+      <LabeledUserDropdown
+        label="Test Label"
+        tooltip="Test Tooltip"
+        name="test"
+        options={[option]}
+        value={option}
+        placeholder=""
+        onChange={jest.fn()}
+        data-testid={dataTestId}
+        canShowWarningMessage={true}
+      />,
+    );
+
+    expect(queryByTestId(`${dataTestId}-warning-message`)).toBeInTheDocument();
+  });
+
+  test('Shows warning for limited account participants', () => {
+    const option: ParticipantDropdownOption = {
+      id: 'subject-id',
+      tag: 'Child',
+    };
+
+    const { queryByTestId } = renderWithProviders(
+      <LabeledUserDropdown
+        label="Test Label"
+        tooltip="Test Tooltip"
+        name="test"
+        options={[option]}
+        value={option}
+        placeholder=""
+        onChange={jest.fn()}
+        data-testid={dataTestId}
+        canShowWarningMessage={true}
+      />,
+    );
+
+    expect(queryByTestId(`${dataTestId}-warning-message`)).toBeInTheDocument();
+  });
+
+  test('Does not show warning when canShowWarningMessage = false', () => {
+    const option: ParticipantDropdownOption = {
+      id: 'subject-id',
+      tag: 'Child',
+    };
+
+    const { queryByTestId } = renderWithProviders(
+      <LabeledUserDropdown
+        label="Test Label"
+        tooltip="Test Tooltip"
+        name="test"
+        options={[option]}
+        value={option}
+        placeholder=""
+        onChange={jest.fn()}
+        data-testid={dataTestId}
+        canShowWarningMessage={false}
+      />,
+    );
+
+    expect(queryByTestId(`${dataTestId}-warning-message`)).not.toBeInTheDocument();
+  });
+
+  describe('featureFlags.enableParticipantMultiInformant = true', () => {
+    beforeEach(() => {
+      mockUseFeatureFlags.mockReturnValue({
+        featureFlags: {
+          enableParticipantMultiInformant: true,
+        },
+      });
+    });
+
+    test('Does not show warning for team members', () => {
+      const option: ParticipantDropdownOption = {
+        id: 'subject-id',
+        userId: 'user-id',
+        tag: 'Team',
+      };
+
+      const { queryByTestId } = renderWithProviders(
+        <LabeledUserDropdown
+          label="Test Label"
+          tooltip="Test Tooltip"
+          name="test"
+          options={[option]}
+          value={option}
+          placeholder=""
+          onChange={jest.fn()}
+          data-testid={dataTestId}
+          canShowWarningMessage={true}
+        />,
+      );
+
+      expect(queryByTestId(`${dataTestId}-warning-message`)).not.toBeInTheDocument();
+    });
+
+    test('Does not show warning for full account participants', () => {
+      const option: ParticipantDropdownOption = {
+        id: 'subject-id',
+        userId: 'user-id',
+        tag: 'Teacher',
+      };
+
+      const { queryByTestId } = renderWithProviders(
+        <LabeledUserDropdown
+          label="Test Label"
+          tooltip="Test Tooltip"
+          name="test"
+          options={[option]}
+          value={option}
+          placeholder=""
+          onChange={jest.fn()}
+          data-testid={dataTestId}
+          canShowWarningMessage={true}
+        />,
+      );
+
+      expect(queryByTestId(`${dataTestId}-warning-message`)).not.toBeInTheDocument();
+    });
+
+    test('Shows warning for limited account participants', () => {
+      const option: ParticipantDropdownOption = {
+        id: 'subject-id',
+        tag: 'Child',
+      };
+
+      const { queryByTestId } = renderWithProviders(
+        <LabeledUserDropdown
+          label="Test Label"
+          tooltip="Test Tooltip"
+          name="test"
+          options={[option]}
+          value={option}
+          placeholder=""
+          onChange={jest.fn()}
+          data-testid={dataTestId}
+          canShowWarningMessage={true}
+        />,
+      );
+
+      expect(queryByTestId(`${dataTestId}-warning-message`)).toBeInTheDocument();
+    });
+
+    test('Does not show warning when canShowWarningMessage = false', () => {
+      const option: ParticipantDropdownOption = {
+        id: 'subject-id',
+        tag: 'Child',
+      };
+
+      const { queryByTestId } = renderWithProviders(
+        <LabeledUserDropdown
+          label="Test Label"
+          tooltip="Test Tooltip"
+          name="test"
+          options={[option]}
+          value={option}
+          placeholder=""
+          onChange={jest.fn()}
+          data-testid={dataTestId}
+          canShowWarningMessage={false}
+        />,
+      );
+
+      expect(queryByTestId(`${dataTestId}-warning-message`)).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/modules/Dashboard/components/TakeNowModal/LabeledDropdown/LabeledUserDropdown.tsx
+++ b/src/modules/Dashboard/components/TakeNowModal/LabeledDropdown/LabeledUserDropdown.tsx
@@ -13,6 +13,7 @@ import {
   variables,
 } from 'shared/styles';
 import { ParticipantSnippet } from 'modules/Dashboard/components/ParticipantSnippet';
+import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 
 import { LabeledUserDropdownProps, ParticipantDropdownOption } from './LabeledUserDropdown.types';
 import { StyledGroupLabel, StyledWarningMessageContainer } from './LabeledUserDropdown.styles';
@@ -37,6 +38,9 @@ export const LabeledUserDropdown = ({
   const debounceRef = useRef<NodeJS.Timeout | null>(null);
   const [combinedOptions, setCombinedOptions] = useState<ParticipantDropdownOption[]>(options);
   const [isSearching, setIsSearching] = useState(false);
+  const {
+    featureFlags: { enableParticipantMultiInformant },
+  } = useFeatureFlags();
 
   const debouncedSearchHandler = useCallback(
     (search: string) => {
@@ -69,7 +73,9 @@ export const LabeledUserDropdown = ({
     [debounce, handleSearch],
   );
 
-  const shouldShowWarningMessage = !!canShowWarningMessage && !!value && !value.userId;
+  const warningMessageValueCondition =
+    !!value && (enableParticipantMultiInformant ? !value.userId : value.tag !== 'Team');
+  const shouldShowWarningMessage = !!canShowWarningMessage && warningMessageValueCondition;
 
   let groupBy: LabeledUserDropdownProps['groupBy'];
 

--- a/src/modules/Dashboard/components/TakeNowModal/LabeledDropdown/LabeledUserDropdown.tsx
+++ b/src/modules/Dashboard/components/TakeNowModal/LabeledDropdown/LabeledUserDropdown.tsx
@@ -69,7 +69,7 @@ export const LabeledUserDropdown = ({
     [debounce, handleSearch],
   );
 
-  const shouldShowWarningMessage = !!canShowWarningMessage && !!value && value.tag !== 'Team';
+  const shouldShowWarningMessage = !!canShowWarningMessage && !!value && !value.userId;
 
   let groupBy: LabeledUserDropdownProps['groupBy'];
 

--- a/src/modules/Dashboard/components/TakeNowModal/LabeledDropdown/LabeledUserDropdown.tsx
+++ b/src/modules/Dashboard/components/TakeNowModal/LabeledDropdown/LabeledUserDropdown.tsx
@@ -34,7 +34,7 @@ export const LabeledUserDropdown = ({
   showGroups,
   ...rest
 }: LabeledUserDropdownProps) => {
-  const { t } = useTranslation('app');
+  const { t, i18n } = useTranslation('app');
   const debounceRef = useRef<NodeJS.Timeout | null>(null);
   const [combinedOptions, setCombinedOptions] = useState<ParticipantDropdownOption[]>(options);
   const [isSearching, setIsSearching] = useState(false);
@@ -173,13 +173,18 @@ export const LabeledUserDropdown = ({
           );
         }}
         getOptionLabel={(value) => {
-          if (value.tag === 'Team') {
-            return `${value.nickname} (${value.tag})`;
+          let translatedTag = '';
+          if (value.tag) {
+            translatedTag = i18n.exists(`participantTag.${value.tag}`)
+              ? ` (${t(`participantTag.${value.tag}`)})`
+              : ` (${value.tag})`;
           }
 
-          return `${value.secretId}${value.nickname ? ` (${value.nickname})` : ''}${
-            value.tag ? ` (${value.tag})` : ''
-          }`;
+          if (value.tag === 'Team') {
+            return `${value.nickname}${translatedTag}`;
+          }
+
+          return `${value.secretId}${value.nickname ? ` (${value.nickname})` : ''}${translatedTag}`;
         }}
         disabled={disabled}
         popupIcon={

--- a/src/modules/Dashboard/components/TakeNowModal/LabeledDropdown/LabeledUserDropdown.tsx
+++ b/src/modules/Dashboard/components/TakeNowModal/LabeledDropdown/LabeledUserDropdown.tsx
@@ -73,9 +73,17 @@ export const LabeledUserDropdown = ({
     [debounce, handleSearch],
   );
 
-  const warningMessageValueCondition =
-    !!value && (enableParticipantMultiInformant ? !value.userId : value.tag !== 'Team');
-  const shouldShowWarningMessage = !!canShowWarningMessage && warningMessageValueCondition;
+  let shouldShowWarningMessage = false;
+
+  // We only potentially show the warning when there is a value
+  if (value) {
+    const hasFullAccount = !!value.userId;
+    const isTeamMember = value.tag === 'Team';
+    const warningMessageValueCondition = enableParticipantMultiInformant
+      ? !hasFullAccount
+      : !isTeamMember;
+    shouldShowWarningMessage = !!canShowWarningMessage && warningMessageValueCondition;
+  }
 
   let groupBy: LabeledUserDropdownProps['groupBy'];
 
@@ -193,7 +201,7 @@ export const LabeledUserDropdown = ({
         {...rest}
       />
       {shouldShowWarningMessage && (
-        <StyledWarningMessageContainer>
+        <StyledWarningMessageContainer data-testid={`${rest['data-testid']}-warning-message`}>
           <Box width={24} height={24}>
             <Svg id={'supervisor-account'} fill={variables.palette.on_surface_variant} />
           </Box>

--- a/src/modules/Dashboard/components/TakeNowModal/LabeledDropdown/LabeledUserDropdown.tsx
+++ b/src/modules/Dashboard/components/TakeNowModal/LabeledDropdown/LabeledUserDropdown.tsx
@@ -147,6 +147,7 @@ export const LabeledUserDropdown = ({
               },
               ...props,
             }}
+            data-testid={`${rest['data-testid']}-option-${id}`}
           />
         )}
         isOptionEqualToValue={(option, value) => option.id === value.id}

--- a/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.test-utils.ts
+++ b/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.test-utils.ts
@@ -1,0 +1,55 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+export const takeNowModalTestId = (testId: string) => `${testId}-take-now-modal`;
+
+export const sourceSubjectDropdownTestId = (testId: string) =>
+  `${takeNowModalTestId(testId)}-source-subject-dropdown`;
+
+export const targetSubjectDropdownTestId = (testId: string) =>
+  `${takeNowModalTestId(testId)}-target-subject-dropdown`;
+
+export const selfReportCheckboxTestId = (testId: string) =>
+  `${takeNowModalTestId(testId)}-participant-self-report-checkbox`;
+
+export const openTakeNowModal = async (testId: string) => {
+  await waitFor(() =>
+    expect(screen.getAllByTestId(`${testId}-activity-actions-dots`)[0]).toBeVisible(),
+  );
+
+  await userEvent.click(screen.getAllByTestId(`${testId}-activity-actions-dots`)[0]);
+
+  await waitFor(() => expect(screen.getByTestId(`${testId}-activity-take-now`)).toBeVisible());
+
+  fireEvent.click(screen.getByTestId(`${testId}-activity-take-now`));
+
+  await waitFor(() => expect(screen.getByTestId(`${takeNowModalTestId(testId)}`)).toBeVisible());
+};
+
+export const selectSourceSubject = async (testId: string, subjectId: string) => {
+  const participantInputElement = screen
+    .getByTestId(sourceSubjectDropdownTestId(testId))
+    .querySelector('input');
+
+  if (participantInputElement === null) {
+    throw new Error('Autocomplete source subject dropdown element not found');
+  }
+
+  fireEvent.mouseDown(participantInputElement);
+
+  const ownerParticipantOption = screen.getByTestId(
+    `${sourceSubjectDropdownTestId(testId)}-option-${subjectId}`,
+  );
+
+  fireEvent.click(ownerParticipantOption);
+};
+
+export const toggleSelfReportCheckbox = async (testId: string) => {
+  const checkbox = screen.getByTestId(selfReportCheckboxTestId(testId)).querySelector('input');
+
+  if (checkbox === null) {
+    throw new Error('Self-report checkbox not found');
+  }
+
+  fireEvent.click(checkbox);
+};

--- a/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.tsx
+++ b/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.tsx
@@ -303,9 +303,7 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
                   options={participantsAndTeamMembers}
                   onChange={(option) => {
                     setSourceSubject(option);
-                    if (option) {
-                      setIsSelfReporting(!!option.userId);
-                    }
+                    setIsSelfReporting(!option || !!option.userId);
                   }}
                   data-testid={`${dataTestId}-take-now-modal-participant-dropdown`}
                   handleSearch={(query) => handleSearch(query, ['team', 'participant'])}

--- a/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.tsx
+++ b/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.tsx
@@ -174,7 +174,7 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
     userData,
     allParticipants,
     allTeamMembers,
-    defaultSourceSubject,
+    loggedInTeamMemberResponse,
     isFetchingParticipants,
     isFetchingManagers,
     isFetchingLoggedInTeamMember,

--- a/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.tsx
+++ b/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.tsx
@@ -79,24 +79,23 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
     },
   );
 
-  const { execute: fetchLoggedInTeamMember, isLoading: isFetchingLoggedInTeamMember } = useAsync(
-    getWorkspaceRespondentsApi,
-    (response) => {
-      if (response?.data) {
-        const loggedInTeamMember = participantToOption(
-          (response.data as ParticipantsData).result[0],
-        );
-        setDefaultSourceSubject(loggedInTeamMember);
-        setAllParticipants((prev) => {
-          if (prev.some((participant) => participant.id === loggedInTeamMember.id)) {
-            return prev;
-          }
+  const {
+    execute: fetchLoggedInTeamMember,
+    isLoading: isFetchingLoggedInTeamMember,
+    value: loggedInTeamMemberResponse,
+  } = useAsync(getWorkspaceRespondentsApi, (response) => {
+    if (response?.data) {
+      const loggedInTeamMember = participantToOption((response.data as ParticipantsData).result[0]);
+      // setDefaultSourceSubject(loggedInTeamMember);
+      setAllParticipants((prev) => {
+        if (prev.some((participant) => participant.id === loggedInTeamMember.id)) {
+          return prev;
+        }
 
-          return [loggedInTeamMember, ...prev];
-        });
-      }
-    },
-  );
+        return [loggedInTeamMember, ...prev];
+      });
+    }
+  });
 
   const allowedTeamMembers = useMemo(
     () =>
@@ -147,7 +146,7 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
         });
       }
 
-      if (userData && defaultSourceSubject === null && !isFetchingLoggedInTeamMember) {
+      if (userData && loggedInTeamMemberResponse === null && !isFetchingLoggedInTeamMember) {
         fetchLoggedInTeamMember({
           params: {
             ownerId,

--- a/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.tsx
+++ b/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.tsx
@@ -346,7 +346,12 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
                   options={participantsAndTeamMembers}
                   onChange={(option) => {
                     setSourceSubject(option);
-                    setIsSelfReporting(!option || !!option.userId);
+
+                    const selfReportingCondition =
+                      !option ||
+                      (enableParticipantMultiInformant ? !!option.userId : option.tag === 'Team');
+
+                    setIsSelfReporting(selfReportingCondition);
                   }}
                   data-testid={`${dataTestId}-take-now-modal-participant-dropdown`}
                   handleSearch={(query) => handleSearch(query, ['team', 'any-participant'])}
@@ -358,7 +363,11 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
                   sx={{ gap: 0.4 }}
                   checked={isSelfReporting}
                   onChange={(_e, checked) => setIsSelfReporting(checked)}
-                  disabled={!sourceSubject?.userId}
+                  disabled={
+                    enableParticipantMultiInformant
+                      ? !sourceSubject?.userId
+                      : sourceSubject?.tag !== 'Team'
+                  }
                   label={t('takeNow.modal.sourceSubjectCheckboxLabel')}
                 />
               </StyledFlexColumn>

--- a/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.tsx
+++ b/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.tsx
@@ -304,7 +304,7 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
                   onChange={(option) => {
                     setSourceSubject(option);
                     if (option) {
-                      setIsSelfReporting(option.tag === 'Team');
+                      setIsSelfReporting(!!option.userId);
                     }
                   }}
                   data-testid={`${dataTestId}-take-now-modal-participant-dropdown`}
@@ -317,7 +317,7 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
                   sx={{ gap: 0.4 }}
                   checked={isSelfReporting}
                   onChange={(_e, checked) => setIsSelfReporting(checked)}
-                  disabled={sourceSubject?.tag !== 'Team'}
+                  disabled={!sourceSubject?.userId}
                   label={t('takeNow.modal.sourceSubjectCheckboxLabel')}
                 />
               </StyledFlexColumn>

--- a/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.tsx
+++ b/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.tsx
@@ -378,10 +378,23 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
                   sx={{ gap: 1, pl: 5.2 }}
                   placeholder={t('takeNow.modal.loggedInUserPlaceholder')}
                   value={loggedInUser}
-                  options={fullAccountParticipantsAndTeamMembers}
+                  options={
+                    enableParticipantMultiInformant
+                      ? fullAccountParticipantsAndTeamMembers
+                      : teamMembersOnly
+                  }
                   onChange={setLoggedInUser}
                   data-testid={`${dataTestId}-take-now-modal-subject-dropdown`}
-                  handleSearch={(query) => handleSearch(query, ['team', 'full-participant'])}
+                  handleSearch={(query) => {
+                    const participantSearchTypes: [FullTeamSearchType, ...FullTeamSearchType[]] = [
+                      'team',
+                    ];
+                    if (enableParticipantMultiInformant) {
+                      participantSearchTypes.push('full-participant');
+                    }
+
+                    return handleSearch(query, participantSearchTypes);
+                  }}
                   showGroups={true}
                 />
               )}

--- a/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.tsx
+++ b/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.tsx
@@ -118,8 +118,8 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
   );
 
   const fullAccountParticipantsOnly = useMemo(
-    () => allParticipants.filter((participant) => !!participant.userId),
-    [allParticipants],
+    () => participantsOnly.filter((participant) => !!participant.userId),
+    [participantsOnly],
   );
 
   const teamMembersOnly = useMemo(

--- a/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.tsx
+++ b/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.tsx
@@ -353,13 +353,18 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
 
                     setIsSelfReporting(selfReportingCondition);
                   }}
-                  data-testid={`${dataTestId}-take-now-modal-participant-dropdown`}
+                  data-testid={`${dataTestId}-take-now-modal-source-subject-dropdown`}
                   handleSearch={(query) => handleSearch(query, ['team', 'any-participant'])}
                   canShowWarningMessage={true}
                   showGroups={true}
                 />
                 <FormControlLabel
-                  control={<Checkbox sx={{ margin: 0, width: 48, height: 48 }} />}
+                  control={
+                    <Checkbox
+                      sx={{ margin: 0, width: 48, height: 48 }}
+                      data-testid={`${dataTestId}-take-now-modal-participant-self-report-checkbox`}
+                    />
+                  }
                   sx={{ gap: 0.4 }}
                   checked={isSelfReporting}
                   onChange={(_e, checked) => setIsSelfReporting(checked)}
@@ -384,7 +389,7 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
                       : teamMembersOnly
                   }
                   onChange={setLoggedInUser}
-                  data-testid={`${dataTestId}-take-now-modal-subject-dropdown`}
+                  data-testid={`${dataTestId}-take-now-modal-logged-in-user-dropdown`}
                   handleSearch={(query) => {
                     const participantSearchTypes: [FullTeamSearchType, ...FullTeamSearchType[]] = [
                       'team',
@@ -406,7 +411,7 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
               value={targetSubject}
               options={participantsAndTeamMembers}
               onChange={setTargetSubject}
-              data-testid={`${dataTestId}-take-now-modal-subject-dropdown`}
+              data-testid={`${dataTestId}-take-now-modal-target-subject-dropdown`}
               handleSearch={(query) => handleSearch(query, ['team', 'any-participant'])}
             />
           </StyledFlexColumn>

--- a/src/modules/Dashboard/features/Applet/Activities/Activities.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Activities/Activities.test.tsx
@@ -280,7 +280,7 @@ describe('Dashboard > Applet > Activities screen', () => {
       });
     });
 
-    test('should pre-populate admin in Take Now modal', async () => {
+    test('should not pre-populate admin in Take Now modal', async () => {
       const mockedOwnerRespondent = {
         id: mockedUserData.id,
         nicknames: [`${mockedUserData.firstName} ${mockedUserData.lastName}`],
@@ -395,9 +395,7 @@ describe('Dashboard > Applet > Activities screen', () => {
         .getByTestId(`${testId}-take-now-modal-participant-dropdown`)
         .querySelector('input');
 
-      expect(inputElement).toHaveValue(
-        `${mockedUserData.firstName} ${mockedUserData.lastName} (Team)`,
-      );
+      expect(inputElement).toHaveValue('');
     });
   });
 });

--- a/src/modules/Dashboard/features/Applet/Activities/Activities.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Activities/Activities.test.tsx
@@ -89,6 +89,7 @@ describe('Dashboard > Applet > Activities screen', () => {
       featureFlags: {
         enableMultiInformant: true,
         enableMultiInformantTakeNow: true,
+        enableParticipantMultiInformant: true,
       },
     });
   });
@@ -261,6 +262,7 @@ describe('Dashboard > Applet > Activities screen', () => {
           featureFlags: {
             enableMultiInformant: true,
             enableMultiInformantTakeNow: false,
+            enableParticipantMultiInformant: false,
           },
         });
 

--- a/src/modules/Dashboard/features/Applet/Activities/Activities.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Activities/Activities.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import mockAxios, { HttpResponse } from 'jest-mock-axios';
 import { generatePath } from 'react-router-dom';
@@ -27,6 +27,14 @@ import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 import { ParticipantsData } from 'modules/Dashboard/features/Participants';
 import { RespondentStatus } from 'modules/Dashboard/types';
 import { ManagersData } from 'modules/Dashboard/features/Managers';
+import {
+  openTakeNowModal,
+  selectSourceSubject,
+  selfReportCheckboxTestId,
+  sourceSubjectDropdownTestId,
+  takeNowModalTestId,
+  toggleSelfReportCheckbox,
+} from 'modules/Dashboard/components/TakeNowModal/TakeNowModal.test-utils';
 
 import { Activities } from './Activities';
 
@@ -81,7 +89,7 @@ jest.mock('shared/hooks/useFeatureFlags', () => ({
   useFeatureFlags: jest.fn(),
 }));
 
-const mockUseFeatureFlags = useFeatureFlags as jest.Mock;
+const mockUseFeatureFlags = jest.mocked(useFeatureFlags);
 
 describe('Dashboard > Applet > Activities screen', () => {
   beforeEach(() => {
@@ -89,7 +97,7 @@ describe('Dashboard > Applet > Activities screen', () => {
       featureFlags: {
         enableMultiInformant: true,
         enableMultiInformantTakeNow: true,
-        enableParticipantMultiInformant: true,
+        enableParticipantMultiInformant: false,
       },
     });
   });
@@ -282,7 +290,7 @@ describe('Dashboard > Applet > Activities screen', () => {
       });
     });
 
-    test('should not pre-populate admin in Take Now modal', async () => {
+    test('should pre-populate admin in Take Now modal', async () => {
       const mockedOwnerRespondent = {
         id: mockedUserData.id,
         nicknames: [`${mockedUserData.firstName} ${mockedUserData.lastName}`],
@@ -381,23 +389,621 @@ describe('Dashboard > Applet > Activities screen', () => {
         routePath,
       });
 
-      await waitFor(() =>
-        expect(screen.getAllByTestId(`${testId}-activity-actions-dots`)[0]).toBeVisible(),
-      );
-
-      await userEvent.click(screen.getAllByTestId(`${testId}-activity-actions-dots`)[0]);
-
-      await waitFor(() => expect(screen.getByTestId(`${testId}-activity-take-now`)).toBeVisible());
-
-      fireEvent.click(screen.getByTestId(`${testId}-activity-take-now`));
-
-      await waitFor(() => expect(screen.getByTestId(`${testId}-take-now-modal`)).toBeVisible());
+      await openTakeNowModal(testId);
 
       const inputElement = screen
-        .getByTestId(`${testId}-take-now-modal-participant-dropdown`)
+        .getByTestId(sourceSubjectDropdownTestId(testId))
         .querySelector('input');
 
-      expect(inputElement).toHaveValue('');
+      expect(inputElement).toHaveValue(
+        `${mockedUserData.firstName} ${mockedUserData.lastName} (Team)`,
+      );
+    });
+
+    test('Full account participants cannot self-report', async () => {
+      const mockedOwnerRespondent = {
+        id: mockedUserData.id,
+        nicknames: [`${mockedUserData.firstName} ${mockedUserData.lastName}`],
+        secretIds: ['mockedOwnerSecretId'],
+        isAnonymousRespondent: false,
+        lastSeen: new Date().toDateString(),
+        isPinned: false,
+        accessId: '912e17b8-195f-4685-b77b-137539b9054d',
+        role: Roles.Owner,
+        details: [
+          {
+            appletId: mockedApplet.id,
+            appletDisplayName: mockedApplet.displayName,
+            appletImage: '',
+            accessId: '912e17b8-195f-4685-b77b-137539b9054d',
+            respondentNickname: `${mockedUserData.firstName} ${mockedUserData.lastName}`,
+            respondentSecretId: 'mockedOwnerSecretId',
+            hasIndividualSchedule: false,
+            encryption: mockedApplet.encryption,
+            subjectId: 'owner-subject-id-123',
+            subjectTag: 'Team' as ParticipantTag,
+            subjectFirstName: 'John',
+            subjectLastName: 'Doe',
+            subjectCreatedAt: '2023-09-26T12:11:46.162083',
+            invitation: null,
+          },
+        ],
+        status: RespondentStatus.Invited,
+        email: mockedUserData.email,
+      };
+
+      const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
+        result: [mockedRespondent, mockedRespondent2, mockedOwnerRespondent],
+        count: 3,
+      });
+
+      const successfulGetAppletManagersMock = mockSuccessfulHttpResponse<ManagersData>({
+        result: [
+          {
+            id: mockedOwnerRespondent.id,
+            firstName: mockedUserData.firstName,
+            lastName: mockedUserData.lastName,
+            email: mockedOwnerRespondent.email,
+            roles: [Roles.Owner],
+            lastSeen: new Date().toDateString(),
+            isPinned: mockedOwnerRespondent.isPinned,
+            applets: [
+              {
+                id: mockedApplet.id,
+                displayName: mockedApplet.displayName,
+                image: '',
+                roles: [
+                  {
+                    accessId: '912e17b8-195f-4685-b77b-137539b9054d',
+                    role: Roles.Owner,
+                  },
+                ],
+                encryption: mockedEncryption,
+              },
+            ],
+            title: null,
+          },
+        ],
+        count: 1,
+      });
+
+      mockGetRequestResponses({
+        [getAppletUrl]: successfulGetAppletMock,
+        [`/activities/applet/${mockedAppletId}`]: successfulGetAppletActivitiesMock,
+        [`/workspaces/${mockedOwnerId}/applets/${mockedAppletId}/respondents`]: (params) => {
+          if (params.userId === mockedOwnerRespondent.id) {
+            return mockSuccessfulHttpResponse<ParticipantsData>({
+              result: [mockedOwnerRespondent],
+              count: 1,
+            });
+          }
+
+          return successfulGetAppletParticipantsMock;
+        },
+        [`/workspaces/${mockedOwnerId}/applets/${mockedAppletId}/managers`]:
+          successfulGetAppletManagersMock,
+      });
+
+      const { getByTestId } = renderWithProviders(<Activities />, {
+        preloadedState: {
+          ...getPreloadedState(),
+          auth: {
+            authentication: mockSchema({
+              user: mockedUserData,
+            }),
+            isAuthorized: true,
+            isLogoutInProgress: false,
+          },
+        },
+        route,
+        routePath,
+      });
+
+      await openTakeNowModal(testId);
+
+      const inputElement = getByTestId(sourceSubjectDropdownTestId(testId)).querySelector('input');
+
+      if (inputElement === null) {
+        throw new Error('Autocomplete dropdown element not found');
+      }
+
+      fireEvent.mouseDown(inputElement);
+
+      const fullAccountParticipantOption = getByTestId(
+        `${sourceSubjectDropdownTestId(testId)}-option-${mockedRespondent.details[0].subjectId}`,
+      );
+
+      fireEvent.click(fullAccountParticipantOption);
+
+      const checkbox = getByTestId(selfReportCheckboxTestId(testId)).querySelector('input');
+
+      expect(checkbox).toBeDisabled();
+    });
+
+    test('Full account participants are not present in the inputting dropdown', async () => {
+      const mockedOwnerRespondent = {
+        id: mockedUserData.id,
+        nicknames: [`${mockedUserData.firstName} ${mockedUserData.lastName}`],
+        secretIds: ['mockedOwnerSecretId'],
+        isAnonymousRespondent: false,
+        lastSeen: new Date().toDateString(),
+        isPinned: false,
+        accessId: '912e17b8-195f-4685-b77b-137539b9054d',
+        role: Roles.Owner,
+        details: [
+          {
+            appletId: mockedApplet.id,
+            appletDisplayName: mockedApplet.displayName,
+            appletImage: '',
+            accessId: '912e17b8-195f-4685-b77b-137539b9054d',
+            respondentNickname: `${mockedUserData.firstName} ${mockedUserData.lastName}`,
+            respondentSecretId: 'mockedOwnerSecretId',
+            hasIndividualSchedule: false,
+            encryption: mockedApplet.encryption,
+            subjectId: 'owner-subject-id-123',
+            subjectTag: 'Team' as ParticipantTag,
+            subjectFirstName: 'John',
+            subjectLastName: 'Doe',
+            subjectCreatedAt: '2023-09-26T12:11:46.162083',
+            invitation: null,
+          },
+        ],
+        status: RespondentStatus.Invited,
+        email: mockedUserData.email,
+      };
+
+      const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
+        result: [mockedRespondent, mockedRespondent2, mockedOwnerRespondent],
+        count: 3,
+      });
+
+      const successfulGetAppletManagersMock = mockSuccessfulHttpResponse<ManagersData>({
+        result: [
+          {
+            id: mockedOwnerRespondent.id,
+            firstName: mockedUserData.firstName,
+            lastName: mockedUserData.lastName,
+            email: mockedOwnerRespondent.email,
+            roles: [Roles.Owner],
+            lastSeen: new Date().toDateString(),
+            isPinned: mockedOwnerRespondent.isPinned,
+            applets: [
+              {
+                id: mockedApplet.id,
+                displayName: mockedApplet.displayName,
+                image: '',
+                roles: [
+                  {
+                    accessId: '912e17b8-195f-4685-b77b-137539b9054d',
+                    role: Roles.Owner,
+                  },
+                ],
+                encryption: mockedEncryption,
+              },
+            ],
+            title: null,
+          },
+        ],
+        count: 1,
+      });
+
+      mockGetRequestResponses({
+        [getAppletUrl]: successfulGetAppletMock,
+        [`/activities/applet/${mockedAppletId}`]: successfulGetAppletActivitiesMock,
+        [`/workspaces/${mockedOwnerId}/applets/${mockedAppletId}/respondents`]: (params) => {
+          if (params.userId === mockedOwnerRespondent.id) {
+            return mockSuccessfulHttpResponse<ParticipantsData>({
+              result: [mockedOwnerRespondent],
+              count: 1,
+            });
+          }
+
+          return successfulGetAppletParticipantsMock;
+        },
+        [`/workspaces/${mockedOwnerId}/applets/${mockedAppletId}/managers`]:
+          successfulGetAppletManagersMock,
+      });
+
+      const { getByTestId, getByRole } = renderWithProviders(<Activities />, {
+        preloadedState: {
+          ...getPreloadedState(),
+          auth: {
+            authentication: mockSchema({
+              user: mockedUserData,
+            }),
+            isAuthorized: true,
+            isLogoutInProgress: false,
+          },
+        },
+        route,
+        routePath,
+      });
+
+      await openTakeNowModal(testId);
+
+      await selectSourceSubject(testId, mockedOwnerRespondent.details[0].subjectId);
+
+      await toggleSelfReportCheckbox(testId);
+
+      const dropdownTestId = `${takeNowModalTestId(testId)}-logged-in-user-dropdown`;
+
+      const inputElement = getByTestId(dropdownTestId).querySelector('input');
+
+      if (inputElement === null) {
+        throw new Error('Autocomplete logged-in user dropdown element not found');
+      }
+
+      fireEvent.mouseDown(inputElement);
+
+      const options = within(getByRole('listbox')).queryAllByRole('option');
+
+      expect(options.length).toBeGreaterThan(0);
+
+      const dropdownOptionTestIdRegex = new RegExp(`^${dropdownTestId}-option-`);
+      const optionsText = options.map(
+        (option) =>
+          option.getAttribute('data-testid')?.replace(dropdownOptionTestIdRegex, '') || '',
+      );
+
+      expect(optionsText).not.toContain(mockedRespondent.details[0].subjectId);
+      expect(optionsText).not.toContain(mockedRespondent2.details[0].subjectId);
+    });
+
+    describe('featureFlags.enableParticipantMultiInformant = true', () => {
+      beforeEach(() => {
+        mockUseFeatureFlags.mockReturnValue({
+          featureFlags: {
+            enableMultiInformant: true,
+            enableMultiInformantTakeNow: true,
+            enableParticipantMultiInformant: true,
+          },
+        });
+      });
+
+      test('Full account participants can self-report', async () => {
+        const mockedOwnerRespondent = {
+          id: mockedUserData.id,
+          nicknames: [`${mockedUserData.firstName} ${mockedUserData.lastName}`],
+          secretIds: ['mockedOwnerSecretId'],
+          isAnonymousRespondent: false,
+          lastSeen: new Date().toDateString(),
+          isPinned: false,
+          accessId: '912e17b8-195f-4685-b77b-137539b9054d',
+          role: Roles.Owner,
+          details: [
+            {
+              appletId: mockedApplet.id,
+              appletDisplayName: mockedApplet.displayName,
+              appletImage: '',
+              accessId: '912e17b8-195f-4685-b77b-137539b9054d',
+              respondentNickname: `${mockedUserData.firstName} ${mockedUserData.lastName}`,
+              respondentSecretId: 'mockedOwnerSecretId',
+              hasIndividualSchedule: false,
+              encryption: mockedApplet.encryption,
+              subjectId: 'owner-subject-id-123',
+              subjectTag: 'Team' as ParticipantTag,
+              subjectFirstName: 'John',
+              subjectLastName: 'Doe',
+              subjectCreatedAt: '2023-09-26T12:11:46.162083',
+              invitation: null,
+            },
+          ],
+          status: RespondentStatus.Invited,
+          email: mockedUserData.email,
+        };
+
+        const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
+          result: [mockedRespondent, mockedRespondent2, mockedOwnerRespondent],
+          count: 3,
+        });
+
+        const successfulGetAppletManagersMock = mockSuccessfulHttpResponse<ManagersData>({
+          result: [
+            {
+              id: mockedOwnerRespondent.id,
+              firstName: mockedUserData.firstName,
+              lastName: mockedUserData.lastName,
+              email: mockedOwnerRespondent.email,
+              roles: [Roles.Owner],
+              lastSeen: new Date().toDateString(),
+              isPinned: mockedOwnerRespondent.isPinned,
+              applets: [
+                {
+                  id: mockedApplet.id,
+                  displayName: mockedApplet.displayName,
+                  image: '',
+                  roles: [
+                    {
+                      accessId: '912e17b8-195f-4685-b77b-137539b9054d',
+                      role: Roles.Owner,
+                    },
+                  ],
+                  encryption: mockedEncryption,
+                },
+              ],
+              title: null,
+            },
+          ],
+          count: 1,
+        });
+
+        mockGetRequestResponses({
+          [getAppletUrl]: successfulGetAppletMock,
+          [`/activities/applet/${mockedAppletId}`]: successfulGetAppletActivitiesMock,
+          [`/workspaces/${mockedOwnerId}/applets/${mockedAppletId}/respondents`]: (params) => {
+            if (params.userId === mockedOwnerRespondent.id) {
+              return mockSuccessfulHttpResponse<ParticipantsData>({
+                result: [mockedOwnerRespondent],
+                count: 1,
+              });
+            }
+
+            return successfulGetAppletParticipantsMock;
+          },
+          [`/workspaces/${mockedOwnerId}/applets/${mockedAppletId}/managers`]:
+            successfulGetAppletManagersMock,
+        });
+
+        const { getByTestId } = renderWithProviders(<Activities />, {
+          preloadedState: {
+            ...getPreloadedState(),
+            auth: {
+              authentication: mockSchema({
+                user: mockedUserData,
+              }),
+              isAuthorized: true,
+              isLogoutInProgress: false,
+            },
+          },
+          route,
+          routePath,
+        });
+
+        await openTakeNowModal(testId);
+
+        await selectSourceSubject(testId, mockedOwnerRespondent.details[0].subjectId);
+
+        const checkbox = getByTestId(selfReportCheckboxTestId(testId)).querySelector('input');
+
+        expect(checkbox).not.toBeDisabled();
+      });
+
+      test('Full account participants are present in the inputting dropdown', async () => {
+        const mockedOwnerRespondent = {
+          id: mockedUserData.id,
+          nicknames: [`${mockedUserData.firstName} ${mockedUserData.lastName}`],
+          secretIds: ['mockedOwnerSecretId'],
+          isAnonymousRespondent: false,
+          lastSeen: new Date().toDateString(),
+          isPinned: false,
+          accessId: '912e17b8-195f-4685-b77b-137539b9054d',
+          role: Roles.Owner,
+          details: [
+            {
+              appletId: mockedApplet.id,
+              appletDisplayName: mockedApplet.displayName,
+              appletImage: '',
+              accessId: '912e17b8-195f-4685-b77b-137539b9054d',
+              respondentNickname: `${mockedUserData.firstName} ${mockedUserData.lastName}`,
+              respondentSecretId: 'mockedOwnerSecretId',
+              hasIndividualSchedule: false,
+              encryption: mockedApplet.encryption,
+              subjectId: 'owner-subject-id-123',
+              subjectTag: 'Team' as ParticipantTag,
+              subjectFirstName: 'John',
+              subjectLastName: 'Doe',
+              subjectCreatedAt: '2023-09-26T12:11:46.162083',
+              invitation: null,
+            },
+          ],
+          status: RespondentStatus.Invited,
+          email: mockedUserData.email,
+        };
+
+        const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
+          result: [mockedRespondent, mockedRespondent2, mockedOwnerRespondent],
+          count: 3,
+        });
+
+        const successfulGetAppletManagersMock = mockSuccessfulHttpResponse<ManagersData>({
+          result: [
+            {
+              id: mockedOwnerRespondent.id,
+              firstName: mockedUserData.firstName,
+              lastName: mockedUserData.lastName,
+              email: mockedOwnerRespondent.email,
+              roles: [Roles.Owner],
+              lastSeen: new Date().toDateString(),
+              isPinned: mockedOwnerRespondent.isPinned,
+              applets: [
+                {
+                  id: mockedApplet.id,
+                  displayName: mockedApplet.displayName,
+                  image: '',
+                  roles: [
+                    {
+                      accessId: '912e17b8-195f-4685-b77b-137539b9054d',
+                      role: Roles.Owner,
+                    },
+                  ],
+                  encryption: mockedEncryption,
+                },
+              ],
+              title: null,
+            },
+          ],
+          count: 1,
+        });
+
+        mockGetRequestResponses({
+          [getAppletUrl]: successfulGetAppletMock,
+          [`/activities/applet/${mockedAppletId}`]: successfulGetAppletActivitiesMock,
+          [`/workspaces/${mockedOwnerId}/applets/${mockedAppletId}/respondents`]: (params) => {
+            if (params.userId === mockedOwnerRespondent.id) {
+              return mockSuccessfulHttpResponse<ParticipantsData>({
+                result: [mockedOwnerRespondent],
+                count: 1,
+              });
+            }
+
+            return successfulGetAppletParticipantsMock;
+          },
+          [`/workspaces/${mockedOwnerId}/applets/${mockedAppletId}/managers`]:
+            successfulGetAppletManagersMock,
+        });
+
+        const { getByTestId, getByRole } = renderWithProviders(<Activities />, {
+          preloadedState: {
+            ...getPreloadedState(),
+            auth: {
+              authentication: mockSchema({
+                user: mockedUserData,
+              }),
+              isAuthorized: true,
+              isLogoutInProgress: false,
+            },
+          },
+          route,
+          routePath,
+        });
+
+        await openTakeNowModal(testId);
+
+        await selectSourceSubject(testId, mockedOwnerRespondent.details[0].subjectId);
+
+        await toggleSelfReportCheckbox(testId);
+
+        const dropdownTestId = `${takeNowModalTestId(testId)}-logged-in-user-dropdown`;
+
+        const inputElement = getByTestId(dropdownTestId).querySelector('input');
+
+        if (inputElement === null) {
+          throw new Error('Autocomplete logged-in user dropdown element not found');
+        }
+
+        fireEvent.mouseDown(inputElement);
+
+        const options = within(getByRole('listbox')).queryAllByRole('option');
+
+        expect(options.length).toBeGreaterThan(0);
+
+        const dropdownOptionTestIdRegex = new RegExp(`^${dropdownTestId}-option-`);
+        const optionsText = options.map(
+          (option) =>
+            option.getAttribute('data-testid')?.replace(dropdownOptionTestIdRegex, '') || '',
+        );
+
+        expect(optionsText).toContain(mockedRespondent.details[0].subjectId);
+        expect(optionsText).toContain(mockedRespondent2.details[0].subjectId);
+      });
+
+      test('should not pre-populate admin in Take Now modal', async () => {
+        const mockedOwnerRespondent = {
+          id: mockedUserData.id,
+          nicknames: [`${mockedUserData.firstName} ${mockedUserData.lastName}`],
+          secretIds: ['mockedOwnerSecretId'],
+          isAnonymousRespondent: false,
+          lastSeen: new Date().toDateString(),
+          isPinned: false,
+          accessId: '912e17b8-195f-4685-b77b-137539b9054d',
+          role: Roles.Owner,
+          details: [
+            {
+              appletId: mockedApplet.id,
+              appletDisplayName: mockedApplet.displayName,
+              appletImage: '',
+              accessId: '912e17b8-195f-4685-b77b-137539b9054d',
+              respondentNickname: `${mockedUserData.firstName} ${mockedUserData.lastName}`,
+              respondentSecretId: 'mockedOwnerSecretId',
+              hasIndividualSchedule: false,
+              encryption: mockedApplet.encryption,
+              subjectId: 'owner-subject-id-123',
+              subjectTag: 'Team' as ParticipantTag,
+              subjectFirstName: 'John',
+              subjectLastName: 'Doe',
+              subjectCreatedAt: '2023-09-26T12:11:46.162083',
+              invitation: null,
+            },
+          ],
+          status: RespondentStatus.Invited,
+          email: mockedUserData.email,
+        };
+
+        const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
+          result: [mockedRespondent, mockedRespondent2, mockedOwnerRespondent],
+          count: 3,
+        });
+
+        const successfulGetAppletManagersMock = mockSuccessfulHttpResponse<ManagersData>({
+          result: [
+            {
+              id: mockedOwnerRespondent.id,
+              firstName: mockedUserData.firstName,
+              lastName: mockedUserData.lastName,
+              email: mockedOwnerRespondent.email,
+              roles: [Roles.Owner],
+              lastSeen: new Date().toDateString(),
+              isPinned: mockedOwnerRespondent.isPinned,
+              applets: [
+                {
+                  id: mockedApplet.id,
+                  displayName: mockedApplet.displayName,
+                  image: '',
+                  roles: [
+                    {
+                      accessId: '912e17b8-195f-4685-b77b-137539b9054d',
+                      role: Roles.Owner,
+                    },
+                  ],
+                  encryption: mockedEncryption,
+                },
+              ],
+              title: null,
+            },
+          ],
+          count: 1,
+        });
+
+        mockGetRequestResponses({
+          [getAppletUrl]: successfulGetAppletMock,
+          [`/activities/applet/${mockedAppletId}`]: successfulGetAppletActivitiesMock,
+          [`/workspaces/${mockedOwnerId}/applets/${mockedAppletId}/respondents`]: (params) => {
+            if (params.userId === mockedOwnerRespondent.id) {
+              return mockSuccessfulHttpResponse<ParticipantsData>({
+                result: [mockedOwnerRespondent],
+                count: 1,
+              });
+            }
+
+            return successfulGetAppletParticipantsMock;
+          },
+          [`/workspaces/${mockedOwnerId}/applets/${mockedAppletId}/managers`]:
+            successfulGetAppletManagersMock,
+        });
+
+        renderWithProviders(<Activities />, {
+          preloadedState: {
+            ...getPreloadedState(),
+            auth: {
+              authentication: mockSchema({
+                user: mockedUserData,
+              }),
+              isAuthorized: true,
+              isLogoutInProgress: false,
+            },
+          },
+          route,
+          routePath,
+        });
+
+        await openTakeNowModal(testId);
+
+        const inputElement = screen
+          .getByTestId(`${sourceSubjectDropdownTestId(testId)}`)
+          .querySelector('input');
+
+        expect(inputElement).toHaveValue('');
+      });
     });
   });
 });

--- a/src/modules/Dashboard/features/Participant/Activities/Activities.test.tsx
+++ b/src/modules/Dashboard/features/Participant/Activities/Activities.test.tsx
@@ -275,7 +275,7 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
       });
     });
 
-    test('should pre-populate admin and participant in Take Now modal', async () => {
+    test('should pre-populate participant in Take Now modal', async () => {
       const mockedOwnerRespondent = {
         id: mockedUserData.id,
         nicknames: [`${mockedUserData.firstName} ${mockedUserData.lastName}`],
@@ -400,9 +400,7 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
 
       expect(subjectInputElement).toHaveValue(`${secretUserId} (${nickname}) (${tag})`);
 
-      expect(participantInputElement).toHaveValue(
-        `${mockedUserData.firstName} ${mockedUserData.lastName} (Team)`,
-      );
+      expect(participantInputElement).toHaveValue('');
     });
   });
 });

--- a/src/modules/Dashboard/features/Participant/Activities/Activities.test.tsx
+++ b/src/modules/Dashboard/features/Participant/Activities/Activities.test.tsx
@@ -115,6 +115,7 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
       featureFlags: {
         enableMultiInformant: true,
         enableMultiInformantTakeNow: true,
+        enableParticipantMultiInformant: true,
       },
     });
   });
@@ -252,6 +253,7 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
           featureFlags: {
             enableMultiInformant: true,
             enableMultiInformantTakeNow: false,
+            enableParticipantMultiInformant: false,
           },
         });
 

--- a/src/modules/Dashboard/features/Participant/Activities/Activities.test.tsx
+++ b/src/modules/Dashboard/features/Participant/Activities/Activities.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import mockAxios, { HttpResponse } from 'jest-mock-axios';
 import { generatePath } from 'react-router-dom';
@@ -29,6 +29,15 @@ import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 import { ParticipantsData } from 'modules/Dashboard/features/Participants';
 import { ManagersData } from 'modules/Dashboard/features/Managers';
 import { RespondentStatus } from 'modules/Dashboard/types';
+import {
+  openTakeNowModal,
+  selectSourceSubject,
+  selfReportCheckboxTestId,
+  sourceSubjectDropdownTestId,
+  takeNowModalTestId,
+  targetSubjectDropdownTestId,
+  toggleSelfReportCheckbox,
+} from 'modules/Dashboard/components/TakeNowModal/TakeNowModal.test-utils';
 
 import { Activities } from './Activities';
 
@@ -107,7 +116,7 @@ jest.mock('shared/hooks/useFeatureFlags', () => ({
   useFeatureFlags: jest.fn(),
 }));
 
-const mockUseFeatureFlags = useFeatureFlags as jest.Mock;
+const mockUseFeatureFlags = jest.mocked(useFeatureFlags);
 
 describe('Dashboard > Applet > Participant > Activities screen', () => {
   beforeEach(() => {
@@ -115,7 +124,7 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
       featureFlags: {
         enableMultiInformant: true,
         enableMultiInformantTakeNow: true,
-        enableParticipantMultiInformant: true,
+        enableParticipantMultiInformant: false,
       },
     });
   });
@@ -277,7 +286,7 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
       });
     });
 
-    test('should pre-populate participant in Take Now modal', async () => {
+    test('should pre-populate admin and participant in Take Now modal', async () => {
       const mockedOwnerRespondent = {
         id: mockedUserData.id,
         nicknames: [`${mockedUserData.firstName} ${mockedUserData.lastName}`],
@@ -375,34 +384,648 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
         routePath,
       });
 
-      await waitFor(() =>
-        expect(screen.getAllByTestId(`${testId}-activity-actions-dots`)[0]).toBeVisible(),
-      );
+      await openTakeNowModal(testId);
 
-      await userEvent.click(screen.getAllByTestId(`${testId}-activity-actions-dots`)[0]);
-
-      await waitFor(() => expect(screen.getByTestId(`${testId}-activity-take-now`)).toBeVisible());
-
-      fireEvent.click(screen.getByTestId(`${testId}-activity-take-now`));
-
-      const modal = screen.getByTestId(`${testId}-take-now-modal`);
-
-      await waitFor(() => expect(modal).toBeVisible());
-
-      const subjectInputElement = screen
-        .getByTestId(`${testId}-take-now-modal-subject-dropdown`)
+      const sourceSubjectInputElement = screen
+        .getByTestId(sourceSubjectDropdownTestId(testId))
         .querySelector('input');
 
-      const participantInputElement = screen
-        .getByTestId(`${testId}-take-now-modal-participant-dropdown`)
+      const targetSubjectInputElement = screen
+        .getByTestId(targetSubjectDropdownTestId(testId))
         .querySelector('input');
 
       const { secretUserId, nickname, tag } =
         preloadedState?.users?.subjectDetails.data?.result ?? {};
 
-      expect(subjectInputElement).toHaveValue(`${secretUserId} (${nickname}) (${tag})`);
+      expect(targetSubjectInputElement).toHaveValue(`${secretUserId} (${nickname}) (${tag})`);
 
-      expect(participantInputElement).toHaveValue('');
+      expect(sourceSubjectInputElement).toHaveValue(
+        `${mockedUserData.firstName} ${mockedUserData.lastName} (Team)`,
+      );
+    });
+
+    test('Full account participants cannot self-report', async () => {
+      const mockedOwnerRespondent = {
+        id: mockedUserData.id,
+        nicknames: [`${mockedUserData.firstName} ${mockedUserData.lastName}`],
+        secretIds: ['mockedOwnerSecretId'],
+        isAnonymousRespondent: false,
+        lastSeen: new Date().toDateString(),
+        isPinned: false,
+        accessId: '912e17b8-195f-4685-b77b-137539b9054d',
+        role: Roles.Owner,
+        details: [
+          {
+            appletId: mockedApplet.id,
+            appletDisplayName: mockedApplet.displayName,
+            appletImage: '',
+            accessId: '912e17b8-195f-4685-b77b-137539b9054d',
+            respondentNickname: `${mockedUserData.firstName} ${mockedUserData.lastName}`,
+            respondentSecretId: 'mockedOwnerSecretId',
+            hasIndividualSchedule: false,
+            encryption: mockedApplet.encryption,
+            subjectId: 'owner-subject-id-123',
+            subjectTag: 'Team' as ParticipantTag,
+            subjectFirstName: 'John',
+            subjectLastName: 'Doe',
+            subjectCreatedAt: '2023-09-26T12:11:46.162083',
+            invitation: null,
+          },
+        ],
+        status: RespondentStatus.Invited,
+        email: mockedUserData.email,
+      };
+
+      const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
+        result: [mockedRespondent, mockedRespondent2, mockedOwnerRespondent],
+        count: 3,
+      });
+
+      const successfulGetAppletManagersMock = mockSuccessfulHttpResponse<ManagersData>({
+        result: [
+          {
+            id: mockedOwnerRespondent.id,
+            firstName: mockedUserData.firstName,
+            lastName: mockedUserData.lastName,
+            email: mockedOwnerRespondent.email,
+            roles: [Roles.Owner],
+            lastSeen: new Date().toDateString(),
+            isPinned: mockedOwnerRespondent.isPinned,
+            applets: [
+              {
+                id: mockedApplet.id,
+                displayName: mockedApplet.displayName,
+                image: '',
+                roles: [
+                  {
+                    accessId: '912e17b8-195f-4685-b77b-137539b9054d',
+                    role: Roles.Owner,
+                  },
+                ],
+                encryption: mockedEncryption,
+              },
+            ],
+            title: null,
+          },
+        ],
+        count: 1,
+      });
+
+      mockGetRequestResponses({
+        [getAppletUrl]: successfulGetAppletMock,
+        [getAppletActivitiesUrl]: successfulGetAppletActivitiesMock,
+        [getWorkspaceRespondentsUrl]: (params) => {
+          if (params.userId === mockedOwnerRespondent.id) {
+            return mockSuccessfulHttpResponse<ParticipantsData>({
+              result: [mockedOwnerRespondent],
+              count: 1,
+            });
+          }
+
+          return successfulGetAppletParticipantsMock;
+        },
+        [getWorkspaceManagersUrl]: successfulGetAppletManagersMock,
+      });
+
+      const { getByTestId } = renderWithProviders(<Activities />, {
+        preloadedState: {
+          ...preloadedState,
+          auth: {
+            authentication: mockSchema({
+              user: mockedUserData,
+            }),
+            isAuthorized: true,
+            isLogoutInProgress: false,
+          },
+        },
+        route,
+        routePath,
+      });
+
+      await openTakeNowModal(testId);
+
+      const inputElement = getByTestId(sourceSubjectDropdownTestId(testId)).querySelector('input');
+
+      if (inputElement === null) {
+        throw new Error('Autocomplete dropdown element not found');
+      }
+
+      fireEvent.mouseDown(inputElement);
+
+      const fullAccountParticipantOption = getByTestId(
+        `${sourceSubjectDropdownTestId(testId)}-option-${mockedRespondent.details[0].subjectId}`,
+      );
+
+      fireEvent.click(fullAccountParticipantOption);
+
+      const checkbox = getByTestId(selfReportCheckboxTestId(testId)).querySelector('input');
+
+      expect(checkbox).toBeDisabled();
+    });
+
+    test('Full account participants are not present in the inputting dropdown', async () => {
+      const mockedOwnerRespondent = {
+        id: mockedUserData.id,
+        nicknames: [`${mockedUserData.firstName} ${mockedUserData.lastName}`],
+        secretIds: ['mockedOwnerSecretId'],
+        isAnonymousRespondent: false,
+        lastSeen: new Date().toDateString(),
+        isPinned: false,
+        accessId: '912e17b8-195f-4685-b77b-137539b9054d',
+        role: Roles.Owner,
+        details: [
+          {
+            appletId: mockedApplet.id,
+            appletDisplayName: mockedApplet.displayName,
+            appletImage: '',
+            accessId: '912e17b8-195f-4685-b77b-137539b9054d',
+            respondentNickname: `${mockedUserData.firstName} ${mockedUserData.lastName}`,
+            respondentSecretId: 'mockedOwnerSecretId',
+            hasIndividualSchedule: false,
+            encryption: mockedApplet.encryption,
+            subjectId: 'owner-subject-id-123',
+            subjectTag: 'Team' as ParticipantTag,
+            subjectFirstName: 'John',
+            subjectLastName: 'Doe',
+            subjectCreatedAt: '2023-09-26T12:11:46.162083',
+            invitation: null,
+          },
+        ],
+        status: RespondentStatus.Invited,
+        email: mockedUserData.email,
+      };
+
+      const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
+        result: [mockedRespondent, mockedRespondent2, mockedOwnerRespondent],
+        count: 3,
+      });
+
+      const successfulGetAppletManagersMock = mockSuccessfulHttpResponse<ManagersData>({
+        result: [
+          {
+            id: mockedOwnerRespondent.id,
+            firstName: mockedUserData.firstName,
+            lastName: mockedUserData.lastName,
+            email: mockedOwnerRespondent.email,
+            roles: [Roles.Owner],
+            lastSeen: new Date().toDateString(),
+            isPinned: mockedOwnerRespondent.isPinned,
+            applets: [
+              {
+                id: mockedApplet.id,
+                displayName: mockedApplet.displayName,
+                image: '',
+                roles: [
+                  {
+                    accessId: '912e17b8-195f-4685-b77b-137539b9054d',
+                    role: Roles.Owner,
+                  },
+                ],
+                encryption: mockedEncryption,
+              },
+            ],
+            title: null,
+          },
+        ],
+        count: 1,
+      });
+
+      mockGetRequestResponses({
+        [getAppletUrl]: successfulGetAppletMock,
+        [getAppletActivitiesUrl]: successfulGetAppletActivitiesMock,
+        [getWorkspaceRespondentsUrl]: (params) => {
+          if (params.userId === mockedOwnerRespondent.id) {
+            return mockSuccessfulHttpResponse<ParticipantsData>({
+              result: [mockedOwnerRespondent],
+              count: 1,
+            });
+          }
+
+          return successfulGetAppletParticipantsMock;
+        },
+        [getWorkspaceManagersUrl]: successfulGetAppletManagersMock,
+      });
+
+      const { getByTestId, getByRole } = renderWithProviders(<Activities />, {
+        preloadedState: {
+          ...preloadedState,
+          auth: {
+            authentication: mockSchema({
+              user: mockedUserData,
+            }),
+            isAuthorized: true,
+            isLogoutInProgress: false,
+          },
+        },
+        route,
+        routePath,
+      });
+
+      await openTakeNowModal(testId);
+
+      await selectSourceSubject(testId, mockedOwnerRespondent.details[0].subjectId);
+
+      await toggleSelfReportCheckbox(testId);
+
+      const dropdownTestId = `${takeNowModalTestId(testId)}-logged-in-user-dropdown`;
+
+      const inputElement = getByTestId(dropdownTestId).querySelector('input');
+
+      if (inputElement === null) {
+        throw new Error('Autocomplete logged-in user dropdown element not found');
+      }
+
+      fireEvent.mouseDown(inputElement);
+
+      const options = within(getByRole('listbox')).queryAllByRole('option');
+
+      expect(options.length).toBeGreaterThan(0);
+
+      const dropdownOptionTestIdRegex = new RegExp(`^${dropdownTestId}-option-`);
+      const optionsText = options.map(
+        (option) =>
+          option.getAttribute('data-testid')?.replace(dropdownOptionTestIdRegex, '') || '',
+      );
+
+      expect(optionsText).not.toContain(mockedRespondent.details[0].subjectId);
+      expect(optionsText).not.toContain(mockedRespondent2.details[0].subjectId);
+    });
+
+    describe('featureFlags.enableParticipantMultiInformant = true', () => {
+      beforeEach(() => {
+        mockUseFeatureFlags.mockReturnValue({
+          featureFlags: {
+            enableMultiInformant: true,
+            enableMultiInformantTakeNow: true,
+            enableParticipantMultiInformant: true,
+          },
+        });
+      });
+
+      test('should pre-populate only participant in Take Now modal', async () => {
+        const mockedOwnerRespondent = {
+          id: mockedUserData.id,
+          nicknames: [`${mockedUserData.firstName} ${mockedUserData.lastName}`],
+          secretIds: ['mockedOwnerSecretId'],
+          isAnonymousRespondent: false,
+          lastSeen: new Date().toDateString(),
+          isPinned: false,
+          accessId: '912e17b8-195f-4685-b77b-137539b9054d',
+          role: Roles.Owner,
+          details: [
+            {
+              appletId: mockedApplet.id,
+              appletDisplayName: mockedApplet.displayName,
+              appletImage: '',
+              accessId: '912e17b8-195f-4685-b77b-137539b9054d',
+              respondentNickname: `${mockedUserData.firstName} ${mockedUserData.lastName}`,
+              respondentSecretId: 'mockedOwnerSecretId',
+              hasIndividualSchedule: false,
+              encryption: mockedApplet.encryption,
+              subjectId: 'owner-subject-id-123',
+              subjectTag: 'Team' as ParticipantTag,
+              subjectFirstName: 'John',
+              subjectLastName: 'Doe',
+              subjectCreatedAt: '2023-09-26T12:11:46.162083',
+              invitation: null,
+            },
+          ],
+          status: RespondentStatus.Invited,
+          email: mockedUserData.email,
+        };
+
+        const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
+          result: [mockedRespondent, mockedRespondent2, mockedOwnerRespondent],
+          count: 3,
+        });
+
+        const successfulGetAppletManagersMock = mockSuccessfulHttpResponse<ManagersData>({
+          result: [
+            {
+              id: mockedOwnerRespondent.id,
+              firstName: mockedUserData.firstName,
+              lastName: mockedUserData.lastName,
+              email: mockedOwnerRespondent.email,
+              roles: [Roles.Owner],
+              lastSeen: new Date().toDateString(),
+              isPinned: mockedOwnerRespondent.isPinned,
+              applets: [
+                {
+                  id: mockedApplet.id,
+                  displayName: mockedApplet.displayName,
+                  image: '',
+                  roles: [
+                    {
+                      accessId: '912e17b8-195f-4685-b77b-137539b9054d',
+                      role: Roles.Owner,
+                    },
+                  ],
+                  encryption: mockedEncryption,
+                },
+              ],
+              title: null,
+            },
+          ],
+          count: 1,
+        });
+
+        mockGetRequestResponses({
+          [getAppletUrl]: successfulGetAppletMock,
+          [getAppletActivitiesUrl]: successfulGetAppletActivitiesMock,
+          [getWorkspaceRespondentsUrl]: (params) => {
+            if (params.userId === mockedOwnerRespondent.id) {
+              return mockSuccessfulHttpResponse<ParticipantsData>({
+                result: [mockedOwnerRespondent],
+                count: 1,
+              });
+            }
+
+            return successfulGetAppletParticipantsMock;
+          },
+          [getWorkspaceManagersUrl]: successfulGetAppletManagersMock,
+        });
+
+        renderWithProviders(<Activities />, {
+          preloadedState: {
+            ...preloadedState,
+            auth: {
+              authentication: mockSchema({
+                user: mockedUserData,
+              }),
+              isAuthorized: true,
+              isLogoutInProgress: false,
+            },
+          },
+          route,
+          routePath,
+        });
+
+        await openTakeNowModal(testId);
+
+        const sourceSubjectInputElement = screen
+          .getByTestId(sourceSubjectDropdownTestId(testId))
+          .querySelector('input');
+
+        const targetSubjectInputElement = screen
+          .getByTestId(targetSubjectDropdownTestId(testId))
+          .querySelector('input');
+
+        const { secretUserId, nickname, tag } =
+          preloadedState?.users?.subjectDetails.data?.result ?? {};
+
+        expect(targetSubjectInputElement).toHaveValue(`${secretUserId} (${nickname}) (${tag})`);
+
+        expect(sourceSubjectInputElement).toHaveValue('');
+      });
+
+      test('Full account participants can self-report', async () => {
+        const mockedOwnerRespondent = {
+          id: mockedUserData.id,
+          nicknames: [`${mockedUserData.firstName} ${mockedUserData.lastName}`],
+          secretIds: ['mockedOwnerSecretId'],
+          isAnonymousRespondent: false,
+          lastSeen: new Date().toDateString(),
+          isPinned: false,
+          accessId: '912e17b8-195f-4685-b77b-137539b9054d',
+          role: Roles.Owner,
+          details: [
+            {
+              appletId: mockedApplet.id,
+              appletDisplayName: mockedApplet.displayName,
+              appletImage: '',
+              accessId: '912e17b8-195f-4685-b77b-137539b9054d',
+              respondentNickname: `${mockedUserData.firstName} ${mockedUserData.lastName}`,
+              respondentSecretId: 'mockedOwnerSecretId',
+              hasIndividualSchedule: false,
+              encryption: mockedApplet.encryption,
+              subjectId: 'owner-subject-id-123',
+              subjectTag: 'Team' as ParticipantTag,
+              subjectFirstName: 'John',
+              subjectLastName: 'Doe',
+              subjectCreatedAt: '2023-09-26T12:11:46.162083',
+              invitation: null,
+            },
+          ],
+          status: RespondentStatus.Invited,
+          email: mockedUserData.email,
+        };
+
+        const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
+          result: [mockedRespondent, mockedRespondent2, mockedOwnerRespondent],
+          count: 3,
+        });
+
+        const successfulGetAppletManagersMock = mockSuccessfulHttpResponse<ManagersData>({
+          result: [
+            {
+              id: mockedOwnerRespondent.id,
+              firstName: mockedUserData.firstName,
+              lastName: mockedUserData.lastName,
+              email: mockedOwnerRespondent.email,
+              roles: [Roles.Owner],
+              lastSeen: new Date().toDateString(),
+              isPinned: mockedOwnerRespondent.isPinned,
+              applets: [
+                {
+                  id: mockedApplet.id,
+                  displayName: mockedApplet.displayName,
+                  image: '',
+                  roles: [
+                    {
+                      accessId: '912e17b8-195f-4685-b77b-137539b9054d',
+                      role: Roles.Owner,
+                    },
+                  ],
+                  encryption: mockedEncryption,
+                },
+              ],
+              title: null,
+            },
+          ],
+          count: 1,
+        });
+
+        mockGetRequestResponses({
+          [getAppletUrl]: successfulGetAppletMock,
+          [getAppletActivitiesUrl]: successfulGetAppletActivitiesMock,
+          [getWorkspaceRespondentsUrl]: (params) => {
+            if (params.userId === mockedOwnerRespondent.id) {
+              return mockSuccessfulHttpResponse<ParticipantsData>({
+                result: [mockedOwnerRespondent],
+                count: 1,
+              });
+            }
+
+            return successfulGetAppletParticipantsMock;
+          },
+          [getWorkspaceManagersUrl]: successfulGetAppletManagersMock,
+        });
+
+        const { getByTestId } = renderWithProviders(<Activities />, {
+          preloadedState: {
+            ...preloadedState,
+            auth: {
+              authentication: mockSchema({
+                user: mockedUserData,
+              }),
+              isAuthorized: true,
+              isLogoutInProgress: false,
+            },
+          },
+          route,
+          routePath,
+        });
+
+        await openTakeNowModal(testId);
+
+        const inputElement = getByTestId(sourceSubjectDropdownTestId(testId)).querySelector(
+          'input',
+        );
+
+        if (inputElement === null) {
+          throw new Error('Autocomplete dropdown element not found');
+        }
+
+        fireEvent.mouseDown(inputElement);
+
+        const fullAccountParticipantOption = getByTestId(
+          `${sourceSubjectDropdownTestId(testId)}-option-${mockedRespondent.details[0].subjectId}`,
+        );
+
+        fireEvent.click(fullAccountParticipantOption);
+
+        const checkbox = getByTestId(selfReportCheckboxTestId(testId)).querySelector('input');
+
+        expect(checkbox).not.toBeDisabled();
+      });
+
+      test('Full account participants are present in the inputting dropdown', async () => {
+        const mockedOwnerRespondent = {
+          id: mockedUserData.id,
+          nicknames: [`${mockedUserData.firstName} ${mockedUserData.lastName}`],
+          secretIds: ['mockedOwnerSecretId'],
+          isAnonymousRespondent: false,
+          lastSeen: new Date().toDateString(),
+          isPinned: false,
+          accessId: '912e17b8-195f-4685-b77b-137539b9054d',
+          role: Roles.Owner,
+          details: [
+            {
+              appletId: mockedApplet.id,
+              appletDisplayName: mockedApplet.displayName,
+              appletImage: '',
+              accessId: '912e17b8-195f-4685-b77b-137539b9054d',
+              respondentNickname: `${mockedUserData.firstName} ${mockedUserData.lastName}`,
+              respondentSecretId: 'mockedOwnerSecretId',
+              hasIndividualSchedule: false,
+              encryption: mockedApplet.encryption,
+              subjectId: 'owner-subject-id-123',
+              subjectTag: 'Team' as ParticipantTag,
+              subjectFirstName: 'John',
+              subjectLastName: 'Doe',
+              subjectCreatedAt: '2023-09-26T12:11:46.162083',
+              invitation: null,
+            },
+          ],
+          status: RespondentStatus.Invited,
+          email: mockedUserData.email,
+        };
+
+        const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
+          result: [mockedRespondent, mockedRespondent2, mockedOwnerRespondent],
+          count: 3,
+        });
+
+        const successfulGetAppletManagersMock = mockSuccessfulHttpResponse<ManagersData>({
+          result: [
+            {
+              id: mockedOwnerRespondent.id,
+              firstName: mockedUserData.firstName,
+              lastName: mockedUserData.lastName,
+              email: mockedOwnerRespondent.email,
+              roles: [Roles.Owner],
+              lastSeen: new Date().toDateString(),
+              isPinned: mockedOwnerRespondent.isPinned,
+              applets: [
+                {
+                  id: mockedApplet.id,
+                  displayName: mockedApplet.displayName,
+                  image: '',
+                  roles: [
+                    {
+                      accessId: '912e17b8-195f-4685-b77b-137539b9054d',
+                      role: Roles.Owner,
+                    },
+                  ],
+                  encryption: mockedEncryption,
+                },
+              ],
+              title: null,
+            },
+          ],
+          count: 1,
+        });
+
+        mockGetRequestResponses({
+          [getAppletUrl]: successfulGetAppletMock,
+          [getAppletActivitiesUrl]: successfulGetAppletActivitiesMock,
+          [getWorkspaceRespondentsUrl]: (params) => {
+            if (params.userId === mockedOwnerRespondent.id) {
+              return mockSuccessfulHttpResponse<ParticipantsData>({
+                result: [mockedOwnerRespondent],
+                count: 1,
+              });
+            }
+
+            return successfulGetAppletParticipantsMock;
+          },
+          [getWorkspaceManagersUrl]: successfulGetAppletManagersMock,
+        });
+
+        const { getByTestId, getByRole } = renderWithProviders(<Activities />, {
+          preloadedState: {
+            ...preloadedState,
+            auth: {
+              authentication: mockSchema({
+                user: mockedUserData,
+              }),
+              isAuthorized: true,
+              isLogoutInProgress: false,
+            },
+          },
+          route,
+          routePath,
+        });
+
+        await openTakeNowModal(testId);
+
+        await selectSourceSubject(testId, mockedOwnerRespondent.details[0].subjectId);
+
+        await toggleSelfReportCheckbox(testId);
+
+        const dropdownTestId = `${takeNowModalTestId(testId)}-logged-in-user-dropdown`;
+
+        const inputElement = getByTestId(dropdownTestId).querySelector('input');
+
+        if (inputElement === null) {
+          throw new Error('Autocomplete logged-in user dropdown element not found');
+        }
+
+        fireEvent.mouseDown(inputElement);
+
+        const options = within(getByRole('listbox')).queryAllByRole('option');
+
+        expect(options.length).toBeGreaterThan(0);
+
+        const dropdownOptionTestIdRegex = new RegExp(`^${dropdownTestId}-option-`);
+        const optionsText = options.map(
+          (option) =>
+            option.getAttribute('data-testid')?.replace(dropdownOptionTestIdRegex, '') || '',
+        );
+
+        expect(optionsText).toContain(mockedRespondent.details[0].subjectId);
+        expect(optionsText).toContain(mockedRespondent2.details[0].subjectId);
+      });
     });
   });
 });

--- a/src/shared/types/featureFlags.ts
+++ b/src/shared/types/featureFlags.ts
@@ -4,6 +4,7 @@ import { LDFlagValue } from 'launchdarkly-react-client-sdk';
 // e.g. enable-multi-informant in LaunchDarky becomes enableMultiInformant
 export const FeatureFlagsKeys = {
   enableMultiInformant: 'enableMultiInformant',
+  enableParticipantMultiInformant: 'enableParticipantMultiInformant',
   enableMultiInformantTakeNow: 'enableMultiInformantTakeNow',
   // TODO: https://mindlogger.atlassian.net/browse/M2-6519 Activity Filter Sort flag cleanup
   enableActivityFilterSort: 'enableActivityFilterSort',


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-6533](https://mindlogger.atlassian.net/browse/M2-6533)

This PR updates the behaviour of the take now modal in the following ways:
- Full account participants, when selected in the "Who will be providing the responses" dropdown, no longer trigger a warning message below the field. The warning is still triggered for those who are pending invitation.
- Full account participants may now self-report. This means that the “This person will be inputting their own responses” checkbox is not disabled, and the user is no longer forced to select a team member in the "Who will be inputting the responses" dropdown.
- Full account participants may now be selected as an option in the "Who will be inputting the responses" dropdown. This field was previously limited to team members only

These behaviours are controlled by the `enableParticipantMultiInformant` feature flag, and revert to their previous behaviour if the flag is turned off.

### 📸 Screenshots

#### Before

A full account participant will trigger a warning message and force the selection of a team member to input the responses

<img width="1552" alt="image" src="https://github.com/ChildMindInstitute/mindlogger-admin/assets/14842108/92ff6305-1182-45ec-9a12-d2a267772102">

#### After

A full account participant may optionally self-report

<img width="1552" alt="image" src="https://github.com/ChildMindInstitute/mindlogger-admin/assets/14842108/697ad4b2-f551-4583-a647-c5d9889f1c68">

They may also report on behalf of someone else

<img width="1552" alt="image" src="https://github.com/ChildMindInstitute/mindlogger-admin/assets/14842108/7615530f-59a1-4dec-9d8d-cd534d554868">

### 🪤 Peer Testing

You may manually toggle the value of the `enableParticipantMultiInformant` feature flag while testing by modifying this function

https://github.com/ChildMindInstitute/mindlogger-admin/blob/60bb60127f708a6c8ea01ecade05dae91a1ae459/src/shared/hooks/useFeatureFlags.ts#L11-L17

```typescript
const featureFlags = () => {
  const keys = Object.keys(FeatureFlagsKeys) as (keyof typeof FeatureFlagsKeys)[];
  const features: FeatureFlags = {};
  keys.forEach((key) => (features[key] = flags[FeatureFlagsKeys[key]]));

  // TODO: remove after testing
  features.enableParticipantMultiInformant = true;

  return features;
};
```

Activate the take now modal and test the conditions mentioned in the description above. Don't proceed to the web app, as it has not yet been updated to facilitate take now by a participant.

### ✏️ Notes

Tests have not yet been added to contrast behaviours depending on the new feature flag
