### PR TITLE
fix(mi): Wrap Admin App soft-lock with feature flag (M2-7109)

### DIFF
--- a/src/shared/hooks/useLogout.ts
+++ b/src/shared/hooks/useLogout.ts
@@ -8,10 +8,14 @@ import { alerts, auth, workspaces } from 'redux/modules';
 import { deleteAccessTokenApi, deleteRefreshTokenApi } from 'modules/Auth/api';
 import { Mixpanel } from 'shared/utils/mixpanel';
 import { FeatureFlags } from 'shared/utils/featureFlags';
+import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 
 export const useLogout = () => {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
+  const {
+    featureFlags: { enableAdminAppSoftLock },
+  } = useFeatureFlags();
 
   const userData = auth.useData();
   const { email } = userData?.user || {};
@@ -20,6 +24,9 @@ export const useLogout = () => {
   // TODO: rewrite to reset the global state data besides the data needed in LockForm (if
   // completing LockForm implementation still planned, now that auth soft-lock is present).
   return async ({ shouldSoftLock = false } = {}) => {
+    // Disable soft-lock feature (avoid logging out at all) with soft-lock feature flag disabled
+    if (shouldSoftLock && !enableAdminAppSoftLock) return;
+
     try {
       await deleteAccessTokenApi();
     } catch (e) {

--- a/src/shared/types/featureFlags.ts
+++ b/src/shared/types/featureFlags.ts
@@ -14,6 +14,7 @@ export const FeatureFlagsKeys = {
   enableParticipantConnections: 'enableParticipantConnections',
   enableLorisIntegration: 'enableLorisIntegration',
   enableItemFlowExtendedItems: 'enableItemFlowExtendedItems',
+  enableAdminAppSoftLock: 'enableAdminAppSoftLock',
 };
 
 export type FeatureFlags = Partial<Record<keyof typeof FeatureFlagsKeys, LDFlagValue>>;


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-7109](https://mindlogger.atlassian.net/browse/M2-7109)

This PR disables the soft-lock feature when the new `enableAdminAppSoftLock` feature flag is disabled.

### 🪤 Peer Testing

- Add this before line 26 of `useFeatureFlags.ts`:
    ```ts
    features.enableAdminAppSoftLock = false;
    ```
- Perform Take Now and complete the assessment, returning to the Admin App.
    **Expected outcome:** Your Admin App login session should remain active and you are not returned to the login screen.
- Edit line 26 of `useFeatureFlags.ts` to:
    ```ts
    features.enableAdminAppSoftLock = true;
    ```
- Perform Take Now and complete the assessment, returning to the Admin App.
    **Expected outcome:** You should be logged out of the Admin App and redirected to the login screen in soft-lock state.
