### PR TITLE
feature: Add "Edit event" confirmation popup (M2-7188)

### DIFF
--- a/src/modules/Dashboard/features/Applet/Schedule/EditEventPopup/EditEventPopup.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/EditEventPopup/EditEventPopup.test.tsx
@@ -13,68 +13,9 @@ import { JEST_TEST_TIMEOUT } from 'shared/consts';
 
 import { EditEventPopup } from './EditEventPopup';
 
-const mockSetEditEventPopupVisible = jest.fn();
-const dataTestid = 'dashboard-calendar-edit-event';
-const mockDefaultStartDate = new Date('03-18-2024');
 const mockAppletId = 'a341e3d7-0170-4894-8823-798c58456130';
 const mockEventId1 = '8a0a2abd-d8e2-4fb6-91bb-65aecfc5396a';
 const mockEventId2 = 'ae1d9534-ad9b-4efc-a0c7-cd82addc44fc';
-const mockEditedEvent1 = {
-  activityOrFlowId: '96d889e2-2264-4e76-8c60-744600e770fe',
-  eventId: mockEventId1,
-  title: 'Mock Activity 1',
-  alwaysAvailable: false,
-  startFlowIcon: false,
-  isHidden: false,
-  backgroundColor: 'transparent',
-  periodicity: 'WEEKLY',
-  eventStart: new Date('2024-03-18T09:00:00.000Z'),
-  eventEnd: new Date('2024-12-31T11:00:00.000Z'),
-  oneTimeCompletion: null,
-  accessBeforeSchedule: false,
-  timerType: 'NOT_SET',
-  timer: null,
-  notification: null,
-  endAlertIcon: false,
-  allDay: false,
-  scheduledColor: '#0b6e99',
-  scheduledBackground: 'rgba(11, 110, 153, 0.3)',
-  startTime: '10:00',
-  endTime: '12:00',
-  id: 'event-4559',
-  start: new Date('2024-03-18T09:00:00.000Z'),
-  end: new Date('2024-03-18T11:00:00.000Z'),
-  eventCurrentDate: '18 Mar 2024',
-  isHiddenInTimeView: false,
-  isOffRange: false,
-};
-const mockEditedEvent2 = {
-  activityOrFlowId: '60f83cbf-8ffe-447b-af34-0e4cc5f8d3d0',
-  eventId: mockEventId2,
-  title: 'Mock Activity 2',
-  alwaysAvailable: true,
-  startFlowIcon: false,
-  isHidden: false,
-  backgroundColor: '#0b6e99',
-  periodicity: 'ALWAYS',
-  eventStart: new Date('2023-11-05T23:00:00.000Z'),
-  eventEnd: null,
-  oneTimeCompletion: false,
-  accessBeforeSchedule: false,
-  timerType: 'NOT_SET',
-  timer: 0,
-  notification: null,
-  endAlertIcon: false,
-  allDay: true,
-  startTime: '00:00',
-  endTime: '23:59',
-  id: 'event-5837',
-  start: new Date('2024-03-18T23:00:00.000Z'),
-  end: new Date('2024-03-18T22:59:00.000Z'),
-  eventCurrentDate: '18 Mar 2024',
-  isHiddenInTimeView: false,
-  isOffRange: false,
-};
 
 export const preloadedState = {
   workspaces: {
@@ -163,8 +104,70 @@ export const preloadedState = {
 };
 
 describe('EditEventPopup', () => {
+  const mockSetEditEventPopupVisible = jest.fn();
+  const mockSetSaveChangesPopupVisible = jest.fn();
+
+  const dataTestid = 'dashboard-calendar-edit-event';
+  const mockDefaultStartDate = new Date('03-18-2024');
+  const mockEditedEvent1 = {
+    activityOrFlowId: '96d889e2-2264-4e76-8c60-744600e770fe',
+    eventId: mockEventId1,
+    title: 'Mock Activity 1',
+    alwaysAvailable: false,
+    startFlowIcon: false,
+    isHidden: false,
+    backgroundColor: 'transparent',
+    periodicity: 'WEEKLY',
+    eventStart: new Date('2024-03-18T09:00:00.000Z'),
+    eventEnd: new Date('2024-12-31T11:00:00.000Z'),
+    oneTimeCompletion: null,
+    accessBeforeSchedule: false,
+    timerType: 'NOT_SET',
+    timer: null,
+    notification: null,
+    endAlertIcon: false,
+    allDay: false,
+    scheduledColor: '#0b6e99',
+    scheduledBackground: 'rgba(11, 110, 153, 0.3)',
+    startTime: '10:00',
+    endTime: '12:00',
+    id: 'event-4559',
+    start: new Date('2024-03-18T09:00:00.000Z'),
+    end: new Date('2024-03-18T11:00:00.000Z'),
+    eventCurrentDate: '18 Mar 2024',
+    isHiddenInTimeView: false,
+    isOffRange: false,
+  };
+  const mockEditedEvent2 = {
+    activityOrFlowId: '60f83cbf-8ffe-447b-af34-0e4cc5f8d3d0',
+    eventId: mockEventId2,
+    title: 'Mock Activity 2',
+    alwaysAvailable: true,
+    startFlowIcon: false,
+    isHidden: false,
+    backgroundColor: '#0b6e99',
+    periodicity: 'ALWAYS',
+    eventStart: new Date('2023-11-05T23:00:00.000Z'),
+    eventEnd: null,
+    oneTimeCompletion: false,
+    accessBeforeSchedule: false,
+    timerType: 'NOT_SET',
+    timer: 0,
+    notification: null,
+    endAlertIcon: false,
+    allDay: true,
+    startTime: '00:00',
+    endTime: '23:59',
+    id: 'event-5837',
+    start: new Date('2024-03-18T23:00:00.000Z'),
+    end: new Date('2024-03-18T22:59:00.000Z'),
+    eventCurrentDate: '18 Mar 2024',
+    isHiddenInTimeView: false,
+    isOffRange: false,
+  };
+
   test(
-    'update event periodicity (WEEKLY -> DAILY)',
+    'update event periodicity and test close edit event popup',
     async () => {
       renderWithProviders(
         <EditEventPopup
@@ -172,6 +175,7 @@ describe('EditEventPopup', () => {
           editedEvent={mockEditedEvent1}
           setEditEventPopupVisible={mockSetEditEventPopupVisible}
           defaultStartDate={mockDefaultStartDate}
+          setSaveChangesPopupVisible={mockSetSaveChangesPopupVisible}
         />,
         {
           preloadedState,
@@ -195,7 +199,44 @@ describe('EditEventPopup', () => {
       // test close edit event popup
       const closeButton = await screen.findByTestId(`${dataTestid}-popup-close-button`);
       expect(closeButton).toBeInTheDocument();
+
       await userEvent.click(closeButton);
+      expect(mockSetSaveChangesPopupVisible).toBeCalledWith(true);
+      expect(mockSetEditEventPopupVisible).not.toBeCalled();
+    },
+    JEST_TEST_TIMEOUT,
+  );
+
+  test(
+    'update event periodicity (WEEKLY -> DAILY)',
+    async () => {
+      renderWithProviders(
+        <EditEventPopup
+          open
+          editedEvent={mockEditedEvent1}
+          setEditEventPopupVisible={mockSetEditEventPopupVisible}
+          defaultStartDate={mockDefaultStartDate}
+          setSaveChangesPopupVisible={mockSetSaveChangesPopupVisible}
+        />,
+        {
+          preloadedState,
+          route: `/dashboard/${mockAppletId}/schedule`,
+          routePath: page.appletSchedule,
+        },
+      );
+
+      expect(await screen.findByTestId(`${dataTestid}-popup`)).toBeInTheDocument();
+      const title = screen.getByTestId(`${dataTestid}-popup-title`);
+      expect(title).toBeInTheDocument();
+      expect(title).toHaveTextContent('Edit Activity Schedule');
+
+      const submitButton = screen.getByTestId(`${dataTestid}-popup-submit-button`);
+      expect(submitButton).toBeDisabled();
+
+      // change event periodicity
+      const daily = screen.getByTestId(`${dataTestid}-popup-form-availability-periodicity-1`);
+      await userEvent.click(daily);
+
       expect(mockSetEditEventPopupVisible).toBeCalledWith(false);
 
       expect(submitButton).not.toBeDisabled();

--- a/src/modules/Dashboard/features/Applet/Schedule/EditEventPopup/EditEventPopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/EditEventPopup/EditEventPopup.tsx
@@ -21,6 +21,7 @@ import { ConfirmScheduledAccessPopup } from '../ConfirmScheduledAccessPopup';
 export const EditEventPopup = ({
   open,
   editedEvent,
+  onClose,
   setEditEventPopupVisible,
   defaultStartDate,
   userId,
@@ -32,7 +33,6 @@ export const EditEventPopup = ({
   const [removeAlwaysAvailablePopupVisible, setRemoveAlwaysAvailablePopupVisible] = useState(false);
   const [currentActivityName, setCurrentActivityName] = useState('');
   const [isFormChanged, setIsFormChanged] = useState(false);
-  const [isClosable, setIsClosable] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const { appletId } = useParams();
   const dispatch = useAppDispatch();
@@ -71,17 +71,12 @@ export const EditEventPopup = ({
   };
 
   const handleEditEventClose = () => {
-    if (!isClosable) return;
-
-    setEditEventPopupVisible(false);
-    setIsClosable(false);
+    onClose?.(eventFormRef.current);
   };
-
-  const handleTransitionEntered = () => setIsClosable(true);
 
   const onRemoveEventClick = () => {
     setRemoveSingleScheduledPopupVisible(true);
-    handleEditEventClose();
+    setEditEventPopupVisible(false);
   };
 
   const onRemoveScheduledEventClose = () => {
@@ -103,7 +98,7 @@ export const EditEventPopup = ({
     if (eventFormRef?.current) {
       await eventFormRef.current.processEvent();
       setRemoveAllScheduledPopupVisible(false);
-      handleEditEventClose();
+      setEditEventPopupVisible(false);
     }
   };
 
@@ -111,7 +106,7 @@ export const EditEventPopup = ({
     if (eventFormRef?.current) {
       await eventFormRef.current.processEvent();
       setRemoveAlwaysAvailablePopupVisible(false);
-      handleEditEventClose();
+      setEditEventPopupVisible(false);
     }
   };
 
@@ -141,7 +136,6 @@ export const EditEventPopup = ({
           buttonText={t('save')}
           width="67.1"
           disabledSubmit={(!!editedEvent && !isFormChanged) || isLoading}
-          onTransitionEntered={handleTransitionEntered}
           data-testid={`${dataTestid}-popup`}
         >
           {isLoading && !removeAllScheduledPopupVisible && !removeAlwaysAvailablePopupVisible && (

--- a/src/modules/Dashboard/features/Applet/Schedule/EditEventPopup/EditEventPopup.types.ts
+++ b/src/modules/Dashboard/features/Applet/Schedule/EditEventPopup/EditEventPopup.types.ts
@@ -2,10 +2,13 @@ import { Dispatch, SetStateAction } from 'react';
 
 import { CalendarEvent } from 'modules/Dashboard/state';
 
+import { EventFormRef } from '../EventForm';
+
 export type EditEventPopupProps = {
   open: boolean;
   editedEvent: CalendarEvent;
   setEditEventPopupVisible: Dispatch<SetStateAction<boolean>>;
   defaultStartDate: Date;
   userId?: string;
+  onClose?: (form?: EventFormRef | null) => void;
 };

--- a/src/modules/Dashboard/features/Applet/Schedule/EventForm/AvailabilityTab/AvailabilityTab.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/EventForm/AvailabilityTab/AvailabilityTab.test.tsx
@@ -18,18 +18,21 @@ const defaultValues = {
   startTime: '00:00',
   endTime: '23:59',
   reminder: null,
-  removeWarning: {},
 };
 
-const FormWrapper = (props) => {
+const FormWrapper = ({ removeWarnings, ...otherProps }) => {
   const methods = useForm({
     mode: 'onChange',
-    defaultValues: { ...props },
+    defaultValues: otherProps,
   });
 
   return (
     <FormProvider {...methods}>
-      <AvailabilityTab hasAlwaysAvailableOption data-testid={dataTestid} />
+      <AvailabilityTab
+        hasAlwaysAvailableOption
+        data-testid={dataTestid}
+        removeWarnings={removeWarnings}
+      />
     </FormProvider>
   );
 };
@@ -113,7 +116,7 @@ describe('AvailabilityTab component', () => {
         activityIncomplete: 1,
         reminderTime: '11:00:00',
       },
-      removeWarning: {
+      removeWarnings: {
         showRemoveAlwaysAvailable: true,
         showRemoveAllScheduled: true,
       },

--- a/src/modules/Dashboard/features/Applet/Schedule/EventForm/AvailabilityTab/AvailabilityTab.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/EventForm/AvailabilityTab/AvailabilityTab.tsx
@@ -34,31 +34,24 @@ import { useNextDayLabel } from '../EventForm.hooks';
 export const AvailabilityTab = ({
   hasAlwaysAvailableOption,
   'data-testid': dataTestid,
+  removeWarnings,
 }: AvailabilityTabProps) => {
   const { t } = useTranslation('app');
   const { control, setValue, trigger } = useFormContext<EventFormValues>();
-  const [
-    alwaysAvailable,
-    periodicity,
-    startDate,
-    endDate,
-    startTime,
-    endTime,
-    reminder,
-    removeWarning,
-  ] = useWatch({
-    control,
-    name: [
-      'alwaysAvailable',
-      'periodicity',
-      'startDate',
-      'endDate',
-      'startTime',
-      'endTime',
-      'reminder',
-      'removeWarning',
-    ],
-  });
+  const [alwaysAvailable, periodicity, startDate, endDate, startTime, endTime, reminder] = useWatch(
+    {
+      control,
+      name: [
+        'alwaysAvailable',
+        'periodicity',
+        'startDate',
+        'endDate',
+        'startTime',
+        'endTime',
+        'reminder',
+      ],
+    },
+  );
   const hasNextDayLabel = useNextDayLabel({ startTime, endTime });
   const isOncePeriodicity = periodicity === Periodicity.Once;
 
@@ -158,10 +151,10 @@ export const AvailabilityTab = ({
         customChange={handleAvailabilityCustomChange}
         data-testid={`${dataTestid}-always-available`}
       />
-      {Object.keys(removeWarning).length !== 0 && (
+      {Object.keys(removeWarnings ?? {}).length !== 0 && (
         <StyledBodyMedium sx={{ marginLeft: theme.spacing(1.6) }} color={variables.palette.primary}>
-          {removeWarning.showRemoveAlwaysAvailable && t('scheduledAccessWarning')}
-          {removeWarning.showRemoveAllScheduled && t('alwaysAvailableWarning')}
+          {removeWarnings?.showRemoveAlwaysAvailable && t('scheduledAccessWarning')}
+          {removeWarnings?.showRemoveAllScheduled && t('alwaysAvailableWarning')}
         </StyledBodyMedium>
       )}
       {alwaysAvailable ? (

--- a/src/modules/Dashboard/features/Applet/Schedule/EventForm/AvailabilityTab/AvailabilityTab.types.ts
+++ b/src/modules/Dashboard/features/Applet/Schedule/EventForm/AvailabilityTab/AvailabilityTab.types.ts
@@ -1,4 +1,7 @@
+import { Warning } from '../EventForm.types';
+
 export type AvailabilityTabProps = {
   hasAlwaysAvailableOption?: boolean;
   'data-testid'?: string;
+  removeWarnings?: Warning;
 };

--- a/src/modules/Dashboard/features/Applet/Schedule/EventForm/EventForm.types.ts
+++ b/src/modules/Dashboard/features/Applet/Schedule/EventForm/EventForm.types.ts
@@ -1,4 +1,5 @@
 import { Dispatch, SetStateAction } from 'react';
+import { FormState } from 'react-hook-form';
 import * as yup from 'yup';
 
 import {
@@ -13,6 +14,7 @@ import { CalendarEvent } from 'modules/Dashboard/state';
 export type EventFormRef = {
   submitForm: () => void;
   processEvent: () => void;
+  formState: FormState<EventFormValues>;
 };
 
 export type EventFormProps = {
@@ -85,6 +87,7 @@ export type GetEventFromTabs = {
   hasNotificationsErrors?: boolean;
   hasAlwaysAvailableOption?: boolean;
   'data-testid'?: string;
+  removeWarnings?: Warning;
 };
 
 export type GetDaysInPeriod = {

--- a/src/modules/Dashboard/features/Applet/Schedule/EventForm/EventForm.utils.test.ts
+++ b/src/modules/Dashboard/features/Applet/Schedule/EventForm/EventForm.utils.test.ts
@@ -195,7 +195,6 @@ describe('EventForm.utils', () => {
         periodicity: Periodicity.Always,
         notifications: [],
         reminder: null,
-        removeWarning: {},
       });
     });
 
@@ -248,7 +247,6 @@ describe('EventForm.utils', () => {
           type: SecondsManipulation.RemoveSeconds,
           reminder: editedEvent.notification.reminder,
         }),
-        removeWarning: {},
       });
     });
   });

--- a/src/modules/Dashboard/features/Applet/Schedule/EventForm/EventForm.utils.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/EventForm/EventForm.utils.tsx
@@ -56,6 +56,7 @@ export const getEventFormTabs = ({
   hasNotificationsErrors,
   hasAlwaysAvailableOption,
   'data-testid': dataTestid,
+  removeWarnings,
 }: GetEventFromTabs) => [
   {
     labelKey: 'availability',
@@ -64,6 +65,7 @@ export const getEventFormTabs = ({
       <AvailabilityTab
         hasAlwaysAvailableOption={hasAlwaysAvailableOption}
         data-testid={`${dataTestid}-availability`}
+        removeWarnings={removeWarnings}
       />
     ),
     hasError: hasAvailabilityErrors,
@@ -412,7 +414,6 @@ export const getDefaultValues = (defaultStartDate: Date, editedEvent?: CalendarE
     periodicity,
     notifications,
     reminder,
-    removeWarning: {},
   };
 };
 

--- a/src/modules/Dashboard/features/Applet/Schedule/ScheduleProvider/ScheduleProvider.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/ScheduleProvider/ScheduleProvider.tsx
@@ -1,12 +1,14 @@
-import { createContext, useState } from 'react';
+import { createContext, useRef, useState } from 'react';
 
 import { CalendarEvent } from 'redux/modules';
 import { EditEventPopup } from 'modules/Dashboard/features/Applet/Schedule/EditEventPopup';
 import { ClearScheduledEventsPopup } from 'modules/Dashboard/features/Applet/Schedule/ClearScheduledEventsPopup';
 import { ConfirmEditDefaultSchedulePopup } from 'modules/Dashboard/features/Applet/Schedule/ConfirmEditDefaultSchedulePopup';
 import { CreateEventPopup } from 'modules/Dashboard/features/Applet/Schedule/CreateEventPopup';
+import { SaveChangesPopup } from 'shared/components';
 
 import { FollowUpPopups, ScheduleContext, ScheduleProviderProps } from './ScheduleProvider.types';
+import { EventFormRef } from '../EventForm';
 
 const DEFAULT_VALUE = {
   appletId: 'Unknown applet ID',
@@ -43,7 +45,9 @@ export const ScheduleProvider = ({
   const [showConfirmEditDefaultPopup, setShowConfirmEditDefaultPopup] = useState(false);
   const [showCreateEventPopup, setShowCreateEventPopup] = useState(false);
   const [showEditEventPopup, setShowEditEventPopup] = useState(false);
+  const [showSaveChangesPopup, setShowSaveChangesPopup] = useState(false);
   const [startDate, setStartDate] = useState(new Date());
+  const editEventFormRef = useRef<EventFormRef | null>(null);
 
   const handleOpenFollowUpPopup = () => {
     setShowConfirmEditDefaultPopup(false);
@@ -100,6 +104,33 @@ export const ScheduleProvider = ({
     }
   };
 
+  const handleCloseEditEventPopup = (formRef?: EventFormRef | null) => {
+    if (formRef?.formState.isDirty) {
+      setShowSaveChangesPopup(true);
+      editEventFormRef.current = formRef;
+
+      return;
+    }
+
+    editEventFormRef.current = null;
+    setShowEditEventPopup(false);
+  };
+
+  const handleSaveChanges = async () => {
+    setShowSaveChangesPopup(false);
+
+    const shouldDismissPopups = await editEventFormRef.current?.submitForm();
+
+    if (shouldDismissPopups) {
+      setShowEditEventPopup(false);
+    }
+  };
+
+  const handleDiscardChanges = () => {
+    setShowSaveChangesPopup(false);
+    setShowEditEventPopup(false);
+  };
+
   return (
     <ScheduleProviderContext.Provider
       value={{
@@ -151,13 +182,22 @@ export const ScheduleProvider = ({
         userId={hasIndividualSchedule && userId ? userId : undefined}
       />
 
+      <SaveChangesPopup
+        popupVisible={showSaveChangesPopup}
+        onDontSave={handleDiscardChanges}
+        onCancel={() => setShowSaveChangesPopup(false)}
+        onSave={handleSaveChanges}
+      />
+
       {selectedEvent && (
         <EditEventPopup
           open={showEditEventPopup}
           editedEvent={selectedEvent}
           setEditEventPopupVisible={(value) => {
+            setShowSaveChangesPopup(false);
             setShowEditEventPopup(value);
           }}
+          onClose={handleCloseEditEventPopup}
           defaultStartDate={startDate}
           userId={hasIndividualSchedule && userId ? userId : undefined}
           data-testid={`${dataTestId}-edit-event-popup`}


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [M2-7188](https://mindlogger.atlassian.net/browse/M2-7188): [Admin Panel] Multi-informant - Add warning if admin has made changes in the 'Edit event' pop-up and closes it with not saving changes

This PR is a re-implementation of work originally done in an earlier task ([M2-6871](https://mindlogger.atlassian.net/browse/M2-6871)), which was undone as a result of addressing irreconcilable merge conflicts when merging [the multi-informant branch into develop](https://github.com/ChildMindInstitute/mindlogger-admin/pull/1844).

There are similarities in the approach taken by the original work, but they are not 1:1. Some changes I made include:

- Updated the `ScheduleProvider` to include the `SaveChangesPopup` and to manage it's state. This was a context provider I previously added to wrap both the `Legend` and `Calendar` components in order to synchronize state changes across both of these components, and in particular to manage/render various popups that either component may open.
- Removed the `removeWarning` field from the `EventForm` component's form state. I did this so that the `dirty` state of the form could be correctly calculated, in order to determine if the "Save Changes" popup should be shown. `removeWarning` was not used as field, but as derived state for showing visible warning flags to the user, which are not reset when resetting changes. This variable is now passed via props to the relevant components (I also pluralized it, because it's an object that contains multiple possible warnings).
- Save a ref to the `EditEventForm`'s own ref object in the `ScheduleProvider`, and use that to determine if the `SaveChangesPopup` should be shown, as well as call the `EditEventForm`'s submission handler. This is a similar approach to the previous implementation, and `EditEventForm` already exposed a custom ref that used `useImperativeHandle` to pass along a few methods, including the submit handler. I'm not 100% happy with this, and it could be more conventionally done by lifting the form state up, but untangling this would have been a much more significant refactor.

### 📸 Screenshots

You may click each gif for a larger version.

| When Saving Changes | When Discarding Changes | When Cancelling "Save Changes" prompt | 
|-|-|-|
| ![when-saving-changes](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/02d27a3e-8b39-4647-9e04-b2a9b4800319) | ![when discarding changes](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/8589de27-bb9d-4f9a-9d3a-bf1db5e0445b) | ![when cancelling](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/5ee342f7-9f61-4e87-b4e7-f4761a8882af) |

### 🪤 Peer Testing

This flow should be replicable for both Scheduled and Unscheduled events, for both Default and Individual schedules.

For an applet with some activities…

1. Navigate to the **Applet → Schedule** and/or the **Participant Details → Schedule** screens.
2. Press an event in the calendar view to open the Edit Event popup.
3. Make a change to the event, and then attempt to close the popup without saving changes.
4. Notice that a "Save Changes" popup opens, prompting you to confirm or discard your changes.
    1. When pressing "Cancel" on the "Save Changes" popup:
      a. Notice that the "Save Changes" popup closes, and returns you to the "Edit Event" popup.
      b. After returning to the "Edit Event" popup, undo any changes you made to the event. 
      c. Close the popup without saving changes. Notice that the "Save Changes" popup does not open, because no changes have been recorded.
    2. When pressing "Don't Save" on the "Save Changes" popup:
        a. Notice that the "Save Changes" and "Edit Event" popups both close, and the event is _not_ updated.
    3. When pressing "Save" on the "Save Changes" popup:
        a. Notice that the "Save Changes" and "Edit Event" popups both close, and the event is updated.



[M2-7188]: https://mindlogger.atlassian.net/browse/M2-7188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[M2-6871]: https://mindlogger.atlassian.net/browse/M2-6871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ