### PR TITLE
fix: show Add Team Member button for Coordinators (M2-6909)

### DIFF
--- a/src/modules/Dashboard/features/Managers/Managers.tsx
+++ b/src/modules/Dashboard/features/Managers/Managers.tsx
@@ -230,9 +230,6 @@ export const Managers = () => {
       if (searchValue) {
         return t('noMatchWasFound', { searchValue });
       }
-      if (!canViewTeam) {
-        return t('noPermissions');
-      }
 
       return appletId ? t('noManagersForApplet') : t('noManagers');
     }
@@ -256,13 +253,15 @@ export const Managers = () => {
         {/* TODO: Add sorting/filtering (https://mindlogger.atlassian.net/browse/M2-5608) */}
 
         <StyledFlexWrap sx={{ gap: 1.2, ml: 'auto' }}>
-          <Search
-            withDebounce
-            placeholder={t('searchTeam')}
-            onSearch={handleSearch}
-            sx={{ width: '32rem' }}
-            data-testid={`${dataTestId}-search`}
-          />
+          {canViewTeam && (
+            <Search
+              withDebounce
+              placeholder={t('searchTeam')}
+              onSearch={handleSearch}
+              sx={{ width: '32rem' }}
+              data-testid={`${dataTestId}-search`}
+            />
+          )}
 
           {!!appletId && (
             <Button
@@ -276,15 +275,19 @@ export const Managers = () => {
         </StyledFlexWrap>
       </StyledFlexWrap>
 
-      <DashboardTable
-        columns={getHeadCells(managersData?.orderingFields, appletId)}
-        rows={rows}
-        keyExtractor={({ id }) => `row-${id.value}`}
-        emptyComponent={renderEmptyComponent()}
-        count={managersData?.count || 0}
-        data-testid={`${dataTestId}-table`}
-        {...tableProps}
-      />
+      {canViewTeam ? (
+        <DashboardTable
+          columns={getHeadCells(managersData?.orderingFields, appletId)}
+          rows={rows}
+          keyExtractor={({ id }) => `row-${id.value}`}
+          emptyComponent={renderEmptyComponent()}
+          count={managersData?.count || 0}
+          data-testid={`${dataTestId}-table`}
+          {...tableProps}
+        />
+      ) : (
+        noPermissionsComponent
+      )}
       {selectedManager && (
         <>
           {removeAccessPopupVisible && (

--- a/src/modules/Dashboard/features/Managers/Popups/AddManagerPopup/AddManagerPopup.const.ts
+++ b/src/modules/Dashboard/features/Managers/Popups/AddManagerPopup/AddManagerPopup.const.ts
@@ -1,10 +1,10 @@
 import { Roles } from 'shared/consts';
 
-export const defaultValues = {
-  role: Roles.Manager,
+export const defaultValues = (roles?: Roles[]) => ({
+  role: roles?.includes(Roles.Coordinator) ? Roles.Reviewer : Roles.Manager,
   email: '',
   firstName: '',
   lastName: '',
-};
+});
 
 export const USER_ALREADY_INVITED = 'User already invited. Edit their access in the Managers tab.';

--- a/src/modules/Dashboard/features/Managers/Popups/AddManagerPopup/AddManagerPopup.tsx
+++ b/src/modules/Dashboard/features/Managers/Popups/AddManagerPopup/AddManagerPopup.tsx
@@ -51,7 +51,7 @@ export const AddManagerPopup = ({
   });
 
   const defaults = {
-    ...defaultValues,
+    ...defaultValues(appletRoles),
     language: i18n.language as Languages,
     workspaceName: workspaceInfo?.name,
   };


### PR DESCRIPTION
### 📝 Description

Displays the "Add Team Member" button in the Team tab for Coordinators

🔗 [Jira Ticket M2-6909](https://mindlogger.atlassian.net/browse/M2-6909)

Changes include:

- Add coordinator role validation to `Managers.tsx`.
- Change `AddManagerPopup` to select Reviewer as default when a Coordinator initiates the flow .

### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

#### Button visible, updated list icon and title

| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| ![CleanShot 2024-06-14 at 11 50 15](https://github.com/ChildMindInstitute/mindlogger-admin/assets/2916156/07fb18ed-29c6-48cb-b543-a06480e2a3bb) | ![CleanShot 2024-06-14 at 11 50 27](https://github.com/ChildMindInstitute/mindlogger-admin/assets/2916156/27f06926-9624-40b9-8805-c3871265ace7) |

#### Roles limited to Reviewer
![CleanShot 2024-06-14 at 11 48 54](https://github.com/ChildMindInstitute/mindlogger-admin/assets/2916156/fee537f6-4c98-4e64-98d5-3fae87cf62de)


### 🪤 Peer Testing

* Log in as an Applet Coordinator
* Navigate to Applet
* Navigate to Team Tab
* Add Team Member button should be visible
* Inviting a new reviewer should complete successfully

### ✏️ Notes

The list doesn't update to reflect newly added team members, but a success notification should be displayed.