### PR TITLE
fix: Activity answers not preselected without Flows in DataViz (M2-7174)

### DIFF
--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/hooks/useReviewActivitiesAndFlows/useReviewActivitiesAndFlows.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/hooks/useReviewActivitiesAndFlows/useReviewActivitiesAndFlows.ts
@@ -63,8 +63,7 @@ export const useReviewActivitiesAndFlows = ({
       submitId ||
       selectedActivity ||
       selectedFlow ||
-      !activities.length ||
-      !flows.length ||
+      (!activities.length && !flows.length) ||
       !handleSelectAnswer
     ) {
       return;

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/RespondentDataSummary.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/RespondentDataSummary.tsx
@@ -66,7 +66,7 @@ export const RespondentDataSummary = () => {
 
   useEffect(() => {
     (async () => {
-      if (selectedEntity || !summaryActivitiesLength || !summaryFlowsLength) return;
+      if (selectedEntity || (!summaryActivitiesLength && !summaryFlowsLength)) return;
 
       const summaryEntities = getConcatenatedEntities({
         activities: summaryActivities,


### PR DESCRIPTION
- [x] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

🔗 [Jira Ticket M2-7174](https://mindlogger.atlassian.net/browse/M2-7174)

### 📸 Screenshots

| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| https://app.screencast.com/MXEwSHMqIq8BP | https://app.screencast.com/LlJYnaGx3rp5Z |

