### PR TITLE
test(mi): Add missing `data-testid`s (M2-7214, M2-7215)

### DIFF
--- a/src/modules/Dashboard/components/FlowGrid/FlowGrid.tsx
+++ b/src/modules/Dashboard/components/FlowGrid/FlowGrid.tsx
@@ -13,6 +13,7 @@ export const FlowGrid = ({
   activities = [],
   flows = [],
   subject,
+  'data-testid': dataTestId,
   ...otherProps
 }: FlowGridProps) => {
   const [showExportPopup, setShowExportPopup] = useState(false);
@@ -29,7 +30,12 @@ export const FlowGrid = ({
 
   return (
     <>
-      <StyledFlexColumn component="ul" sx={{ gap: 0.8, m: 0, p: 0 }} {...otherProps}>
+      <StyledFlexColumn
+        component="ul"
+        sx={{ gap: 0.8, m: 0, p: 0 }}
+        data-testid={`${dataTestId}-flow-grid`}
+        {...otherProps}
+      >
         {flows.map((flow) => {
           const { id, activityIds = [] } = flow;
           const hydratedFlow = {
@@ -45,6 +51,7 @@ export const FlowGrid = ({
               component="li"
               menuItems={getActionsMenu({ flow: hydratedFlow })}
               key={id}
+              data-testid={`${dataTestId}-flow-card`}
             />
           );
         })}

--- a/src/modules/Dashboard/components/FlowGrid/FlowGrid.types.ts
+++ b/src/modules/Dashboard/components/FlowGrid/FlowGrid.types.ts
@@ -8,6 +8,7 @@ export interface FlowGridProps extends BoxProps {
   flows?: ActivityFlow[];
   activities?: Activity[];
   subject?: RespondentDetails;
+  'data-testid': string;
 }
 
 export type HydratedActivityFlow = ActivityFlow & {

--- a/src/modules/Dashboard/features/Applet/Activities/Activities.tsx
+++ b/src/modules/Dashboard/features/Applet/Activities/Activities.tsx
@@ -69,7 +69,12 @@ export const Activities = () => {
             <StyledFlexColumn component="section" sx={{ gap: 1.6 }}>
               <ActivitiesSectionHeader title={t('flows')} count={flows?.length ?? 0} />
 
-              <FlowGrid applet={appletData} activities={activities} flows={flows} />
+              <FlowGrid
+                applet={appletData}
+                activities={activities}
+                data-testid={dataTestId}
+                flows={flows}
+              />
             </StyledFlexColumn>
           )}
 

--- a/src/modules/Dashboard/features/Applet/Overview/Overview.tsx
+++ b/src/modules/Dashboard/features/Applet/Overview/Overview.tsx
@@ -68,6 +68,8 @@ export const Overview = () => {
     [data, handleViewSubmissionPopupOpen],
   );
 
+  const dataTestId = 'dashboard-applet-overview';
+
   if (isForbidden || !canAccessData) {
     return noPermissionsComponent;
   }
@@ -101,6 +103,7 @@ export const Overview = () => {
               appletId={appletId}
               popupVisible={addPopupOpen}
               onClose={handleAddPopupClose}
+              data-testid={`${dataTestId}-add-participant-popup`}
             />
           )}
 

--- a/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.types.ts
+++ b/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.types.ts
@@ -6,7 +6,7 @@ export type AddParticipantPopupProps = {
   popupVisible: boolean;
   appletId: string | null;
   onClose?: (shouldRefetch: boolean) => void;
-  'data-testid'?: string;
+  'data-testid': string;
 };
 
 export enum AddParticipantSteps {

--- a/src/modules/Dashboard/features/Participant/Activities/Activities.tsx
+++ b/src/modules/Dashboard/features/Participant/Activities/Activities.tsx
@@ -167,6 +167,7 @@ export const Activities = () => {
               <FlowGrid
                 activities={activities}
                 applet={appletData}
+                data-testid={dataTestId}
                 flows={flows}
                 subject={subject?.result}
               />

--- a/src/modules/Dashboard/features/Participants/Participants.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.tsx
@@ -383,7 +383,7 @@ export const Participants = () => {
               nickname,
               tag,
               status,
-              dataTestid,
+              dataTestid: dataTestId,
               showAssignActivity: featureFlags.enableActivityAssign,
               roles,
               invitation: detail.invitation,
@@ -391,7 +391,7 @@ export const Participants = () => {
               lastName: detail.subjectLastName,
               subjectCreatedAt: detail.subjectCreatedAt,
             })}
-            data-testid={`${dataTestid}-table-actions`}
+            data-testid={`${dataTestId}-table-actions`}
           />
         ),
         value: '',
@@ -461,7 +461,7 @@ export const Participants = () => {
 
   const viewableAppletsSmallTableRows = getAppletsSmallTable(FilteredAppletsKey.Viewable);
   const editableAppletsSmallTableRows = getAppletsSmallTable(FilteredAppletsKey.Editable);
-  const dataTestid = 'dashboard-participants';
+  const dataTestId = 'dashboard-participants';
   const canAddParticipant = appletId && checkIfCanManageParticipants(roles);
 
   if (isForbidden || !canViewParticipants) return noPermissionsComponent;
@@ -477,13 +477,13 @@ export const Participants = () => {
             placeholder={t('searchParticipants')}
             onSearch={handleSearch}
             sx={{ width: '32rem' }}
-            data-testid={`${dataTestid}-search`}
+            data-testid={`${dataTestId}-search`}
           />
           {canAddParticipant && (
             <AddParticipantButton
               variant="contained"
               onClick={handleToggleAddParticipant}
-              data-testid={`${dataTestid}-add`}
+              data-testid={`${dataTestId}-add`}
             >
               {t('addParticipant')}
             </AddParticipantButton>
@@ -508,7 +508,7 @@ export const Participants = () => {
           ) : undefined
         }
         count={respondentsData?.count || 0}
-        data-testid={`${dataTestid}-table`}
+        data-testid={`${dataTestId}-table`}
         {...tableProps}
       />
       {appletId && showAddParticipant && (
@@ -516,6 +516,7 @@ export const Participants = () => {
           popupVisible={showAddParticipant}
           appletId={appletId}
           onClose={addParticipantOnClose}
+          data-testid={`${dataTestId}-add-participant-popup`}
         />
       )}
       {removeAccessPopupVisible && (
@@ -533,7 +534,7 @@ export const Participants = () => {
           tableRows={viewableAppletsSmallTableRows}
           chosenAppletData={chosenAppletData}
           setChosenAppletData={setChosenAppletData}
-          data-testid={`${dataTestid}-export-data-popup`}
+          data-testid={`${dataTestId}-export-data-popup`}
         />
       )}
       {editRespondentPopupVisible && (


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-7214](https://mindlogger.atlassian.net/browse/M2-7214)
🔗 [Jira Ticket M2-7215](https://mindlogger.atlassian.net/browse/M2-7215)

This PR adds `data-testid` attributes to Activity Flow Grids and the Add Participant popup where they were missing, to facilitate writing of automated tests.

### 📸 Screenshots

#### Activity Flows

![CleanShot 2024-07-04 at 19 47 05@2x](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1282772/580ec10d-42c4-439e-9632-6c7b8e895768)

#### Add Participant popup

![CleanShot 2024-07-04 at 19 46 10@2x](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1282772/8042ceed-6f37-4c78-8e67-431514b79a6a)

#### Add Participant form elements

![CleanShot 2024-07-04 at 19 45 41@2x](https://github.com/ChildMindInstitute/mindlogger-admin/assets/1282772/78d84b8f-6e2a-40fc-9fb1-a0a691b961d0)

### 🪤 Peer Testing

**Prerequisites:**
- An applet with at least 1 activity flow

**Steps:**
1. Navigate to your applet's **Activities** tab, and inspect the source code using DevTools, expanding the `<ul>` representing the Activity Flow Grid.
    **Expected outcome:** The `<ul>` should have an appropriate `data-testid` attribute, and each of its `<li>`s should also have appropriate `data-testid` attributes.
2. Navigate to **Applet > Participants** and press **Add Participant**. Inspect the source code using DevTools, expanding the `<div role="presentation">` element just before `</body>`, representing the Add Participant popup container.
    **Expected outcome:** The `<div>` should have an appropriate `data-testid` attribute.
3. Press **Next**. Inspect the source code using DevTools, digging into the children of the popup until you find the first `<div class="MuiFormControl-root …">` element.
    **Expected outcome:** The `<div>` should have an appropriate `data-testid` attribute.