### PR TITLE
feature: Add question text tooltips to Item Flow condition dropdowns (M2-6908)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "markdown-it-task-lists": "^2.1.1",
         "md-editor-rt": "^4.7.0",
         "mixpanel-browser": "^2.47.0",
+        "popper-max-size-modifier": "0.2.0",
         "react": "^18.2.0",
         "react-beautiful-dnd": "^13.1.1",
         "react-big-calendar": "^1.8.4",
@@ -19362,6 +19363,15 @@
       "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/popper-max-size-modifier": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/popper-max-size-modifier/-/popper-max-size-modifier-0.2.0.tgz",
+      "integrity": "sha512-UerPt9pZfTFnpSpIBVJrR3ibHMuU1k5K01AyNLfMUWCr4z1MFH+dsayPlAF9ZeYExa02HPiQn5OIMqUSVtJEbg==",
+      "deprecated": "We recommend switching to Floating UI which supports this modifier out of the box: https://floating-ui.com/docs/size",
+      "peerDependencies": {
+        "@popperjs/core": "^2.2.0"
       }
     },
     "node_modules/postcss": {
@@ -39897,6 +39907,12 @@
           "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="
         }
       }
+    },
+    "popper-max-size-modifier": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/popper-max-size-modifier/-/popper-max-size-modifier-0.2.0.tgz",
+      "integrity": "sha512-UerPt9pZfTFnpSpIBVJrR3ibHMuU1k5K01AyNLfMUWCr4z1MFH+dsayPlAF9ZeYExa02HPiQn5OIMqUSVtJEbg==",
+      "requires": {}
     },
     "postcss": {
       "version": "8.4.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/styled": "^11.11.0",
         "@hookform/resolvers": "^3.3.1",
         "@mui/material": "^5.14.11",
+        "@popperjs/core": "2.11.8",
         "@reduxjs/toolkit": "^1.9.6",
         "@sentry/react": "^7.107.0",
         "@testing-library/jest-dom": "^6.1.3",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "markdown-it-task-lists": "^2.1.1",
     "md-editor-rt": "^4.7.0",
     "mixpanel-browser": "^2.47.0",
+    "popper-max-size-modifier": "0.2.0",
     "react": "^18.2.0",
     "react-beautiful-dnd": "^13.1.1",
     "react-big-calendar": "^1.8.4",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@emotion/styled": "^11.11.0",
     "@hookform/resolvers": "^3.3.1",
     "@mui/material": "^5.14.11",
+    "@popperjs/core": "2.11.8",
     "@reduxjs/toolkit": "^1.9.6",
     "@sentry/react": "^7.107.0",
     "@testing-library/jest-dom": "^6.1.3",

--- a/src/modules/Builder/components/ConditionRow/Condition/Condition.tsx
+++ b/src/modules/Builder/components/ConditionRow/Condition/Condition.tsx
@@ -2,10 +2,11 @@ import { useTranslation } from 'react-i18next';
 
 import { StyledTitleMedium, StyledClearedButton, theme } from 'shared/styles';
 import { Svg } from 'shared/components/Svg';
+import { ItemFlowSelectController } from 'modules/Builder/components/ItemFlowSelectController/ItemFlowSelectController';
 import { useCustomFormContext } from 'modules/Builder/hooks';
 import { ConditionRowType } from 'modules/Builder/types';
 
-import { StyledCondition, StyledSelectController } from './Condition.styles';
+import { StyledCondition } from './Condition.styles';
 import { ConditionProps } from './Condition.types';
 import { getScoreConditionOptions, getStateOptions } from './Condition.utils';
 import { SwitchCondition } from './SwitchCondition';
@@ -50,8 +51,11 @@ export const Condition = ({
   return (
     <StyledCondition data-testid={dataTestid}>
       <StyledTitleMedium>{t('if')}</StyledTitleMedium>
-      <StyledSelectController
+      <ItemFlowSelectController
         control={control}
+        customChange={onItemChange}
+        data-testid={`${dataTestid}-name`}
+        disabled={isRowTypeScore}
         name={itemName}
         options={itemOptions}
         placeholder={t(isRowTypeItem ? 'conditionItemNamePlaceholder' : 'select')}
@@ -65,15 +69,15 @@ export const Condition = ({
             return <span>{placeholder}</span>;
           },
         }}
-        customChange={onItemChange}
-        disabled={isRowTypeScore}
         shouldSkipIcon={isRowTypeScore}
-        isLabelNeedTranslation={false}
-        data-testid={`${dataTestid}-name`}
+        tooltipTitle={selectedItem?.question}
       />
       <SwitchCondition {...switchConditionProps}>
-        <StyledSelectController
+        <ItemFlowSelectController
           control={control}
+          customChange={onStateChange}
+          data-testid={`${dataTestid}-type`}
+          disabled={isStateSelectDisabled}
           name={stateName}
           options={getStateOptions(selectedItem?.type)}
           placeholder={
@@ -81,32 +85,26 @@ export const Condition = ({
               ? t('conditionDisabledPlaceholder')
               : t('conditionTypePlaceholder')
           }
-          customChange={onStateChange}
-          isLabelNeedTranslation={false}
-          data-testid={`${dataTestid}-type`}
-          disabled={isStateSelectDisabled}
         />
       </SwitchCondition>
       {isStateSelectDisabled && (
         <>
-          <StyledSelectController
+          <ItemFlowSelectController
             control={control}
+            customChange={onStateChange}
+            data-testid={`${dataTestid}-type`}
+            disabled
             name={stateName}
             options={getStateOptions()}
             placeholder={t('conditionDisabledPlaceholder')}
-            customChange={onStateChange}
-            isLabelNeedTranslation={false}
-            data-testid={`${dataTestid}-type`}
-            disabled
           />
-          <StyledSelectController
+          <ItemFlowSelectController
             control={control}
+            data-testid={`${dataTestid}-selection-value`}
+            disabled
             name={isItemScoreCondition ? numberValueName : optionValueName}
             options={isItemScoreCondition ? getScoreConditionOptions() : valueOptions}
             placeholder={t('conditionDisabledPlaceholder')}
-            isLabelNeedTranslation={false}
-            data-testid={`${dataTestid}-selection-value`}
-            disabled
           />
         </>
       )}

--- a/src/modules/Builder/components/ConditionRow/Condition/Condition.types.ts
+++ b/src/modules/Builder/components/ConditionRow/Condition/Condition.types.ts
@@ -14,6 +14,7 @@ import { ConditionItemType } from './Condition.const';
 type ConditionItemGeneric<T> = {
   value: string;
   labelKey: string;
+  question: string;
 } & T;
 
 export type SliderConditionItem = ConditionItemGeneric<{

--- a/src/modules/Builder/components/ConditionRow/ConditionRow.utils.ts
+++ b/src/modules/Builder/components/ConditionRow/ConditionRow.utils.ts
@@ -80,6 +80,7 @@ export const getItemOptions = (
           value: getEntityKey(item),
           type: getConditionItemType(item),
           responseValues: item.responseValues,
+          question: item.question,
         },
       ];
     }

--- a/src/modules/Builder/components/ItemFlowSelectController/ItemFlowSelectController.styles.ts
+++ b/src/modules/Builder/components/ItemFlowSelectController/ItemFlowSelectController.styles.ts
@@ -93,6 +93,7 @@ export const StyledMdPreview = styled(MdPreview)({
     '--md-theme-link-color': 'inherit',
     '--md-theme-link-hover-color': 'inherit',
     fontSize: theme.spacing(1.4),
+    wordBreak: 'unset',
   },
 
   '& p': {

--- a/src/modules/Builder/components/ItemFlowSelectController/ItemFlowSelectController.styles.ts
+++ b/src/modules/Builder/components/ItemFlowSelectController/ItemFlowSelectController.styles.ts
@@ -1,0 +1,145 @@
+import { styled } from '@mui/material';
+import { MdPreview } from 'md-editor-rt';
+
+import { SelectController } from 'shared/components/FormComponents';
+import { theme, variables } from 'shared/styles';
+
+export const StyledSelectController = styled(SelectController)({
+  minWidth: theme.spacing(10),
+  width: '100%',
+
+  '&& .MuiInputBase-root': {
+    borderRadius: variables.borderRadius.md,
+
+    '&.Mui-error': {
+      background: variables.palette.error_container,
+    },
+
+    '&.Mui-disabled .MuiOutlinedInput-notchedOutline': {
+      borderColor: variables.palette.outline,
+    },
+  },
+
+  '&& .MuiSelect-select': {
+    padding: theme.spacing(0.65, 1.2),
+  },
+
+  '&& .MuiFormHelperText-root': {
+    display: 'none',
+  },
+
+  '&& .MuiSvgIcon-root.Mui-disabled': {
+    display: 'none',
+  },
+
+  '&& .MuiOutlinedInput-notchedOutline': {
+    borderColor: variables.palette.outline,
+  },
+});
+
+export const StyledMdPreview = styled(MdPreview)({
+  '--md-bk-color': 'inherit',
+  '--md-bk-color-outstand': 'inherit',
+  '--md-bk-hover-color': 'inherit',
+  '--md-border-active-color': 'inherit',
+  '--md-border-color': 'inherit',
+  '--md-border-hover-color': 'inherit',
+  '--md-color': 'inherit',
+  '--md-hover-color': 'inherit',
+  '--md-modal-mask': 'inherit',
+  '--md-scrollbar-bg-color': 'inherit',
+  '--md-scrollbar-thumb-active-color': 'inherit',
+  '--md-scrollbar-thumb-color': 'inherit',
+  '--md-scrollbar-thumb-hover-color': 'inherit',
+  '--md-theme-bg-color': 'inherit',
+  '--md-theme-bg-color-inset': 'inherit',
+  '--md-theme-bg-color-scrollbar-thumb': 'inherit',
+  '--md-theme-bg-color-scrollbar-thumb-active': 'inherit',
+  '--md-theme-bg-color-scrollbar-thumb-hover': 'inherit',
+  '--md-theme-bg-color-scrollbar-track': 'inherit',
+  '--md-theme-border-color': 'inherit',
+  '--md-theme-border-color-inset': 'inherit',
+  '--md-theme-border-color-reverse': 'inherit',
+  '--md-theme-code-active-color': 'inherit',
+  '--md-theme-code-copy-tips-bg-color': 'inherit',
+  '--md-theme-code-copy-tips-color': 'inherit',
+  '--md-theme-color': 'inherit',
+  '--md-theme-color-hover': 'inherit',
+  '--md-theme-color-hover-inset': 'inherit',
+  '--md-theme-color-reverse': 'inherit',
+  '--md-theme-link-color': 'inherit',
+  '--md-theme-link-hover-color': 'inherit',
+  fontFamily: 'inherit',
+
+  '& .md-editor-preview-wrapper': { padding: 0 },
+
+  '& .md-editor-preview': {
+    '--md-theme-bg-color': 'inherit',
+    '--md-theme-bg-color-inset': 'inherit',
+    '--md-theme-bg-color-scrollbar-thumb': 'inherit',
+    '--md-theme-bg-color-scrollbar-thumb-active': 'inherit',
+    '--md-theme-bg-color-scrollbar-thumb-hover': 'inherit',
+    '--md-theme-bg-color-scrollbar-track': 'inherit',
+    '--md-theme-border-color': 'inherit',
+    '--md-theme-border-color-inset': 'inherit',
+    '--md-theme-border-color-reverse': 'inherit',
+    '--md-theme-code-active-color': 'inherit',
+    '--md-theme-code-copy-tips-bg-color': 'inherit',
+    '--md-theme-code-copy-tips-color': 'inherit',
+    '--md-theme-color': 'inherit',
+    '--md-theme-color-hover': 'inherit',
+    '--md-theme-color-hover-inset': 'inherit',
+    '--md-theme-color-reverse': 'inherit',
+    '--md-theme-link-color': 'inherit',
+    '--md-theme-link-hover-color': 'inherit',
+    fontSize: theme.spacing(1.4),
+  },
+
+  '& p': {
+    lineHeight: 'inherit',
+    margin: 0,
+    padding: 0,
+  },
+
+  '& h1, & h2, & h3, & h4, & h5, & h6': {
+    margin: '0.5rem 0',
+  },
+
+  '& h1': { fontSize: theme.spacing(2.2) },
+  '& h2': { fontSize: theme.spacing(2) },
+  '& h3': { fontSize: theme.spacing(1.8) },
+  '& h4': { fontSize: theme.spacing(1.6) },
+  '& h5': { fontSize: theme.spacing(1.4) },
+  '& h6': { fontSize: theme.spacing(1.4) },
+
+  '& ol, & ul': {
+    margin: 0,
+
+    '& li': { margin: 0 },
+  },
+
+  '& table': {
+    margin: 0,
+
+    '& tr th, & tr td': {
+      padding: theme.spacing(0.4),
+    },
+  },
+
+  '& audio': { maxWidth: '100%' },
+  '& video': { maxWidth: '100%' },
+  '&& code, && .code-block': { padding: theme.spacing(0.8) },
+  '&& .code-block': { padding: 0 },
+
+  '&& pre': {
+    margin: theme.spacing(0.8, 0),
+
+    '&:before, & code[language]:before': { content: 'none' },
+    '& .copy-button': { display: 'none' },
+  },
+});
+
+StyledMdPreview.defaultProps = {
+  noHighlight: true,
+  noImgZoomIn: true,
+};

--- a/src/modules/Builder/components/ItemFlowSelectController/ItemFlowSelectController.tsx
+++ b/src/modules/Builder/components/ItemFlowSelectController/ItemFlowSelectController.tsx
@@ -1,0 +1,59 @@
+import { Control, FieldValues } from 'react-hook-form';
+import { useRef, useState } from 'react';
+
+import { Tooltip } from 'shared/components';
+
+import { StyledMdPreview, StyledSelectController } from './ItemFlowSelectController.styles';
+import { ItemFlowSelectControllerProps } from './ItemFlowSelectController.types';
+
+export const ItemFlowSelectController = ({
+  control,
+  SelectProps,
+  tooltipTitle,
+  ...otherProps
+}: ItemFlowSelectControllerProps) => {
+  const [open, setOpen] = useState(false);
+  const selectIsOpen = useRef(false);
+
+  const handleCloseSelect = (e: React.SyntheticEvent) => {
+    selectIsOpen.current = false;
+
+    SelectProps?.onClose?.(e);
+  };
+
+  const handleOpenSelect = (e: React.SyntheticEvent) => {
+    selectIsOpen.current = true;
+    setOpen(false);
+
+    SelectProps?.onOpen?.(e);
+  };
+
+  const handleCloseTooltip = () => {
+    setOpen(false);
+  };
+
+  const handleOpenTooltip = () => {
+    if (!selectIsOpen.current) {
+      setOpen(true);
+    }
+  };
+
+  return (
+    <Tooltip
+      enterNextDelay={500}
+      onClose={handleCloseTooltip}
+      onOpen={handleOpenTooltip}
+      open={open}
+      tooltipTitle={tooltipTitle ? <StyledMdPreview modelValue={tooltipTitle} /> : undefined}
+    >
+      <span>
+        <StyledSelectController
+          control={control as Control<FieldValues> | undefined}
+          isLabelNeedTranslation={false}
+          SelectProps={{ ...SelectProps, onClose: handleCloseSelect, onOpen: handleOpenSelect }}
+          {...otherProps}
+        />
+      </span>
+    </Tooltip>
+  );
+};

--- a/src/modules/Builder/components/ItemFlowSelectController/ItemFlowSelectController.types.ts
+++ b/src/modules/Builder/components/ItemFlowSelectController/ItemFlowSelectController.types.ts
@@ -1,0 +1,7 @@
+import React from 'react';
+
+import { StyledSelectController } from './ItemFlowSelectController.styles';
+
+export type ItemFlowSelectControllerProps = {
+  tooltipTitle?: string;
+} & React.ComponentProps<typeof StyledSelectController>;

--- a/src/modules/Builder/features/ActivityItemsFlow/ItemFlow/SummaryRow/SummaryRow.tsx
+++ b/src/modules/Builder/features/ActivityItemsFlow/ItemFlow/SummaryRow/SummaryRow.tsx
@@ -5,11 +5,9 @@ import { useWatch } from 'react-hook-form';
 import { StyledTitleMedium } from 'shared/styles';
 import { getEntityKey } from 'shared/utils';
 import { SelectEvent } from 'shared/types';
+import { ItemFlowSelectController } from 'modules/Builder/components/ItemFlowSelectController/ItemFlowSelectController';
 import { ItemFormValues } from 'modules/Builder/types';
-import {
-  StyledSummaryRow,
-  StyledSummarySelectController,
-} from 'shared/styles/styledComponents/ConditionalSummary';
+import { StyledSummaryRow } from 'shared/styles/styledComponents/ConditionalSummary';
 import { useCustomFormContext } from 'modules/Builder/hooks';
 
 import { SummaryRowProps } from './SummaryRow.types';
@@ -18,7 +16,7 @@ import { useItemsInUsage } from './SummaryRow.hooks';
 
 export const SummaryRow = ({ name, activityName, 'data-testid': dataTestid }: SummaryRowProps) => {
   const { t } = useTranslation('app');
-  const { control, setValue } = useCustomFormContext();
+  const { control, setValue, getValues } = useCustomFormContext();
   const items = useWatch({ name: `${activityName}.items` });
   const itemsInUsage = useItemsInUsage(name);
 
@@ -34,11 +32,15 @@ export const SummaryRow = ({ name, activityName, 'data-testid': dataTestid }: Su
     [items, activityName, setValue],
   );
 
+  const { question } =
+    ((items ?? []) as ItemFormValues[]).find(({ id }) => id === getValues(`${name}.itemKey`)) ?? {};
+
   return (
     <>
       <StyledSummaryRow data-testid={dataTestid}>
         <StyledTitleMedium>{t('if')}</StyledTitleMedium>
-        <StyledSummarySelectController
+
+        <ItemFlowSelectController
           control={control}
           name={`${name}.match`}
           options={getMatchOptions()}
@@ -46,8 +48,10 @@ export const SummaryRow = ({ name, activityName, 'data-testid': dataTestid }: Su
           data-testid={`${dataTestid}-match`}
           isLabelNeedTranslation={false}
         />
+
         <StyledTitleMedium>{t('summaryRowDescription')}</StyledTitleMedium>
-        <StyledSummarySelectController
+
+        <ItemFlowSelectController
           control={control}
           name={`${name}.itemKey`}
           options={getItemsOptions({ items, itemsInUsage })}
@@ -62,7 +66,7 @@ export const SummaryRow = ({ name, activityName, 'data-testid': dataTestid }: Su
           }}
           customChange={handleChangeItemKey}
           data-testid={`${dataTestid}-item`}
-          isLabelNeedTranslation={false}
+          tooltipTitle={question}
         />
       </StyledSummaryRow>
     </>

--- a/src/shared/components/Tooltip/Tooltip.styles.tsx
+++ b/src/shared/components/Tooltip/Tooltip.styles.tsx
@@ -6,7 +6,7 @@ import { variables } from 'shared/styles/variables';
 export const StyledTooltip = styled(({ className, children, ...props }: TooltipProps) => (
   <Tooltip {...props} classes={{ popper: className }} children={children} />
 ))(() => ({
-  [`& .${tooltipClasses.tooltip}`]: {
+  [`&& .${tooltipClasses.tooltip}`]: {
     backgroundColor: variables.palette.inverse_surface,
     color: variables.palette.inverse_on_surface,
     textAlign: 'left',
@@ -15,5 +15,8 @@ export const StyledTooltip = styled(({ className, children, ...props }: TooltipP
     padding: theme.spacing(0.4, 0.8),
     fontWeight: variables.font.weight.regular,
     letterSpacing: variables.font.letterSpacing.sm,
+    overflow: 'hidden',
+    maxHeight: '100%',
+    margin: 0,
   },
 }));

--- a/src/shared/components/Tooltip/Tooltip.tsx
+++ b/src/shared/components/Tooltip/Tooltip.tsx
@@ -36,7 +36,11 @@ export const Tooltip = ({
 
   useEffect(() => {
     setInnerOpen(open ?? false);
-  }, [open]);
+
+    if (open) {
+      document.dispatchEvent(new CustomEvent('tooltipOpen', { detail: tooltipId }));
+    }
+  }, [open, tooltipId]);
 
   const handleClose = useCallback(
     (e: Event | React.SyntheticEvent) => {
@@ -52,13 +56,12 @@ export const Tooltip = ({
   );
 
   const handleOpen = (e: React.SyntheticEvent) => {
-    document.dispatchEvent(new CustomEvent('tooltipOpen', { detail: tooltipId }));
-
     onOpen?.(e);
 
     // Only set innerOpen value if Tooltip is uncontrolled.
     if (typeof open !== 'boolean') {
       setInnerOpen(true);
+      document.dispatchEvent(new CustomEvent('tooltipOpen', { detail: tooltipId }));
     }
   };
 

--- a/src/shared/components/Tooltip/Tooltip.tsx
+++ b/src/shared/components/Tooltip/Tooltip.tsx
@@ -1,9 +1,30 @@
+import { State } from '@popperjs/core';
+import maxSize from 'popper-max-size-modifier';
+
 import { TooltipProps } from './Tooltip.types';
 import { StyledTooltip } from './Tooltip.styles';
+
+const applyMaxSize = {
+  name: 'applyMaxSize' as const,
+  enabled: true,
+  phase: 'beforeWrite' as const,
+  requires: ['maxSize'],
+  fn: ({ state }: { state: State }) => {
+    const { height } = state.modifiersData.maxSize;
+
+    state.styles.popper = {
+      ...state.styles.popper,
+      display: 'flex',
+      placeItems: state.placement.includes('bottom') ? 'flex-start' : 'flex-end',
+      height: `${height - 24}px`,
+    };
+  },
+};
 
 export const Tooltip = ({ tooltipTitle = '', children, maxWidth, ...props }: TooltipProps) => (
   <StyledTooltip
     {...props}
+    PopperProps={{ ...props.PopperProps, modifiers: [maxSize, applyMaxSize] }}
     title={tooltipTitle}
     sx={{
       '.MuiTooltip-tooltip': {


### PR DESCRIPTION
### 📝 Description

🔗 [M2-6908](https://mindlogger.atlassian.net/browse/M2-6908): [Admin] - Add Tooltip to Item Flow section

This PR updates the Item Flow section of the Activity builder so that dropdowns in the Item flow conditions now show tooltips, which display the question/"Displayed Content" of the selected item in the dropdown.

To do this, I've added a new `ItemFlowSelectController` component, which is a styled variant of the `SelectController`, and wrapped in a `Tooltip` that expects a markdown-formatted string as content, for use in the Condition & SummaryRow components.

As part of this, I've added a styled variant of the `MDPreview` component from our [`md-editor-rt`](https://github.com/imzbf/md-editor-rt) dependency, which removes much of the "themed" styles it otherwise provides.

Finally, I've also updated the `Tooltip` component so that it is styled with a calculated `maxHeight` property that prevents tooltips from extending off of the vertical edges of the viewport. As part of this change, I added a new dependency: `popper-max-size-modifier`, to calculate the max height of the Tooltip. 

This also meant adding an explicit `@popperjs/core` dependency to the project. This was already a transitive dependency via `@mui/core`, which uses Popperjs to implement it's Tooltips already, but I wanted to include specific type annotations that referenced definitions in that package, and wanted to avoid referencing a dependency that was only implicitly included.

Finally, there is a small design update that changes the dropdown inputs in the Condition row, to match the dropdown inputs in the Summary row. This is how this UI is depicted in the designs, and there were existing styles that were intended to implement this, but incorrect selectors previously prevented them from being applied.

### 📸 Screenshots

| Before | After |
|-|-|
| ![before](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/4600ab62-3fe5-4157-b23f-28721b70c124) | ![after](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/3f172469-256b-43ee-a127-202abbfe71e7) |

### 🪤 Peer Testing

For an applet with an activity that contains various items…

1. Navigate to the "Edit Activity" screen, and then to the "Item Flow" tab.
2. Create a new condition, if necessary. Interact with the item dropdowns and observe that they show tooltips containing the rendered markdown content entered in the Item configuration's "Displayed Content" input.

### ✏️ Notes

- One detail I noticed is that `sup`, `sub`, and `blockquote` elements don't seem to be parsed correctly by MDPreview, and the markdown tags for them just render as plain-text characters. This seems like a pre-existing issue with the third-party component, so I opted not to address this within the scope of the task.

[M2-6908]: https://mindlogger.atlassian.net/browse/M2-6908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ