### PR TITLE
feat(mi): add Upgrade to Full Account event tracking (M2-7114)

### DIFF
--- a/src/modules/Dashboard/features/Applet/Popups/UpgradeAccountPopup/UpgradeAccountPopup.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/UpgradeAccountPopup/UpgradeAccountPopup.test.tsx
@@ -4,14 +4,14 @@ import mockAxios from 'jest-mock-axios';
 
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
 import { mockedAppletId, mockedSubjectId1 } from 'shared/mock';
-import { expectBanner } from 'shared/utils';
-import * as MixpanelFunc from 'shared/utils/mixpanel';
+import { Mixpanel, MixpanelProps, expectBanner } from 'shared/utils';
 import { ParticipantTag } from 'shared/consts';
 
 import { UpgradeAccountPopup } from './UpgradeAccountPopup';
 
 const dataTestid = 'test-id';
 const onCloseMock = jest.fn();
+const mixpanelTrack = jest.spyOn(Mixpanel, 'track');
 
 const props = {
   onClose: onCloseMock,
@@ -31,11 +31,10 @@ const testValues = {
 
 describe('UpgradeAccountPopup component', () => {
   afterEach(() => {
-    jest.restoreAllMocks();
+    jest.resetAllMocks();
   });
 
   test('should submit the form and show success banner', async () => {
-    const mixpanelTrack = jest.spyOn(MixpanelFunc.Mixpanel, 'track');
     mockAxios.post.mockResolvedValueOnce({
       data: {
         result: testValues,
@@ -51,9 +50,17 @@ describe('UpgradeAccountPopup component', () => {
 
     await userEvent.click(getByText('Send Invitation'));
 
+    expect(mixpanelTrack).toBeCalledWith('Upgrade to Full Account invitation form submitted', {
+      [MixpanelProps.AppletId]: mockedAppletId,
+    });
+
     await waitFor(() => {
       expectBanner(store, 'AddParticipantSuccessBanner');
     });
-    expect(mixpanelTrack).toBeCalledWith('Invitation sent successfully');
+
+    expect(mixpanelTrack).toBeCalledWith(
+      'Upgrade to Full Account invitation created successfully',
+      { [MixpanelProps.AppletId]: mockedAppletId },
+    );
   });
 });

--- a/src/modules/Dashboard/features/Applet/Popups/UpgradeAccountPopup/UpgradeAccountPopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/UpgradeAccountPopup/UpgradeAccountPopup.tsx
@@ -11,7 +11,7 @@ import {
   StyledModalWrapper,
 } from 'shared/styles';
 import { useFormError } from 'modules/Dashboard/hooks';
-import { Mixpanel, getErrorMessage } from 'shared/utils';
+import { Mixpanel, MixpanelProps, getErrorMessage } from 'shared/utils';
 import { Languages, postSubjectInvitationApi } from 'api';
 import { useAppDispatch } from 'redux/store';
 import { useAsync } from 'shared/hooks';
@@ -79,13 +79,20 @@ export const UpgradeAccountPopup = ({
         },
       }),
     );
-    Mixpanel.track('Invitation sent successfully');
+
+    Mixpanel.track('Upgrade to Full Account invitation created successfully', {
+      [MixpanelProps.AppletId]: appletId,
+    });
+
     handleClose(true);
   });
 
   const handleSubmitForm = (values: UpgradeAccountFormValues) => {
     if (!appletId || !subjectId) return;
-    Mixpanel.track('Subject Invitation click');
+
+    Mixpanel.track('Upgrade to Full Account invitation form submitted', {
+      [MixpanelProps.AppletId]: appletId,
+    });
 
     createInvitation({
       appletId,

--- a/src/modules/Dashboard/features/Participants/Participants.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.tsx
@@ -172,6 +172,11 @@ export const Participants = () => {
     nickname,
     tag,
   }: HandleUpgradeAccount) => {
+    Mixpanel.track('Upgrade to Full Account clicked', {
+      [MixpanelProps.AppletId]: appletId,
+      [MixpanelProps.Via]: 'Applet - Participants',
+    });
+
     setRespondentKey(respondentOrSubjectId);
     setParticipantDetails({ secretId, nickname, tag });
     handleSetDataForAppletPage({


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-7114](https://mindlogger.atlassian.net/browse/M2-7114)

This PR tracks new/updated Mixpanel events related to upgrading Limited Accounts to Full Accounts.

### 🪤 Peer Testing

Please refer to [JIRA ticket](https://mindlogger.atlassian.net/browse/M2-7114) for details around when events are triggered and what event properties should be attached to those events.

#### Prerequisites:

- To test, you'll need to have access to the **MindLogger Analytics Dev** project in Mixpanel; please let @farmerpaul know if you are planning to do peer testing so that you can be granted access.
- Ensure you have these env vars set locally:
  ```
  REACT_APP_ENV=dev
  REACT_APP_MIXPANEL_TOKEN=c1e1e662f03d9f1363768731077ea000
  REACT_APP_MIXPANEL_FORCE_ENABLE=true
  REACT_APP_DEVELOP_BUILD_VERSION=head
  ```

#### Testing:
* For each table row in the [JIRA ticket](https://mindlogger.atlassian.net/browse/M2-6735):
  1. Follow the instructions under the **Trigger** column to trigger the event.
  2. Open the **MindLogger Analytics Dev** project in Mixpanel, and navigate to the [Events tab](https://mixpanel.com/project/3333580/view/3841316/app/events). Refresh if needed.

      **Expected outcome:** The event matching the **New Event Name** column should have been added to the top of the list.

  4. Expand the event and open the **Your Properties** tab:  
      <img width="832" alt="Screenshot 2024-06-18 at 4 32 53 PM" src="https://github.com/ChildMindInstitute/mindlogger-admin/assets/1282772/f49b7db6-2faf-41aa-9f78-a7ecdd56e8ea">

      **Expected outcome:** The custom properties for that event mentioned in the **Details** column should be listed, as well as **Applet ID** as the JIRA ticket says applies to all events.
