### PR TITLE
feature: Add ability to duplicate Item Flows (M2-6907)

### DIFF
--- a/src/modules/Builder/features/ActivityItemsFlow/ActivityItemsFlow.test.tsx
+++ b/src/modules/Builder/features/ActivityItemsFlow/ActivityItemsFlow.test.tsx
@@ -165,6 +165,23 @@ describe('Activity Items Flow', () => {
     expect(addItemFlow).not.toBeDisabled();
   });
 
+  describe('Duplicate ItemFlow', () => {
+    beforeEach(() => {
+      renderActivityItemsFlow(mockedAppletWithAllItemTypes);
+    });
+
+    test('Duplicates ItemFlow successfully', async () => {
+      fireEvent.click(screen.getByTestId(`${mockedTestid}-add`));
+
+      expect(screen.getAllByTestId(new RegExp(`^${mockedTestid}-\\d+$`))).toHaveLength(1);
+
+      fireEvent.click(screen.getByTestId(`builder-activity-item-flow-0-condition-0-name`));
+      fireEvent.click(screen.getByTestId(`${mockedTestid}-0-duplicate`));
+
+      expect(screen.getAllByTestId(new RegExp(`^${mockedTestid}-\\d+$`))).toHaveLength(2);
+    });
+  });
+
   test('Add/Remove Conditional works correctly', async () => {
     renderActivityItemsFlow(mockedAppletWithAllItemTypes);
 
@@ -221,6 +238,7 @@ describe('Activity Items Flow', () => {
     expect(screen.getAllByTestId(new RegExp(`^${mockedTestid}-0-summary$`))).toHaveLength(1);
     expect(screen.getByTestId(`${mockedTestid}-0-title`)).toHaveTextContent('Conditional 1');
     expect(screen.getByTestId(`${mockedTestid}-0-add`)).toBeVisible();
+    expect(screen.getByTestId(`${mockedTestid}-0-duplicate`)).toBeVisible();
     expect(screen.getByTestId(`${mockedTestid}-0-remove`)).toBeVisible();
     expect(screen.getByTestId(`${mockedTestid}-0-condition-0-name`)).toBeVisible();
 

--- a/src/modules/Builder/features/ActivityItemsFlow/ActivityItemsFlow.tsx
+++ b/src/modules/Builder/features/ActivityItemsFlow/ActivityItemsFlow.tsx
@@ -25,8 +25,7 @@ import {
 export const ActivityItemsFlow = () => {
   const { t } = useTranslation('app');
   const [itemIndexToDelete, setItemIndexToDelete] = useState(-1);
-
-  const { control } = useCustomFormContext();
+  const { control, getValues, setError } = useCustomFormContext();
   const { fieldName } = useCurrentActivity();
   useRedirectIfNoMatchedActivity();
 
@@ -62,6 +61,26 @@ export const ActivityItemsFlow = () => {
     targetSelector: `.${ACTIVITY_ITEMS_FLOW_END_ITEM_CLASS}`,
   });
 
+  const handleDuplicate = async (index: number) => {
+    const emptyFlowItem = getEmptyFlowItem();
+    const currentFlowItems = getValues(`${fieldName}.conditionalLogic`);
+    const copiedFlowItem = currentFlowItems?.[index];
+
+    if (copiedFlowItem && emptyFlowItem) {
+      const newFlowItem = {
+        ...emptyFlowItem,
+        conditions: [...copiedFlowItem.conditions],
+        match: copiedFlowItem.match,
+      } as ConditionalLogic;
+
+      appendFlowItem(newFlowItem);
+
+      setError(`${fieldName}.conditionalLogic.${currentFlowItems.length}.itemKey`, {
+        type: 'required',
+      });
+    }
+  };
+
   const headerProps = {
     isAddItemFlowDisabled: items?.length < 2 || isPending,
     onAddItemFlow: handleAddItemFlow,
@@ -85,6 +104,7 @@ export const ActivityItemsFlow = () => {
             name={conditionalLogicName}
             index={index}
             isStaticActive={flowItemsData.length > ITEMS_COUNT_TO_ACTIVATE_STATIC}
+            onDuplicate={handleDuplicate}
             onRemove={() => handleRemoveItemFlow(index)}
           />
         ))}

--- a/src/modules/Builder/features/ActivityItemsFlow/ItemFlow/ItemFlow.tsx
+++ b/src/modules/Builder/features/ActivityItemsFlow/ItemFlow/ItemFlow.tsx
@@ -23,7 +23,7 @@ import { getEmptyCondition, getObserverSelector } from './ItemFlow.utils';
 import { StyledTitle, StyledCollapse } from './ItemFlow.styles';
 import { ItemFlowContent } from './ItemFlowContent';
 
-export const ItemFlow = ({ name, index, isStaticActive, onRemove }: ItemFlowProps) => {
+export const ItemFlow = ({ name, index, isStaticActive, onDuplicate, onRemove }: ItemFlowProps) => {
   const { t } = useTranslation('app');
   const [isExpanded, setExpanded] = useState(true);
   const [isStatic, setStatic] = useState(isStaticActive);
@@ -83,6 +83,7 @@ export const ItemFlow = ({ name, index, isStaticActive, onRemove }: ItemFlowProp
           <ItemFlowActions
             name={itemName}
             onAdd={handleAddCondition}
+            onDuplicate={() => onDuplicate?.(index)}
             onRemove={onRemove}
             data-testid={dataTestid}
             open={isExpanded}

--- a/src/modules/Builder/features/ActivityItemsFlow/ItemFlow/ItemFlow.types.ts
+++ b/src/modules/Builder/features/ActivityItemsFlow/ItemFlow/ItemFlow.types.ts
@@ -2,5 +2,6 @@ export type ItemFlowProps = {
   name: string;
   index: number;
   isStaticActive: boolean;
+  onDuplicate?: (index: number) => void;
   onRemove: () => void;
 };

--- a/src/modules/Builder/features/ActivityItemsFlow/ItemFlow/ItemFlowActions/ItemFlowActions.tsx
+++ b/src/modules/Builder/features/ActivityItemsFlow/ItemFlow/ItemFlowActions/ItemFlowActions.tsx
@@ -14,6 +14,7 @@ export const ItemFlowActions = ({
   open,
   name,
   onAdd,
+  onDuplicate,
   onRemove,
   onToggle,
   'data-testid': dataTestid,
@@ -53,7 +54,12 @@ export const ItemFlowActions = ({
         </StyledTitleMedium>
       )}
       <Actions
-        items={getItemFlowActions({ onAdd: handleAdd, onRemove, 'data-testid': dataTestid })}
+        items={getItemFlowActions({
+          onAdd: handleAdd,
+          onDuplicate,
+          onRemove,
+          'data-testid': dataTestid,
+        })}
         context={name}
         visibleByDefault={open}
         sxProps={{ width: 'unset' }}

--- a/src/modules/Builder/features/ActivityItemsFlow/ItemFlow/ItemFlowActions/ItemFlowActions.types.ts
+++ b/src/modules/Builder/features/ActivityItemsFlow/ItemFlow/ItemFlowActions/ItemFlowActions.types.ts
@@ -4,7 +4,11 @@ export type ItemFlowActionsProps = {
   onAdd: () => void;
   onRemove: () => void;
   onToggle: () => void;
+  onDuplicate: () => void;
   'data-testid'?: string;
 };
 
-export type ItemFlowActionsType = Pick<ItemFlowActionsProps, 'onAdd' | 'onRemove' | 'data-testid'>;
+export type ItemFlowActionsType = Pick<
+  ItemFlowActionsProps,
+  'onAdd' | 'onRemove' | 'onDuplicate' | 'data-testid'
+>;

--- a/src/modules/Builder/features/ActivityItemsFlow/ItemFlow/ItemFlowActions/ItemFlowActions.utils.tsx
+++ b/src/modules/Builder/features/ActivityItemsFlow/ItemFlow/ItemFlowActions/ItemFlowActions.utils.tsx
@@ -4,6 +4,7 @@ import { ItemFlowActionsType } from './ItemFlowActions.types';
 
 export const getItemFlowActions = ({
   onAdd,
+  onDuplicate,
   onRemove,
   'data-testid': dataTestid,
 }: ItemFlowActionsType) => [
@@ -11,6 +12,11 @@ export const getItemFlowActions = ({
     icon: <Svg id="add" />,
     action: () => onAdd(),
     'data-testid': `${dataTestid}-add`,
+  },
+  {
+    icon: <Svg id="duplicate" />,
+    action: onDuplicate,
+    'data-testid': `${dataTestid}-duplicate`,
   },
   {
     icon: <Svg id="trash" />,

--- a/src/modules/Builder/features/ActivityItemsFlow_old/ActivityItemsFlow.test.tsx
+++ b/src/modules/Builder/features/ActivityItemsFlow_old/ActivityItemsFlow.test.tsx
@@ -147,6 +147,23 @@ describe('Activity Items Flow', () => {
     expect(addItemFlow).not.toBeDisabled();
   });
 
+  describe('Duplicate ItemFlow', () => {
+    beforeEach(() => {
+      renderActivityItemsFlow(mockedAppletWithAllItemTypes);
+    });
+
+    test('Duplicates ItemFlow successfully', async () => {
+      fireEvent.click(screen.getByTestId(`${mockedTestid}-add`));
+
+      expect(screen.getAllByTestId(new RegExp(`^${mockedTestid}-\\d+$`))).toHaveLength(1);
+
+      fireEvent.click(screen.getByTestId(`builder-activity-item-flow-0-condition-0-name`));
+      fireEvent.click(screen.getByTestId(`${mockedTestid}-0-duplicate`));
+
+      expect(screen.getAllByTestId(new RegExp(`^${mockedTestid}-\\d+$`))).toHaveLength(2);
+    });
+  });
+
   test('Add/Remove Conditional works correctly', async () => {
     renderActivityItemsFlow(mockedAppletWithAllItemTypes);
 

--- a/src/modules/Builder/features/ActivityItemsFlow_old/ActivityItemsFlow.tsx
+++ b/src/modules/Builder/features/ActivityItemsFlow_old/ActivityItemsFlow.tsx
@@ -25,8 +25,7 @@ import {
 export const ActivityItemsFlow = () => {
   const { t } = useTranslation('app');
   const [itemIndexToDelete, setItemIndexToDelete] = useState(-1);
-
-  const { control } = useCustomFormContext();
+  const { control, getValues, setError } = useCustomFormContext();
   const { fieldName } = useCurrentActivity();
   useRedirectIfNoMatchedActivity();
 
@@ -45,6 +44,27 @@ export const ActivityItemsFlow = () => {
   const handleAddItemFlow = () => {
     appendFlowItem(getEmptyFlowItem() as ConditionalLogic);
   };
+
+  const handleDuplicate = async (index: number) => {
+    const emptyFlowItem = getEmptyFlowItem();
+    const currentFlowItems = getValues(`${fieldName}.conditionalLogic`);
+    const copiedFlowItem = currentFlowItems?.[index];
+
+    if (copiedFlowItem && emptyFlowItem) {
+      const newFlowItem = {
+        ...emptyFlowItem,
+        conditions: [...copiedFlowItem.conditions],
+        match: copiedFlowItem.match,
+      } as ConditionalLogic;
+
+      appendFlowItem(newFlowItem);
+
+      setError(`${fieldName}.conditionalLogic.${currentFlowItems.length}.itemKey`, {
+        type: 'required',
+      });
+    }
+  };
+
   const handleRemoveItemFlow = (index: number) => {
     setItemIndexToDelete(index);
   };
@@ -85,6 +105,7 @@ export const ActivityItemsFlow = () => {
             name={conditionalLogicName}
             index={index}
             isStaticActive={flowItemsData.length > ITEMS_COUNT_TO_ACTIVATE_STATIC}
+            onDuplicate={handleDuplicate}
             onRemove={() => handleRemoveItemFlow(index)}
           />
         ))}

--- a/src/modules/Builder/features/ActivityItemsFlow_old/ItemFlow/ItemFlow.tsx
+++ b/src/modules/Builder/features/ActivityItemsFlow_old/ItemFlow/ItemFlow.tsx
@@ -23,7 +23,7 @@ import { getEmptyCondition, getObserverSelector } from './ItemFlow.utils';
 import { StyledTitle, StyledCollapse } from './ItemFlow.styles';
 import { ItemFlowContent } from './ItemFlowContent';
 
-export const ItemFlow = ({ name, index, isStaticActive, onRemove }: ItemFlowProps) => {
+export const ItemFlow = ({ name, index, isStaticActive, onDuplicate, onRemove }: ItemFlowProps) => {
   const { t } = useTranslation('app');
   const [isExpanded, setExpanded] = useState(true);
   const [isStatic, setStatic] = useState(isStaticActive);
@@ -83,6 +83,7 @@ export const ItemFlow = ({ name, index, isStaticActive, onRemove }: ItemFlowProp
           <ItemFlowActions
             name={itemName}
             onAdd={handleAddCondition}
+            onDuplicate={() => onDuplicate?.(index)}
             onRemove={onRemove}
             data-testid={dataTestid}
             open={isExpanded}

--- a/src/modules/Builder/features/ActivityItemsFlow_old/ItemFlow/ItemFlow.types.ts
+++ b/src/modules/Builder/features/ActivityItemsFlow_old/ItemFlow/ItemFlow.types.ts
@@ -2,5 +2,6 @@ export type ItemFlowProps = {
   name: string;
   index: number;
   isStaticActive: boolean;
+  onDuplicate?: (index: number) => void;
   onRemove: () => void;
 };

--- a/src/modules/Builder/features/ActivityItemsFlow_old/ItemFlow/ItemFlowActions/ItemFlowActions.tsx
+++ b/src/modules/Builder/features/ActivityItemsFlow_old/ItemFlow/ItemFlowActions/ItemFlowActions.tsx
@@ -14,6 +14,7 @@ export const ItemFlowActions = ({
   open,
   name,
   onAdd,
+  onDuplicate,
   onRemove,
   onToggle,
   'data-testid': dataTestid,
@@ -53,7 +54,12 @@ export const ItemFlowActions = ({
         </StyledTitleMedium>
       )}
       <Actions
-        items={getItemFlowActions({ onAdd: handleAdd, onRemove, 'data-testid': dataTestid })}
+        items={getItemFlowActions({
+          onAdd: handleAdd,
+          onDuplicate,
+          onRemove,
+          'data-testid': dataTestid,
+        })}
         context={name}
         visibleByDefault={open}
         sxProps={{ width: 'unset' }}

--- a/src/modules/Builder/features/ActivityItemsFlow_old/ItemFlow/ItemFlowActions/ItemFlowActions.types.ts
+++ b/src/modules/Builder/features/ActivityItemsFlow_old/ItemFlow/ItemFlowActions/ItemFlowActions.types.ts
@@ -2,9 +2,13 @@ export type ItemFlowActionsProps = {
   open: boolean;
   name: string;
   onAdd: () => void;
+  onDuplicate: () => void;
   onRemove: () => void;
   onToggle: () => void;
   'data-testid'?: string;
 };
 
-export type ItemFlowActionsType = Pick<ItemFlowActionsProps, 'onAdd' | 'onRemove' | 'data-testid'>;
+export type ItemFlowActionsType = Pick<
+  ItemFlowActionsProps,
+  'onAdd' | 'onRemove' | 'onDuplicate' | 'data-testid'
+>;

--- a/src/modules/Builder/features/ActivityItemsFlow_old/ItemFlow/ItemFlowActions/ItemFlowActions.utils.tsx
+++ b/src/modules/Builder/features/ActivityItemsFlow_old/ItemFlow/ItemFlowActions/ItemFlowActions.utils.tsx
@@ -4,6 +4,7 @@ import { ItemFlowActionsType } from './ItemFlowActions.types';
 
 export const getItemFlowActions = ({
   onAdd,
+  onDuplicate,
   onRemove,
   'data-testid': dataTestid,
 }: ItemFlowActionsType) => [
@@ -11,6 +12,11 @@ export const getItemFlowActions = ({
     icon: <Svg id="add" />,
     action: () => onAdd(),
     'data-testid': `${dataTestid}-add`,
+  },
+  {
+    icon: <Svg id="duplicate" />,
+    action: onDuplicate,
+    'data-testid': `${dataTestid}-duplicate`,
   },
   {
     icon: <Svg id="trash" />,


### PR DESCRIPTION
### 📝 Description

🔗 [M2-6907](https://mindlogger.atlassian.net/browse/M2-6907): [Admin] - Allow Admin to Duplicate Item Conditions


### 📸 Screenshots

![duplicatin](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/bfd5ead8-b903-4ba4-8ff2-30d015507a18)

### 🪤 Peer Testing

For an applet, with an activity populated by multiple items…

1. From the **Builder** screens's Activity tab for the given applet, press the Activity you want to edit, and then press the **Item Flow** tab to switch to it.
2. If no Item Flows exist yet, create one and fill in the relevant options.
3. Press the duplicate button on the item flow you want to duplicate.
4. Observe that a new Item Flow has been created. It should be appended to the end of the list of Item Flows, have an identical set of conditions as the Item Flow you chose to copy, and the "Shown Item" dropdown should be empty, with an error prompt that requires the user to set a value.

### ✏️ Notes

> [!NOTE]  
> The [second commit in this PR](https://github.com/ChildMindInstitute/mindlogger-admin/pull/1830/commits/cf96b35e3ab21b022e899b841b9062e5246f573d) duplicates the changes from the previous commit to the `_old` variations of the same components.
>
> Control of which component is rendered is determined by the `enableItemFlowExtendedItems` feature flag.
>
> There should be no functional differences, but you may want to test with the flag both set/unset to verify. Note that when the flag is set, a number of unsupported item types will be rendered and selectable as options in Item Flows, which are not yet supported by the backend, and will return errors, as determined by [this check](https://github.com/ChildMindInstitute/mindlogger-backend-refactor/blob/86cd23bd1151ccc097687a81e2c2504d6194df0b/src/apps/activities/domain/custom_validation.py#L51-L55).
>
> You may toggle this feature flag by adding …
>
> ```jsx
> features.enableItemFlowExtendedItems = false;
> ```
>
> … prior to the `return` statement [here in `useFeatureFlags`](https://github.com/ChildMindInstitute/mindlogger-admin/blob/6dc81667f7dd06c89f4fab6e80236a011f0ed106/src/shared/hooks/useFeatureFlags.ts#L22-L28).

[M2-6907]: https://mindlogger.atlassian.net/browse/M2-6907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ