### PR TITLE
fix: Update Autocomplete dropdown placement (M2-7152)

### DIFF
--- a/src/shared/components/FormComponents/TagsAutocompleteController/TagsAutocompleteController.tsx
+++ b/src/shared/components/FormComponents/TagsAutocompleteController/TagsAutocompleteController.tsx
@@ -147,19 +147,7 @@ export const TagsAutocompleteController = <
                 </Paper>
               );
             }}
-            // ensure that the popper always stays at the bottom
-            slotProps={{
-              popper: {
-                modifiers: [
-                  {
-                    name: 'flip',
-                    options: {
-                      rootBoundary: 'document',
-                    },
-                  },
-                ],
-              },
-            }}
+            slotProps={{ popper: { placement: 'bottom' } }}
             data-testid={dataTestid}
           />
         );


### PR DESCRIPTION
### 📝 Description

🔗 [M2-7152](https://mindlogger.atlassian.net/browse/M2-7152): [Admin Panel] Add team member: there is no option to scroll the list of members in the "This Reviewer Can View" dropdown if there are more than 2 participants

This PR fixes an issue where the `TagsAutocompleteController` dropdown menu was being forced to open below the reference element (ie, the text input).

This caused issues where an open dropdown, when opened on a viewport with a small height, would extend offscreen, rather than be positioned according to available space. This prevented some options in the dropdown from being seen.

To fix this, I replaced the existing prop values with a `placement="bottom"` prop, to describe the preferred placement of the dropdown, but allow it to open on an alternate side based on available space.

### 📸 Screenshots

| Before | After |
|-|-|
| ![before](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/f50e9cc4-6348-4131-8b72-340e01f736b5) | ![after-2](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/35eeb65a-f549-4968-a421-97492ba69e11) |

### 🪤 Peer Testing

For an applet with multiple participants…

1. Navigate to the **Applet Dashboard → Team** screen. 
2. Press the "Add Team Member" button, and then choose the "Reviewer" role.
3. Open the "This Reviewer Can View Dropdown".
4. If necessary, resize your browser window's height.
5. Observe that the dropdown no longer extends off the viewport when the dropdown cannot fit below the text input, and instead swaps to the opposite side.

[M2-7152]: https://mindlogger.atlassian.net/browse/M2-7152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ