### PR TITLE
fix(mi): Close Web App tab after Take Now (M2-7159)

### DIFF
--- a/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.tsx
+++ b/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.tsx
@@ -294,7 +294,21 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
         });
 
         setActivityOrFlow(null);
-        window.open(url.toString(), '_blank');
+
+        const newTab = window.open(url.toString(), '_blank');
+        // message received from the TakeNowSuccessModal.tsx file from the web app
+        // it's needed to close the new tab after the user clicks the "Close" button
+        window.addEventListener('message', function messageHandler(event) {
+          if (event.origin === url.origin) {
+            const message = event.data;
+
+            if (message === 'close-me') {
+              newTab?.close();
+            }
+
+            this.removeEventListener('message', messageHandler);
+          }
+        });
       }
     }, [targetSubject, sourceSubject, loggedInUser, isSelfReporting]);
 


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-7159](https://mindlogger.atlassian.net/browse/M2-7159)

Currently the application is window is unable to close itself for some security reason on browsers when using [window.close](https://developer.mozilla.org/en-US/docs/Web/API/Window/close) the solution is to create a message event and share that message event with the parent window whose open this window

Changes include:

- store the new window reference
- add a message listener whos validates the origin of the message

### 📸 Screenshots

https://github.com/ChildMindInstitute/mindlogger-web-refactor/assets/28871425/763761e3-d1e5-4cc5-94c6-39a8b645b102
