### PR TITLE
fix: Add tooltips to `_old` ItemFlow variations

### DIFF
--- a/src/modules/Builder/components/ConditionRow_old/Condition/Condition.tsx
+++ b/src/modules/Builder/components/ConditionRow_old/Condition/Condition.tsx
@@ -4,10 +4,11 @@ import { useWatch } from 'react-hook-form';
 import { StyledTitleMedium, StyledClearedButton, theme } from 'shared/styles';
 import { Svg } from 'shared/components/Svg';
 import { CONDITION_TYPES_TO_HAVE_RANGE_VALUE } from 'shared/consts';
+import { ItemFlowSelectController } from 'modules/Builder/components/ItemFlowSelectController/ItemFlowSelectController';
 import { useCustomFormContext } from 'modules/Builder/hooks';
 import { ConditionRowType } from 'modules/Builder/types';
 
-import { StyledCondition, StyledInputController, StyledSelectController } from './Condition.styles';
+import { StyledCondition, StyledInputController } from './Condition.styles';
 import { ConditionProps } from './Condition.types';
 import { ConditionItemType } from './Condition.const';
 import {
@@ -70,7 +71,7 @@ export const Condition = ({
   return (
     <StyledCondition data-testid={dataTestid}>
       <StyledTitleMedium>{t('if')}</StyledTitleMedium>
-      <StyledSelectController
+      <ItemFlowSelectController
         control={control}
         name={itemName}
         options={itemOptions}
@@ -88,11 +89,11 @@ export const Condition = ({
         customChange={onItemChange}
         disabled={isRowTypeScore}
         shouldSkipIcon={isRowTypeScore}
-        isLabelNeedTranslation={false}
         data-testid={`${dataTestid}-name`}
+        tooltipTitle={selectedItem?.question}
       />
       {!isRowTypeItem && <StyledTitleMedium>{t('is')}</StyledTitleMedium>}
-      <StyledSelectController
+      <ItemFlowSelectController
         control={control}
         name={stateName}
         options={getStateOptions(selectedItem?.type)}
@@ -100,17 +101,15 @@ export const Condition = ({
           isStateSelectDisabled ? t('conditionDisabledPlaceholder') : t('conditionTypePlaceholder')
         }
         customChange={onStateChange}
-        isLabelNeedTranslation={false}
         data-testid={`${dataTestid}-type`}
         disabled={isStateSelectDisabled}
       />
       {isValueSelectShown && (
-        <StyledSelectController
+        <ItemFlowSelectController
           control={control}
           name={isItemScoreCondition ? numberValueName : optionValueName}
           options={isItemScoreCondition ? getScoreConditionOptions() : valueOptions}
           placeholder={isValueSelectDisabled ? t('conditionDisabledPlaceholder') : t('value')}
-          isLabelNeedTranslation={false}
           data-testid={`${dataTestid}-selection-value`}
           disabled={isValueSelectDisabled}
         />

--- a/src/modules/Builder/components/ConditionRow_old/Condition/Condition.types.ts
+++ b/src/modules/Builder/components/ConditionRow_old/Condition/Condition.types.ts
@@ -10,6 +10,7 @@ export type ConditionItem = {
   value: string;
   labelKey: string;
   responseValues?: SingleAndMultipleSelectItemResponseValues | SliderItemResponseValues;
+  question: string;
 };
 
 export type ConditionProps = {

--- a/src/modules/Builder/components/ConditionRow_old/ConditionRow.utils.tsx
+++ b/src/modules/Builder/components/ConditionRow_old/ConditionRow.utils.tsx
@@ -12,6 +12,7 @@ import {
 import { DEFAULT_PAYLOAD_MIN_VALUE, DEFAULT_PAYLOAD_MAX_VALUE } from './ConditionRow.const';
 import { GetPayload, OptionListItem } from './ConditionRow.types';
 import { ConditionItemType } from './Condition';
+import { StyledMdPreview } from '../ItemFlowSelectController/StyledMdPreview/StyledMdPreview.styles';
 
 const { t } = i18n;
 
@@ -45,6 +46,9 @@ export const getItemOptions = (items: ItemFormValues[], conditionRowType: Condit
           value: getEntityKey(item),
           type: getConditionItemType(item),
           responseValues: item.responseValues,
+          question: item.question,
+          tooltip: <StyledMdPreview modelValue={item.question ?? ''} />,
+          tooltipPlacement: 'right',
         },
       ];
     }

--- a/src/modules/Builder/features/ActivityItemsFlow_old/ItemFlow/SummaryRow/SummaryRow.tsx
+++ b/src/modules/Builder/features/ActivityItemsFlow_old/ItemFlow/SummaryRow/SummaryRow.tsx
@@ -5,11 +5,9 @@ import { useWatch } from 'react-hook-form';
 import { StyledTitleMedium } from 'shared/styles';
 import { getEntityKey } from 'shared/utils';
 import { SelectEvent } from 'shared/types';
+import { ItemFlowSelectController } from 'modules/Builder/components/ItemFlowSelectController/ItemFlowSelectController';
 import { ItemFormValues } from 'modules/Builder/types';
-import {
-  StyledSummaryRow,
-  StyledSummarySelectController,
-} from 'shared/styles/styledComponents/ConditionalSummary';
+import { StyledSummaryRow } from 'shared/styles/styledComponents/ConditionalSummary';
 import { useCustomFormContext } from 'modules/Builder/hooks';
 
 import { SummaryRowProps } from './SummaryRow.types';
@@ -18,7 +16,7 @@ import { useItemsInUsage } from './SummaryRow.hooks';
 
 export const SummaryRow = ({ name, activityName, 'data-testid': dataTestid }: SummaryRowProps) => {
   const { t } = useTranslation('app');
-  const { control, setValue } = useCustomFormContext();
+  const { control, setValue, getValues } = useCustomFormContext();
   const items = useWatch({ name: `${activityName}.items` });
   const itemsInUsage = useItemsInUsage(name);
 
@@ -34,20 +32,22 @@ export const SummaryRow = ({ name, activityName, 'data-testid': dataTestid }: Su
     [items, activityName, setValue],
   );
 
+  const { question } =
+    ((items ?? []) as ItemFormValues[]).find(({ id }) => id === getValues(`${name}.itemKey`)) ?? {};
+
   return (
     <>
       <StyledSummaryRow data-testid={dataTestid}>
         <StyledTitleMedium>{t('if')}</StyledTitleMedium>
-        <StyledSummarySelectController
+        <ItemFlowSelectController
           control={control}
           name={`${name}.match`}
           options={getMatchOptions()}
           placeholder={t('select')}
           data-testid={`${dataTestid}-match`}
-          isLabelNeedTranslation={false}
         />
         <StyledTitleMedium>{t('summaryRowDescription')}</StyledTitleMedium>
-        <StyledSummarySelectController
+        <ItemFlowSelectController
           control={control}
           name={`${name}.itemKey`}
           options={getItemsOptions({ items, itemsInUsage })}
@@ -62,7 +62,7 @@ export const SummaryRow = ({ name, activityName, 'data-testid': dataTestid }: Su
           }}
           customChange={handleChangeItemKey}
           data-testid={`${dataTestid}-item`}
-          isLabelNeedTranslation={false}
+          tooltipTitle={question}
         />
       </StyledSummaryRow>
     </>

--- a/src/modules/Builder/features/ActivityItemsFlow_old/ItemFlow/SummaryRow/SummaryRow.utils.test.ts
+++ b/src/modules/Builder/features/ActivityItemsFlow_old/ItemFlow/SummaryRow/SummaryRow.utils.test.ts
@@ -51,16 +51,30 @@ describe('SummaryRow.utils', () => {
         tooltip:
           "This item is already selected in another Conditional card's summary row. If multiple conditions are necessary, use the same Conditional card with ALL or ANY conditions.",
         value: 'item-1',
+        tooltipPlacement: 'right',
       },
-      { disabled: false, labelKey: 'ms1', tooltip: undefined, value: 'item-2' },
+      {
+        disabled: false,
+        labelKey: 'ms1',
+        tooltip: undefined,
+        value: 'item-2',
+        tooltipPlacement: undefined,
+      },
       {
         disabled: true,
         labelKey: 'sl1',
         tooltip:
           "This item is already selected in another Conditional card's summary row. If multiple conditions are necessary, use the same Conditional card with ALL or ANY conditions.",
         value: 'item-3',
+        tooltipPlacement: 'right',
       },
-      { disabled: false, labelKey: 't1', tooltip: undefined, value: 'item-4' },
+      {
+        disabled: false,
+        labelKey: 't1',
+        tooltip: undefined,
+        value: 'item-4',
+        tooltipPlacement: undefined,
+      },
     ];
     test('should return options with tooltips and disable statuses for items in usage', () => {
       //eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/src/modules/Builder/features/ActivityItemsFlow_old/ItemFlow/SummaryRow/SummaryRow.utils.tsx
+++ b/src/modules/Builder/features/ActivityItemsFlow_old/ItemFlow/SummaryRow/SummaryRow.utils.tsx
@@ -1,6 +1,7 @@
 import i18n from 'i18n';
 import { ConditionalLogicMatch } from 'shared/consts';
 import { getEntityKey } from 'shared/utils';
+import { StyledMdPreview } from 'modules/Builder/components/ItemFlowSelectController/StyledMdPreview/StyledMdPreview.styles';
 
 import { ITEMS_RESPONSE_TYPES_TO_SHOW } from './SummaryRow.const';
 import { GetItemsInUsageProps, GetItemsOptionsProps } from './SummaryRow.types';
@@ -23,9 +24,18 @@ export const getItemsOptions = ({ items, itemsInUsage }: GetItemsOptionsProps) =
     if (item.responseType && ITEMS_RESPONSE_TYPES_TO_SHOW.includes(item.responseType)) {
       const value = getEntityKey(item);
       const disabled = itemsInUsage.has(value);
-      const tooltip = disabled ? t('conditionalLogicValidation.usageInSummaryRow') : undefined;
+      const showTooltip = disabled || item.question;
+      const tooltipPlacement: 'right' | undefined = showTooltip ? 'right' : undefined;
+      let tooltip;
+      if (showTooltip) {
+        tooltip = disabled ? (
+          t('conditionalLogicValidation.usageInSummaryRow')
+        ) : (
+          <StyledMdPreview modelValue={item.question ?? ''} />
+        );
+      }
 
-      return [...optionList, { value, labelKey: item.name, disabled, tooltip }];
+      return [...optionList, { value, labelKey: item.name, disabled, tooltip, tooltipPlacement }];
     }
 
     return optionList;


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-#](https://mindlogger.atlassian.net/browse/M2-#)

This PR corrects an issue where tooltips on ItemFlow condition dropdowns would not be displayed when the `enableItemFlowExtendedItems` feature flag was unset.

Correcting this involved copying the existing logic from the relevant Condition/Summary ItemFlow components and utility functions into the corresponding `_old` file variants.

### 🪤 Peer Testing

With the `enableItemFlowExtendedItems` feature flag set to false…

1. The testing notes in the earlier Tooltip PR (https://github.com/ChildMindInstitute/mindlogger-admin/pull/1822 & https://github.com/ChildMindInstitute/mindlogger-admin/pull/1814) continue to apply, and tooltips work as expected.

### ✏️ Notes

> [!TIP]  
> Testing this PR requires the `enableItemFlowExtendedItems` feature flag to be unset. You may do this locally by adding…
>
> ```jsx
> features.enableItemFlowExtendedItems = false;
> ```
>
> …prior to the `return` statement [here in `useFeatureFlags`](https://github.com/ChildMindInstitute/mindlogger-admin/blob/6dc81667f7dd06c89f4fab6e80236a011f0ed106/src/shared/hooks/useFeatureFlags.ts#L22-L28).