### PR TITLE
feat(mi): Soft-lock Admin App during Take Now (M2-7109)

### DIFF
--- a/src/modules/Auth/features/Login/Banners/SoftLockWarningBanner/SoftLockWarningBanner.test.tsx
+++ b/src/modules/Auth/features/Login/Banners/SoftLockWarningBanner/SoftLockWarningBanner.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { renderWithProviders } from 'shared/utils/renderWithProviders';
+
+import { SoftLockWarningBanner } from './SoftLockWarningBanner';
+
+const mockOnClose = jest.fn();
+
+describe('SoftLockWarningBanner', () => {
+  test('should render', () => {
+    renderWithProviders(<SoftLockWarningBanner />);
+
+    expect(screen.getByTestId('warning-banner')).toBeInTheDocument();
+    expect(
+      screen.getByText('To keep your account secure, you were automatically logged out.'),
+    ).toBeInTheDocument();
+  });
+
+  test('clicking the close button hides the banner', () => {
+    render(<SoftLockWarningBanner onClose={mockOnClose} />);
+
+    const closeButton = screen.getByRole('button');
+    fireEvent.click(closeButton);
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/modules/Auth/features/Login/Banners/SoftLockWarningBanner/SoftLockWarningBanner.tsx
+++ b/src/modules/Auth/features/Login/Banners/SoftLockWarningBanner/SoftLockWarningBanner.tsx
@@ -1,0 +1,12 @@
+import { Trans } from 'react-i18next';
+
+import { Banner, BannerProps } from 'shared/components/Banners/Banner';
+
+export const SoftLockWarningBanner = (props: BannerProps) => (
+  <Banner duration={null} severity="warning" {...props}>
+    <Trans i18nKey="softLockWarningBanner">
+      <strong>To keep your account secure, you were automatically logged out.</strong>
+      <div>Please enter your password below to resume where you left off.</div>
+    </Trans>
+  </Banner>
+);

--- a/src/modules/Auth/features/Login/Banners/SoftLockWarningBanner/index.ts
+++ b/src/modules/Auth/features/Login/Banners/SoftLockWarningBanner/index.ts
@@ -1,0 +1,1 @@
+export * from './SoftLockWarningBanner';

--- a/src/modules/Auth/features/Login/Banners/index.ts
+++ b/src/modules/Auth/features/Login/Banners/index.ts
@@ -1,1 +1,2 @@
 export * from './PasswordResetSuccessfulBanner';
+export * from './SoftLockWarningBanner';

--- a/src/modules/Auth/features/Login/LockForm/LockForm.tsx
+++ b/src/modules/Auth/features/Login/LockForm/LockForm.tsx
@@ -90,7 +90,11 @@ export const LockForm = () => {
         <StyledButton variant="contained" type="submit" data-testid="lock-form-login">
           {t('login')}
         </StyledButton>
-        <StyledButton variant="outlined" onClick={handleLogout} data-testid="lock-form-logout">
+        <StyledButton
+          variant="outlined"
+          onClick={() => handleLogout()}
+          data-testid="lock-form-logout"
+        >
           {t('logOut')}
         </StyledButton>
       </StyledForm>

--- a/src/modules/Auth/features/Login/LoginForm/LoginForm.tsx
+++ b/src/modules/Auth/features/Login/LoginForm/LoginForm.tsx
@@ -118,7 +118,7 @@ export const LoginForm = () => {
         window.removeEventListener('focus', handleWindowFocus);
       };
     }
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleCreateAccountClick = () => {
     clearSoftLock();

--- a/src/modules/Auth/features/Login/LoginForm/LoginForm.tsx
+++ b/src/modules/Auth/features/Login/LoginForm/LoginForm.tsx
@@ -33,9 +33,21 @@ export const LoginForm = () => {
   const { t } = useTranslation('app');
   const location = useLocation();
   const navigate = useNavigate();
-  const { handleSubmit, control } = useForm<SignIn>({
+  const softLockData = auth.useSoftLockData();
+
+  const clearSoftLock = () => {
+    if (softLockData) {
+      dispatch(auth.actions.endSoftLock());
+      dispatch(banners.actions.removeBanner({ key: 'SoftLockWarningBanner' }));
+    }
+  };
+
+  const { handleSubmit, control, setFocus } = useForm<SignIn>({
     resolver: yupResolver(loginFormSchema()),
-    defaultValues: { email: '', password: '' },
+    defaultValues: {
+      email: softLockData?.email ?? '',
+      password: '',
+    },
   });
 
   const [errorMessage, setErrorMessage] = useState('');
@@ -43,12 +55,25 @@ export const LoginForm = () => {
     setErrorMessage('');
     const { signIn } = auth.thunk;
     const result = await dispatch(signIn(data));
-    const fromUrl = location?.state?.[LocationStateKeys.From];
 
     if (signIn.fulfilled.match(result)) {
-      if (fromUrl) navigate(fromUrl);
-      navigateToLibrary(navigate);
+      // If user logged in as the same user that was soft-locked, restore their nav state
+      if (data.email === softLockData?.email) {
+        navigate(softLockData?.redirectTo, {
+          state: { [LocationStateKeys.Workspace]: softLockData.workspace },
+        });
+      } else {
+        const fromUrl = location.state?.[LocationStateKeys.From];
+        if (fromUrl) {
+          navigate(fromUrl);
+        } else {
+          navigateToLibrary(navigate);
+        }
+      }
+
       Mixpanel.track('Login Successful');
+
+      clearSoftLock();
     }
 
     if (signIn.rejected.match(result)) {
@@ -57,6 +82,7 @@ export const LoginForm = () => {
   };
 
   useEffect(() => {
+    // Handle password reset success state
     if (location.state?.[LocationStateKeys.IsPasswordReset]) {
       // Shown for 5 seconds
       dispatch(
@@ -74,9 +100,28 @@ export const LoginForm = () => {
         replace: true,
       });
     }
+
+    // Display soft-lock state
+    if (softLockData) {
+      dispatch(banners.actions.addBanner({ key: 'SoftLockWarningBanner' }));
+      setFocus('password');
+
+      // Refocus password field when window regains focus
+      const handleWindowFocus = () => {
+        setFocus('password');
+        window.removeEventListener('focus', handleWindowFocus);
+      };
+
+      window.addEventListener('focus', handleWindowFocus);
+
+      return () => {
+        window.removeEventListener('focus', handleWindowFocus);
+      };
+    }
   }, []);
 
   const handleCreateAccountClick = () => {
+    clearSoftLock();
     navigate(page.signUp);
 
     Mixpanel.track('Create account button on login screen click');
@@ -84,6 +129,11 @@ export const LoginForm = () => {
 
   const handleLoginClick = () => {
     Mixpanel.track('Login Button click');
+  };
+
+  const handleResetPasswordClick = () => {
+    clearSoftLock();
+    navigate(page.passwordReset);
   };
 
   return (
@@ -121,7 +171,7 @@ export const LoginForm = () => {
         </StyledController>
         {errorMessage && <StyledErrorText marginTop={0}>{errorMessage}</StyledErrorText>}
         <StyledForgotPasswordLink
-          onClick={() => navigate(page.passwordReset)}
+          onClick={handleResetPasswordClick}
           data-testid="login-form-forgot-password"
         >
           {t('forgotPassword')}

--- a/src/modules/Auth/state/Auth.reducer.ts
+++ b/src/modules/Auth/state/Auth.reducer.ts
@@ -1,8 +1,8 @@
-import { ActionReducerMapBuilder } from '@reduxjs/toolkit';
+import { ActionReducerMapBuilder, PayloadAction } from '@reduxjs/toolkit';
 
 import { ApiErrorReturn } from 'shared/state/Base';
 
-import { AuthSchema } from './Auth.schema';
+import { AuthSchema, SoftLockData } from './Auth.schema';
 import { signIn, getUserDetails } from './Auth.thunk';
 import {
   createAuthFulfilledData,
@@ -22,6 +22,12 @@ export const reducers = {
     sessionStorage.clear();
     state.authentication = initialState.authentication;
     state.isAuthorized = false;
+  },
+  startSoftLock: (state: AuthSchema, { payload }: PayloadAction<SoftLockData>): void => {
+    state.softLockData = payload;
+  },
+  endSoftLock: (state: AuthSchema): void => {
+    delete state.softLockData;
   },
 };
 

--- a/src/modules/Auth/state/Auth.schema.ts
+++ b/src/modules/Auth/state/Auth.schema.ts
@@ -1,3 +1,4 @@
+import { Workspace } from 'redux/modules';
 import { BaseSchema } from 'shared/state/Base';
 
 export type User = {
@@ -11,8 +12,15 @@ export type AuthData = {
   user: User;
 };
 
+export type SoftLockData = {
+  email?: string;
+  redirectTo: string;
+  workspace: Workspace | null;
+};
+
 export type AuthSchema = {
   authentication: BaseSchema<AuthData | null>;
   isAuthorized: boolean;
   isLogoutInProgress: boolean;
+  softLockData?: SoftLockData;
 };

--- a/src/modules/Auth/state/index.ts
+++ b/src/modules/Auth/state/index.ts
@@ -54,4 +54,6 @@ export const auth = {
     ),
   useLogoutInProgress: (): AuthSchema['isLogoutInProgress'] =>
     useAppSelector(({ auth: { isLogoutInProgress } }) => isLogoutInProgress),
+  useSoftLockData: (): AuthSchema['softLockData'] =>
+    useAppSelector(({ auth: { softLockData } }) => softLockData),
 };

--- a/src/modules/Builder/features/SaveAndPublish/SaveAndPublish.hooks.test.tsx
+++ b/src/modules/Builder/features/SaveAndPublish/SaveAndPublish.hooks.test.tsx
@@ -23,15 +23,6 @@ jest.mock('modules/Builder/hooks', () => ({
   useAppletPrivateKeySetter: jest.fn(),
 }));
 
-jest.mock('redux/modules', () => ({
-  auth: {
-    useLogoutInProgress: () => false,
-  },
-  workspaces: {
-    useData: () => ({ ownerId: 'mockOwnerId' }),
-  },
-}));
-
 describe('useSaveAndPublishSetup hook', () => {
   afterEach(() => {
     jest.resetAllMocks();
@@ -44,6 +35,7 @@ describe('useSaveAndPublishSetup hook', () => {
         mockAxios.post.mockResolvedValueOnce({ data: {} });
 
         const { result, store } = renderHookWithProviders(useSaveAndPublishSetup, {
+          preloadedState: getPreloadedState(),
           route: '/builder/new-applet/about',
           routePath: '/builder/new-applet/about',
         });
@@ -57,6 +49,7 @@ describe('useSaveAndPublishSetup hook', () => {
         mockAxios.post.mockRejectedValueOnce({});
 
         const { result, rerender, store } = renderHookWithProviders(useSaveAndPublishSetup, {
+          preloadedState: getPreloadedState(),
           route: '/builder/new-applet/about',
           routePath: '/builder/new-applet/about',
         });

--- a/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.tsx
+++ b/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.tsx
@@ -20,7 +20,7 @@ import {
   joinWihComma,
 } from 'shared/utils';
 import { ParticipantsData } from 'modules/Dashboard/features/Participants';
-import { useAsync } from 'shared/hooks';
+import { useAsync, useLogout } from 'shared/hooks';
 import { Manager, Respondent } from 'modules/Dashboard/types';
 import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 import { FlowSummaryThumbnail } from 'modules/Dashboard/components/FlowSummaryCard/FlowSummaryThumbnail';
@@ -244,6 +244,7 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
   ]);
 
   const TakeNowModal = ({ onClose }: TakeNowModalProps) => {
+    const handleLogout = useLogout();
     const handleClose = () => {
       track('Take Now dialogue closed');
 
@@ -309,8 +310,10 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
             this.removeEventListener('message', messageHandler);
           }
         });
+
+        handleLogout({ shouldSoftLock: true });
       }
-    }, [targetSubject, sourceSubject, loggedInUser, isSelfReporting]);
+    }, [targetSubject, sourceSubject, isSelfReporting, loggedInUser, handleLogout]);
 
     /**
      * Handle participant search. It can be a combination of team members and any participants

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -1209,6 +1209,7 @@
   "sliderRows": "Slider Rows",
   "sliderRowsHint": "Rows of numerical scales with a single answer",
   "smallTo": "to",
+  "softLockWarningBanner": "<0>To keep your account secure, you were automatically logged out.</0> <1>Please enter your password below to resume where you left off.</1>",
   "sortBy": "Sort By",
   "startDate": "Start date",
   "startEndDate": "Start Date / End Date",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -1207,6 +1207,7 @@
   "sliderRows": "Lignes de curseurs",
   "sliderRowsHint": "Lignes d'échelles numériques avec une seule réponse",
   "smallTo": "à",
+  "softLockWarningBanner":  "<0>Pour assurer la sécurité de votre compte, vous avez été automatiquement déconnecté.</0> <1>Veuillez entrer votre mot de passe ci-dessous pour reprendre là où vous vous étiez arrêté.</1>",
   "sortBy": "Trier Par",
   "startDate": "Date de début",
   "startEndDate": "Date de début / Date de fin",

--- a/src/shared/components/Banners/Banners.const.ts
+++ b/src/shared/components/Banners/Banners.const.ts
@@ -1,7 +1,10 @@
 import { ComponentType } from 'react';
 
 import { BannerType } from 'redux/modules';
-import { PasswordResetSuccessfulBanner } from 'modules/Auth/features/Login/Banners';
+import {
+  PasswordResetSuccessfulBanner,
+  SoftLockWarningBanner,
+} from 'modules/Auth/features/Login/Banners';
 import { AppletWithoutChangesBanner } from 'modules/Builder/components';
 import { FileSizeExceededBanner } from 'shared/components/Banners/FileSizeExceededBanner';
 import { IncorrectFileBanner } from 'shared/components/Banners/IncorrectFileBanner';
@@ -25,4 +28,5 @@ export const BannerComponents: Record<keyof typeof BannerType, ComponentType<Ban
   TransferOwnershipSuccessBanner,
   ShellAccountSuccessBanner,
   AddParticipantSuccessBanner,
+  SoftLockWarningBanner,
 };

--- a/src/shared/components/FormComponents/InputController/InputController.tsx
+++ b/src/shared/components/FormComponents/InputController/InputController.tsx
@@ -27,20 +27,24 @@ export const InputController = <T extends FieldValues>({
     <Controller
       name={name}
       control={control}
-      render={({ field: { onChange, onBlur, value }, fieldState: { error } }) => (
-        <Input
-          inputRef={inputRef}
-          type={type}
-          onChange={onChange}
-          onBlur={onBlur}
-          value={value}
-          error={!!error || providedError}
-          helperText={isErrorVisible ? error?.message || helperText : ''}
-          onCustomChange={onCustomChange}
-          onWheel={handleOnWheel}
-          {...props}
-        />
-      )}
+      render={({ field: { onChange, onBlur, value, ref }, fieldState: { error } }) => {
+        ref(inputRef.current);
+
+        return (
+          <Input
+            inputRef={inputRef}
+            type={type}
+            onChange={onChange}
+            onBlur={onBlur}
+            value={value}
+            error={!!error || providedError}
+            helperText={isErrorVisible ? error?.message || helperText : ''}
+            onCustomChange={onCustomChange}
+            onWheel={handleOnWheel}
+            {...props}
+          />
+        );
+      }}
     />
   );
 };

--- a/src/shared/hooks/useLogout.test.ts
+++ b/src/shared/hooks/useLogout.test.ts
@@ -1,8 +1,10 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
 import mockAxios from 'jest-mock-axios';
 
 import { page } from 'resources';
 import { ApiResponseCodes } from 'api';
+import { renderHookWithProviders } from 'shared/utils/renderHookWithProviders';
+import { getPreloadedState } from 'shared/tests/getPreloadedState';
 
 import { useLogout } from './useLogout';
 
@@ -23,8 +25,10 @@ const mockedUseAppDispatch = jest.fn();
 const mockedUseNavigate = jest.fn();
 
 jest.mock('redux/store', () => ({
+  ...jest.requireActual('redux/store'),
   useAppDispatch: () => mockedUseAppDispatch,
 }));
+
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useNavigate: () => mockedUseNavigate,
@@ -36,7 +40,7 @@ describe('useLogout', () => {
   });
 
   test('deleting access token navigates to login', async () => {
-    const { result } = renderHook(useLogout);
+    const { result } = renderHookWithProviders(useLogout, { preloadedState: getPreloadedState() });
     mockAxios.post.mockResolvedValueOnce(null);
 
     await waitFor(() => {
@@ -47,7 +51,7 @@ describe('useLogout', () => {
   });
 
   test('deleting access token resets all data', async () => {
-    const { result } = renderHook(useLogout);
+    const { result } = renderHookWithProviders(useLogout, { preloadedState: getPreloadedState() });
     mockAxios.post.mockResolvedValueOnce(null);
 
     await waitFor(() => {
@@ -60,7 +64,7 @@ describe('useLogout', () => {
   });
 
   test('delete refresh token api is called if delete access token rejects with Unauthorized status code', async () => {
-    const { result } = renderHook(useLogout);
+    const { result } = renderHookWithProviders(useLogout, { preloadedState: getPreloadedState() });
     mockAxios.post.mockRejectedValueOnce({
       response: {
         status: ApiResponseCodes.Unauthorized,

--- a/src/shared/hooks/useLogout.ts
+++ b/src/shared/hooks/useLogout.ts
@@ -13,18 +13,34 @@ export const useLogout = () => {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
 
-  //TODO: rewrite to reset the global state data besides the data needed in lock form
-  return async () => {
+  const userData = auth.useData();
+  const { email } = userData?.user || {};
+  const workspace = workspaces.useData();
+
+  // TODO: rewrite to reset the global state data besides the data needed in LockForm (if
+  // completing LockForm implementation still planned, now that auth soft-lock is present).
+  return async ({ shouldSoftLock = false } = {}) => {
     try {
       await deleteAccessTokenApi();
     } catch (e) {
       if ((e as AxiosError).response?.status === ApiResponseCodes.Unauthorized)
         await deleteRefreshTokenApi();
     } finally {
+      if (shouldSoftLock) {
+        dispatch(
+          auth.actions.startSoftLock({
+            email,
+            redirectTo: window.location.pathname,
+            workspace,
+          }),
+        );
+      }
       dispatch(workspaces.actions.setCurrentWorkspace(null));
       dispatch(alerts.actions.resetAlerts());
       dispatch(auth.actions.resetAuthorization());
+
       navigate(page.login);
+
       Mixpanel.track('Logout');
       Mixpanel.logout();
       FeatureFlags.logout();

--- a/src/shared/state/Banners/Banners.schema.ts
+++ b/src/shared/state/Banners/Banners.schema.ts
@@ -10,6 +10,7 @@ export enum BannerType {
   PasswordResetSuccessfulBanner,
   ShellAccountSuccessBanner,
   AddParticipantSuccessBanner,
+  SoftLockWarningBanner,
 }
 
 export type BannerPayload = {


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-7190](https://mindlogger.atlassian.net/browse/M2-7190)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

This PR introduces the ability to soft-lock the Admin App for use with Take Now. Now, when a user starts Take Now:
- User is logged out of the Admin App while the user proceeds with the assessment in the Web App (to secure its data in case the device was handed over to another person)
- When the assessment is complete and user returns to the Admin App, the login screen is shown with the email field pre-populated and password field focused, as well as a banner explaining why the user was logged out.
- Upon logging in, the user is redirected back to the screen they were viewing, including the active Workspace.

> [!NOTE]
> The Admin App has an existing `LockForm` screen, whose purpose was going to be to lock the app after 15 minutes of inactivity, but its implementation was never completed and is not currently accessible in the app. It's more complex than this implementation, and it may be removed in the future with this version becoming its replacement.

> [!TIP]
> Changes are broken up [by commit](https://github.com/ChildMindInstitute/mindlogger-admin/pull/1851/commits), if that makes reviewing the code easier.

### 📸 Screenshots

https://github.com/ChildMindInstitute/mindlogger-admin/assets/1282772/f4d869aa-258f-4eb6-a44b-5fd0df5a60e3

### 🪤 Peer Testing

**Prerequisites:**
- An admin user (User A) who owns an applet
- Another admin user (User B) who is a Team Member with Manager role on that applet

**Steps:**
1. Log into the Admin App as **User A**, navigate to your own Applet's **Activities** screen.
2. Initiate **Take Now** on an activity to open the Web App. Complete the assessment in the Web App and click **Return to Admin App**.
    **Expected outcome:** You are returned to the Admin App tab, but are now logged out, with a warning banner, the email field pre-populated with User A's email address, and the password field focused.
3. Log in as **User A**.
    **Expected outcome:** You are logged in and returned to the same Applet > Activities screen you navigated to in step 1.
4. Repeat step 2.
5. Log in as **User B**.
    **Expected outcome:** You are logged in and taken to User B's dashboard.
6. Navigate to **User A's workspace**, then the aforementioned applet.
7. Navigate to the **Participants** tab, then click a participant, then navigate to that Participant's **Participant Details > Activities** tab.
8. Initiate **Take Now** on an activity to open the Web App. Complete the assessment in the Web App and click **Return to Admin App**.
    **Expected outcome:** You are returned to the Admin App tab, but are now logged out, with a warning banner, the email field pre-populated with User B's email address, and the password field focused.
9. Log in as **User B**.
    **Expected outcome:** You are logged in and returned to the same **Applet > Participant Details > Activities** screen you navigated to in step 7, in **User A's workspace**.
