### PR TITLE
chore: add exception for Text Item in case receiving object as an answer (M2-7244)

### DIFF
--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ActivityResponses/ActivityResponses.utils.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ActivityResponses/ActivityResponses.utils.test.tsx
@@ -16,7 +16,7 @@ const getActivityItemAnswer = (responseType: ItemResponseType) => ({
   activityItem: {
     responseType,
   },
-  answer: {},
+  answer: responseType === ItemResponseType.Text ? 'some answer' : {},
 });
 
 const singleSelectDataTestid = 'single-select-response-item';

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ActivityResponses/ActivityResponses.utils.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ActivityResponses/ActivityResponses.utils.tsx
@@ -44,7 +44,13 @@ export const getTimeResponseItem = (answer?: DecryptedTimeAnswer) => {
 };
 
 export const getResponseItem = (activityItemAnswer: ActivityItemAnswer) => {
-  if (!activityItemAnswer.answer) {
+  if (
+    !activityItemAnswer.answer ||
+    // exception for MiResource answers for Text Item: in case of receiving an object instead of
+    // string or null
+    (activityItemAnswer.activityItem.responseType === ItemResponseType.Text &&
+      Object.prototype.toString.call(activityItemAnswer.answer) === '[object Object]')
+  ) {
     return (
       <StyledBodyLarge color={variables.palette.outline} data-testid="no-response-data">
         {t('noResponseData')}

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ActivityResponses/ActivityResponses.utils.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ActivityResponses/ActivityResponses.utils.tsx
@@ -5,6 +5,7 @@ import { DateFormats, ItemResponseType } from 'shared/consts';
 import { ActivityItemAnswer, DecryptedTimeAnswer } from 'shared/types';
 import { StyledBodyLarge, variables } from 'shared/styles';
 import i18n from 'i18n';
+import { isObject } from 'shared/utils/isObject';
 
 import {
   MultiSelectItemAnswer,
@@ -49,7 +50,7 @@ export const getResponseItem = (activityItemAnswer: ActivityItemAnswer) => {
     // exception for MiResource answers for Text Item: in case of receiving an object instead of
     // string or null
     (activityItemAnswer.activityItem.responseType === ItemResponseType.Text &&
-      Object.prototype.toString.call(activityItemAnswer.answer) === '[object Object]')
+      isObject(activityItemAnswer.answer))
   ) {
     return (
       <StyledBodyLarge color={variables.palette.outline} data-testid="no-response-data">

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponseItems/MultiSelectResponseItem/MultiSelectResponseItem.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponseItems/MultiSelectResponseItem/MultiSelectResponseItem.tsx
@@ -10,7 +10,7 @@ export const MultiSelectResponseItem = ({
 }: MultiSelectItemAnswer) => (
   <StyledContainer data-testid={dataTestid}>
     {activityItem.responseValues.options.map(({ id, text, value }, index) => {
-      const values = answer?.value.map((value) => +value) || [];
+      const values = answer?.value?.map((value) => +value) || [];
       const checked = values.includes(value!);
 
       return (

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ReportTable/ReportTable.hooks.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ReportTable/ReportTable.hooks.ts
@@ -8,6 +8,7 @@ import {
   DateAnswer,
   TimeRangeAnswer,
 } from 'modules/Dashboard/features/RespondentData/RespondentData.types';
+import { isObject } from 'shared/utils/isObject';
 
 import {
   FormattedAnswers,
@@ -77,9 +78,7 @@ export const useResponseData = ({
                 answer:
                   // exception for MiResource answers for Text Item: in case of receiving an object instead of
                   // string or null
-                  Object.prototype.toString.call(answer.value) === '[object Object]'
-                    ? ''
-                    : answer.value || '',
+                  isObject(answer.value) ? '' : answer.value || '',
               },
             ];
           },

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ReportTable/ReportTable.hooks.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ReportTable/ReportTable.hooks.ts
@@ -74,7 +74,12 @@ export const useResponseData = ({
               {
                 date,
                 time,
-                answer: answer.value || '',
+                answer:
+                  // exception for MiResource answers for Text Item: in case of receiving an object instead of
+                  // string or null
+                  Object.prototype.toString.call(answer.value) === '[object Object]'
+                    ? ''
+                    : answer.value || '',
               },
             ];
           },

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -41,3 +41,4 @@ export * from './testUtils';
 export * from './toggleBooleanState';
 export * from './sortItemsByOrder';
 export * from './nullReturnFunc';
+export * from './isObject';

--- a/src/shared/utils/isObject.ts
+++ b/src/shared/utils/isObject.ts
@@ -1,0 +1,2 @@
+export const isObject = (value: unknown) =>
+  Object.prototype.toString.call(value) === '[object Object]';


### PR DESCRIPTION
…

<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added
- [x] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-7244](https://mindlogger.atlassian.net/browse/M2-7244)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Changes include:

Added additional exception for the Text Item in DataViz: if we receive an empty object as an answer for the Text Item, it will be skipped on our side to prevent any issues.
