### PR TITLE
fix(mi): update edit action for Performance Task (M2-7091)

### DIFF
--- a/src/modules/Dashboard/components/ActivityGrid/ActivityGrid.hooks.tsx
+++ b/src/modules/Dashboard/components/ActivityGrid/ActivityGrid.hooks.tsx
@@ -144,7 +144,7 @@ export const useActivityGrid = (
                 menuItems={getActivityActions({
                   actions: actions || defaultActions,
                   appletId,
-                  activityId,
+                  activity,
                   dataTestId,
                   roles,
                   featureFlags,

--- a/src/modules/Dashboard/components/ActivityGrid/ActivityGrid.hooks.tsx
+++ b/src/modules/Dashboard/components/ActivityGrid/ActivityGrid.hooks.tsx
@@ -17,6 +17,8 @@ import {
   StyledSvg,
 } from 'modules/Dashboard/components/ActivityGrid';
 import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
+import { getPerformanceTaskPath } from 'modules/Builder/features/Activities/Activities.utils';
+import { EditablePerformanceTasksType } from 'modules/Builder/features/Activities/Activities.types';
 
 import { useTakeNowModal } from '../TakeNowModal/TakeNowModal';
 
@@ -48,9 +50,20 @@ export const useActivityGrid = (
     () => ({
       editActivity: ({ context }: MenuActionProps<ActivityActionProps>) => {
         const { activityId } = context || {};
+        if (!activityId || !appletId) return;
+        const activity = getActivityById(activityId);
 
-        navigate(
-          generatePath(page.builderAppletActivity, {
+        const navigateTo =
+          activity?.isPerformanceTask && activity?.performanceTaskType
+            ? // Additional validation for flanker, gyroscope and touch is done in getActivityActions as these are the only editable options
+              // Here it's safe to assume the task is EditablePerformanceTasksType
+              getPerformanceTaskPath(
+                activity?.performanceTaskType as unknown as EditablePerformanceTasksType,
+              )
+            : page.builderAppletActivity;
+
+        return navigate(
+          generatePath(navigateTo, {
             appletId,
             activityId,
           }),
@@ -75,7 +88,7 @@ export const useActivityGrid = (
         }
       },
     }),
-    [appletId, getActivityById, navigate, openTakeNowModal],
+    [appletId, getActivityById, navigate, onClickExportData, openTakeNowModal],
   );
 
   const formatRow = useCallback(

--- a/src/modules/Dashboard/components/ActivityGrid/ActivityGrid.types.ts
+++ b/src/modules/Dashboard/components/ActivityGrid/ActivityGrid.types.ts
@@ -35,10 +35,10 @@ export type ActivityActions = {
   actions: ActionsObject;
   dataTestId: string;
   appletId: string;
-  activityId: string;
   roles?: Roles[];
   hasParticipants?: boolean;
   featureFlags: FeatureFlags;
+  activity: BaseActivity;
 };
 
 export type ActionsObject = {

--- a/src/modules/Dashboard/components/ActivityGrid/ActivityGrid.utils.test.ts
+++ b/src/modules/Dashboard/components/ActivityGrid/ActivityGrid.utils.test.ts
@@ -71,7 +71,9 @@ describe('getActivityActions', () => {
     actions,
     dataTestId,
     appletId: mockedAppletId,
-    activityId: mockedActivityId,
+    activity: {
+      id: mockedActivityId,
+    },
     roles: [],
     featureFlags: {
       enableMultiInformant: true,

--- a/src/modules/Dashboard/components/ActivityGrid/ActivityGrid.utils.tsx
+++ b/src/modules/Dashboard/components/ActivityGrid/ActivityGrid.utils.tsx
@@ -8,25 +8,31 @@ import {
   checkIfCanManageParticipants,
   checkIfFullAccess,
 } from 'shared/utils';
+import { EditablePerformanceTasks } from 'modules/Builder/features/Activities/Activities.const';
 
 import { ActivityActions, ActivityActionProps } from './ActivityGrid.types';
 
 export const getActivityActions = ({
   actions: { editActivity, exportData, assignActivity, takeNow },
   appletId,
-  activityId,
   dataTestId,
   roles,
   featureFlags,
   hasParticipants,
+  activity,
 }: ActivityActions): MenuItem<ActivityActionProps>[] => {
-  const canEdit = checkIfCanEdit(roles);
+  const canEdit =
+    (checkIfCanEdit(roles) && !activity?.isPerformanceTask) ||
+    EditablePerformanceTasks.includes(activity?.performanceTaskType ?? '');
   const canAccessData = checkIfCanAccessData(roles);
   const canDoTakeNow =
     featureFlags.enableMultiInformantTakeNow && hasParticipants && checkIfFullAccess(roles);
   const canAssignActivity =
     checkIfCanManageParticipants(roles) && featureFlags.enableActivityAssign;
   const showDivider = (canEdit || canAccessData) && (canDoTakeNow || canAssignActivity);
+  const { id: activityId } = activity;
+
+  if (!activityId) return [];
 
   return [
     {


### PR DESCRIPTION
### 📝 Description

Fixes navigation to Performance Task type activities from `ActivitySummaryCards`

🔗 [Jira Ticket M2-7091](https://mindlogger.atlassian.net/browse/M2-7091)


### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

#### Before

https://github.com/ChildMindInstitute/mindlogger-admin/assets/2916156/e7764482-da70-4f03-8218-6da5492ffd01



#### After


https://github.com/ChildMindInstitute/mindlogger-admin/assets/2916156/efaf54d1-0094-4e2a-afc7-ad4631329725



### 🪤 Peer Testing


- Depends on [Backend PR #1436](https://github.com/ChildMindInstitute/mindlogger-backend-refactor/pull/1436)
- Navigate to Applet
- Select more menu and edit Activity
  - Should navigate to `builder/{appletId}/activities/{activityId}/about`
- Select more menu and edit a Performance Type Activity
  - Should navigate to `builder/{appletId}/activities/performance-task/{performanceTaskType}/{activityId}` where `performanceTaskType` can be  `flanker|gyroscope|touch` 

### ✏️ Notes

You can create a Performance Task Type by selecting the "Add Performance Task" button in the Applet Builder
![CleanShot 2024-06-21 at 14 20 02@2x](https://github.com/ChildMindInstitute/mindlogger-admin/assets/2916156/a45b93be-fc80-4f1f-af8b-e2ea6965a59a)


