### PR TITLE
fix: Disable Take Now on unsupported activities (M2-7130)

### DIFF
--- a/src/modules/Dashboard/api/api.ts
+++ b/src/modules/Dashboard/api/api.ts
@@ -76,6 +76,8 @@ import {
   DeleteFlowReviewParams,
   AssessmentFlowReviewParams,
   FeedbackNote,
+  GetActivityResponse,
+  GetActivityParams,
 } from './api.types';
 import { DEFAULT_ROWS_PER_PAGE } from './api.const';
 
@@ -471,6 +473,11 @@ export const getReviewFlowsApi = (
 
 export const getAnswerApi = ({ appletId, answerId }: ActivityAnswerParams, signal?: AbortSignal) =>
   authApiClient.get(`/answers/applet/${appletId}/answers/${answerId}`, { signal });
+
+export const getActivityApi = ({ activityId }: GetActivityParams, signal?: AbortSignal) =>
+  authApiClient.get(`activities/${activityId}`, { signal }) as Promise<
+    AxiosResponse<GetActivityResponse>
+  >;
 
 export const getActivityAnswerApi = (
   { appletId, answerId, activityId }: ActivityAnswerParams,

--- a/src/modules/Dashboard/api/api.types.ts
+++ b/src/modules/Dashboard/api/api.types.ts
@@ -1,5 +1,5 @@
 import { ActivityId, AppletId } from 'shared/api';
-import { Item, SingleApplet, SubscaleSetting } from 'shared/state';
+import { Activity, Item, SingleApplet, SubscaleSetting } from 'shared/state';
 import { ParticipantTag, Roles } from 'shared/consts';
 import { RetentionPeriods, EncryptedAnswerSharedProps, ExportActivity } from 'shared/types';
 import { Encryption } from 'shared/utils';
@@ -311,6 +311,13 @@ export type Answers = AppletId & TargetSubjectId & { createdDate?: string };
 
 export type ActivityAnswerParams = AppletId & { answerId: string; activityId: string };
 
+export interface GetActivityParams {
+  activityId: string;
+}
+
+export interface GetActivityResponse {
+  result: Activity;
+}
 export interface GetAppletSubmissionsParams extends AppletId {
   page?: number;
   limit?: number;

--- a/src/modules/Dashboard/components/ActivityGrid/ActivityGrid.utils.tsx
+++ b/src/modules/Dashboard/components/ActivityGrid/ActivityGrid.utils.tsx
@@ -7,6 +7,7 @@ import {
   checkIfCanEdit,
   checkIfCanManageParticipants,
   checkIfFullAccess,
+  getIsWebSupported,
 } from 'shared/utils';
 import { EditablePerformanceTasks } from 'modules/Builder/features/Activities/Activities.const';
 
@@ -31,6 +32,7 @@ export const getActivityActions = ({
     checkIfCanManageParticipants(roles) && featureFlags.enableActivityAssign;
   const showDivider = (canEdit || canAccessData) && (canDoTakeNow || canAssignActivity);
   const { id: activityId } = activity;
+  const isWebUnsupported = !getIsWebSupported(activity.items);
 
   if (!activityId) return [];
 
@@ -66,6 +68,8 @@ export const getActivityActions = ({
       title: t('takeNow.menuItem'),
       context: { appletId, activityId },
       isDisplayed: canDoTakeNow,
+      disabled: isWebUnsupported,
+      tooltip: isWebUnsupported && t('activityIsMobileOnly'),
       'data-testid': `${dataTestId}-activity-take-now`,
     },
   ];

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataHeader/RespondentDataHeader.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataHeader/RespondentDataHeader.tsx
@@ -3,7 +3,7 @@ import { Button } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { useParams, useNavigate, generatePath } from 'react-router-dom';
 
-import { Chip, ChipShape, Svg } from 'shared/components';
+import { Chip, ChipShape, Svg, Tooltip } from 'shared/components';
 import { ExportDataSetting } from 'shared/features/AppletSettings';
 import {
   StyledFlexSpaceBetween,
@@ -14,7 +14,7 @@ import {
   theme,
   variables,
 } from 'shared/styles';
-import { Mixpanel, checkIfFullAccess } from 'shared/utils';
+import { Mixpanel, checkIfFullAccess, getIsWebSupported } from 'shared/utils';
 import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 import { useTakeNowModal } from 'modules/Dashboard/components/TakeNowModal/TakeNowModal';
 import { workspaces } from 'redux/modules';
@@ -42,6 +42,7 @@ export const RespondentDataHeader = ({
   const [isExportOpen, setIsExportOpen] = useState(false);
   const { TakeNowModal, openTakeNowModal } = useTakeNowModal({ dataTestId });
   const navigate = useNavigate();
+  const isWebSupported = getIsWebSupported(activity?.items);
 
   const navigateUp = () =>
     navigate(
@@ -53,6 +54,7 @@ export const RespondentDataHeader = ({
 
   const handleTakeNow = () => {
     if (!activity) return;
+
     openTakeNowModal(activity, {
       targetSubject: {
         id: subject.id,
@@ -104,11 +106,7 @@ export const RespondentDataHeader = ({
           margin: theme.spacing(0, 3.2, 0.8),
         }}
       >
-        <StyledFlexTopCenter
-          sx={{
-            gap: theme.spacing(1.6),
-          }}
-        >
+        <StyledFlexTopCenter sx={{ gap: theme.spacing(1.6) }}>
           {!!headerElements.image && <StyledLogo src={headerElements.image} />}
           <StyledHeadlineLarge color={palette.on_surface}>
             {headerElements.name}
@@ -147,13 +145,18 @@ export const RespondentDataHeader = ({
               </Button>
             )}
             {canDoTakeNow && (
-              <Button
-                variant="contained"
-                onClick={handleTakeNow}
-                data-testid={`${dataTestid}-take-now`}
-              >
-                {t('takeNow.buttonLabel')}
-              </Button>
+              <Tooltip tooltipTitle={!isWebSupported && t('activityIsMobileOnly')}>
+                <span>
+                  <Button
+                    disabled={!isWebSupported}
+                    data-testid={`${dataTestid}-take-now`}
+                    onClick={handleTakeNow}
+                    variant="contained"
+                  >
+                    {t('takeNow.buttonLabel')}
+                  </Button>
+                </span>
+              </Tooltip>
             )}
           </StyledFlexTopCenter>
         )}

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -31,6 +31,7 @@
   "activityImageDescription": "This image is displayed next to the activity name in the admin panel, and in the respondent's interface.",
   "activityImg": "Activity Image",
   "activityIncomplete": "Activity incomplete",
+  "activityIsMobileOnly": "This activity must be completed on the Mindlogger mobile app.",
   "activityIsRequired": "At least 1 activity is required.",
   "activityItemsFlow": "Item Flow",
   "activityItemsFlowDescription": "To determine the order of transition from one Item to another, an Item Flow can be created.",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -32,6 +32,7 @@
   "activityImg": "Image de l'activité",
   "activityIncomplete": "Activité incomplète",
   "activityIsRequired": "Au moins 1 activité est requise.",
+  "activityIsMobileOnly": "Cette activité doit être réalisée sur l'application mobile Mindlogger.",
   "activityItemsFlow": "Flux d'éléments",
   "activityItemsFlowDescription": "Pour déterminer l'ordre de transition d'un élément à un autre, un flux d'éléments peut être créé.",
   "activityItemsFlowItemTitle": "Conditionnel {{- index}}",

--- a/src/shared/components/Menu/Menu.types.ts
+++ b/src/shared/components/Menu/Menu.types.ts
@@ -18,7 +18,7 @@ export type MenuItem<T = unknown> = {
   context?: T;
   isDisplayed?: boolean;
   disabled?: boolean;
-  tooltip?: string;
+  tooltip?: React.ReactNode;
   customItemColor?: string;
   'data-testid'?: string;
 };

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -42,3 +42,4 @@ export * from './toggleBooleanState';
 export * from './sortItemsByOrder';
 export * from './nullReturnFunc';
 export * from './isObject';
+export * from './responseType';

--- a/src/shared/utils/responseType.test.ts
+++ b/src/shared/utils/responseType.test.ts
@@ -1,0 +1,27 @@
+import { ItemResponseType } from 'shared/consts';
+
+import { getIsWebSupported } from './responseType';
+
+describe('getIsWebSupported', () => {
+  test.each`
+    responseType                                | expected | description
+    ${ItemResponseType.Text}                    | ${true}  | ${'Should return true for Text response type'}
+    ${ItemResponseType.SingleSelection}         | ${true}  | ${'Should return true for SingleSelection response type'}
+    ${ItemResponseType.MultipleSelection}       | ${true}  | ${'Should return true for MultipleSelection response type'}
+    ${ItemResponseType.Slider}                  | ${true}  | ${'Should return true for Slider response type'}
+    ${ItemResponseType.NumberSelection}         | ${true}  | ${'Should return true for NumberSelection response type'}
+    ${ItemResponseType.Message}                 | ${true}  | ${'Should return true for Message response type'}
+    ${ItemResponseType.Date}                    | ${true}  | ${'Should return true for Date response type'}
+    ${ItemResponseType.Time}                    | ${true}  | ${'Should return true for Time response type'}
+    ${ItemResponseType.TimeRange}               | ${true}  | ${'Should return true for TimeRange response type'}
+    ${ItemResponseType.AudioPlayer}             | ${true}  | ${'Should return true for AudioPlayer response type'}
+    ${ItemResponseType.MultipleSelectionPerRow} | ${true}  | ${'Should return true for MultipleSelectionPerRow response type'}
+    ${ItemResponseType.SingleSelectionPerRow}   | ${true}  | ${'Should return true for SingleSelectionPerRow response type'}
+    ${ItemResponseType.SliderRows}              | ${true}  | ${'Should return true for SliderRows response type'}
+    ${'test'}                                   | ${false} | ${'Should return true for other response types'}
+    ${1}                                        | ${false} | ${'Should return true for other response types'}
+    ${false}                                    | ${false} | ${'Should return true for other response types'}
+  `('$description', ({ responseType, expected }) => {
+    expect(getIsWebSupported([{ responseType }])).toEqual(expected);
+  });
+});

--- a/src/shared/utils/responseType.ts
+++ b/src/shared/utils/responseType.ts
@@ -1,0 +1,20 @@
+import { ItemResponseType } from 'shared/consts';
+
+export const webSupportedResponseTypes = [
+  ItemResponseType.Text,
+  ItemResponseType.SingleSelection,
+  ItemResponseType.MultipleSelection,
+  ItemResponseType.Slider,
+  ItemResponseType.NumberSelection,
+  ItemResponseType.Message,
+  ItemResponseType.Date,
+  ItemResponseType.Time,
+  ItemResponseType.TimeRange,
+  ItemResponseType.AudioPlayer,
+  ItemResponseType.MultipleSelectionPerRow,
+  ItemResponseType.SingleSelectionPerRow,
+  ItemResponseType.SliderRows,
+];
+
+export const getIsWebSupported = (itemResponseTypes: { responseType: ItemResponseType }[] = []) =>
+  itemResponseTypes.every(({ responseType }) => webSupportedResponseTypes.includes(responseType));


### PR DESCRIPTION
### 📝 Description

🔗 [M2-7130](https://mindlogger.atlassian.net/browse/M2-7130): [Admin] Admin shouldn't initiate Take Now on Cog Tasks

This PR updates locations where the Take Now option is presented, and conditionally disables the option if the Activity or ActivityFlow contains items that are not supported on the web application.

This is handled by a new check, `getIsWebSupported`, which compares the activity's items to a list of supported types. This check is similar to one already performed in the web app, and the list [is copied from from there](https://github.com/ChildMindInstitute/mindlogger-web-refactor/blob/f225e78ea30c2106f6a13ce96e3a3a3c69b9a5b2/src/abstract/lib/constants.ts#L5-L19). It'd be cool if we could share this data between apps at some point 😅.

I initially planned to make additional backend modifications to more easily support this (ie,  add child item responseType information directly to ActivityFlows, instead of mapping the list of flow.activityIds to actual activities, and then reducing to the activities' items) or even have this determination made directly on the backend — but @mbanting pointed out that swapping the endpoint used would be a smaller lift to getting this done, and I liked that we got to drop an additional query on the Activities pages as a result. Perhaps this would be worthwhile to revisit post-launch, especially if conditions for allowing actions like "Take Now" may continue to grow.

The original query for Flows was used because I naively assumed the activities query was paginated, based on the supported [query parameters specified in the docs](https://api-dev3.cmiml.net/docs#/Activities/applet_activities_activities_applet__applet_id__get). This endpoint is actually not paginated, and those [parameters are unused](https://github.com/ChildMindInstitute/mindlogger-backend-refactor/blob/297697bd825f059a4d760f2776fc4bc34bb087cc/src/apps/activities/api/activities.py#L60-L99), so it should be safe to use for our purposes here (ie, we don't need to worry about not having a result for an activity used by a flow because we queried for the wrong page or similar issue).

### 📸 Screenshots

![Screenshot 2024-07-02 at 10 36 19 AM](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1670836/a97d2b76-1f8f-4b88-82db-f25e07f35011)

### 🪤 Peer Testing

For an applet, with an activity and/or activity flow containing an item with a responseType that is unsupported on the web app…

1. Navigate to the **Applet → Activities** screen.
2. Open the context menu for the unsupported Activity and/or Activity Flow.
3. Notice that the "Take Now" menu item is disabled. A tooltip is shown when hovering over the item.
4. Navigate to the **Participant Details → Activities** screen.
5. Open the context menu for the unsupported Activity and/or Activity Flow.
6. Notice that the "Take Now" menu item is disabled. A tooltip is shown when hovering over the item.

[M2-7130]: https://mindlogger.atlassian.net/browse/M2-7130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ