### PR TITLE
fix: User is able to set the same item in one condition (M2-7105)

### DIFF
--- a/src/modules/Builder/features/ActivityItemsFlow/ItemFlow/SummaryRow/SummaryRow.tsx
+++ b/src/modules/Builder/features/ActivityItemsFlow/ItemFlow/SummaryRow/SummaryRow.tsx
@@ -10,6 +10,7 @@ import { ItemFormValues } from 'modules/Builder/types';
 import { StyledSummaryRow } from 'shared/styles/styledComponents/ConditionalSummary';
 import { useCustomFormContext } from 'modules/Builder/hooks';
 import { ConditionalLogicMatch } from 'shared/consts';
+import { Condition } from 'shared/state/Applet';
 
 import { SummaryRowProps } from './SummaryRow.types';
 import { getItemsOptions, getMatchOptions } from './utils';
@@ -19,16 +20,16 @@ export const SummaryRow = ({ name, activityName, 'data-testid': dataTestid }: Su
   const { t } = useTranslation('app');
   const { control, setValue, getValues } = useCustomFormContext();
   const matchFieldName = `${name}.match`;
-  const [items, conditions, match] = useWatch({
-    name: [`${activityName}.items`, `${name}.conditions`, matchFieldName],
-  });
+  const itemKeyFieldName = `${name}.itemKey`;
+  const [items, conditions, match]: [ItemFormValues[], Condition[], ConditionalLogicMatch] =
+    useWatch({
+      name: [`${activityName}.items`, `${name}.conditions`, matchFieldName],
+    });
   const itemsInUsage = useItemsInUsage(name);
 
   const handleChangeItemKey = useCallback(
     (event: SelectEvent) => {
-      const itemIndex = items?.findIndex(
-        (item: ItemFormValues) => getEntityKey(item) === event.target.value,
-      );
+      const itemIndex = items?.findIndex((item) => getEntityKey(item) === event.target.value);
 
       if (itemIndex !== undefined && itemIndex !== -1 && items[itemIndex]?.isHidden)
         setValue(`${activityName}.items.${itemIndex}.isHidden`, false);
@@ -41,8 +42,7 @@ export const SummaryRow = ({ name, activityName, 'data-testid': dataTestid }: Su
     () => getItemsOptions({ items, itemsInUsage, conditions }),
     [items, itemsInUsage, conditions],
   );
-  const { question } =
-    ((items ?? []) as ItemFormValues[]).find(({ id }) => id === getValues(`${name}.itemKey`)) ?? {};
+  const { question } = (items ?? []).find(({ id }) => id === getValues(itemKeyFieldName)) ?? {};
 
   useEffect(() => {
     // If there are contradictory conditions, change the value of the match option from 'All' to 'Any'
@@ -70,7 +70,7 @@ export const SummaryRow = ({ name, activityName, 'data-testid': dataTestid }: Su
 
         <ItemFlowSelectController
           control={control}
-          name={`${name}.itemKey`}
+          name={itemKeyFieldName}
           options={itemsOptions}
           placeholder={t('conditionItemNamePlaceholder')}
           SelectProps={{

--- a/src/modules/Builder/features/ActivityItemsFlow/ItemFlow/SummaryRow/utils/getItemsOptions.test.tsx
+++ b/src/modules/Builder/features/ActivityItemsFlow/ItemFlow/SummaryRow/utils/getItemsOptions.test.tsx
@@ -188,20 +188,31 @@ describe('getItemsOptions', () => {
     },
   ];
   const itemsInUsage = new Set(['item-1', 'item-3']);
+  const conditions = [
+    {
+      key: 'key-1',
+      type: 'INCLUDES_OPTION',
+      itemName: 'item-2',
+      payload: {
+        optionValue: 'option-value-1',
+      },
+    },
+  ];
   const result = [
     {
       disabled: true,
       labelKey: 'ss1',
       tooltip:
-        "This item is already selected in another Conditional card's summary row. If multiple conditions are necessary, use the same Conditional card with ALL or ANY conditions.",
+        'This Item appears in the Activity before one of the Items involved in the conditional.',
       value: 'item-1',
       tooltipPlacement: 'right',
     },
     {
-      disabled: false,
+      disabled: true,
       labelKey: 'ms1',
       value: 'item-2',
-      tooltip: <StyledMdPreview modelValue="item-2" />,
+      tooltip:
+        'This Item already defines one of the conditions and cannot be its result at the same time.',
       tooltipPlacement: 'right',
     },
     {
@@ -325,9 +336,10 @@ describe('getItemsOptions', () => {
       tooltipPlacement: 'right',
     },
   ];
+
   test('should return options with tooltips and disable statuses for items in usage', () => {
     //eslint-disable-next-line @typescript-eslint/ban-ts-comment
     //@ts-ignore
-    expect(getItemsOptions({ items, itemsInUsage, conditions: [] })).toStrictEqual(result);
+    expect(getItemsOptions({ items, itemsInUsage, conditions })).toStrictEqual(result);
   });
 });

--- a/src/modules/Builder/features/ActivityItemsFlow/ItemFlow/SummaryRow/utils/getItemsOptions.tsx
+++ b/src/modules/Builder/features/ActivityItemsFlow/ItemFlow/SummaryRow/utils/getItemsOptions.tsx
@@ -12,13 +12,9 @@ const { t } = i18n;
 export const getItemsOptions = ({ items, itemsInUsage, conditions }: GetItemsOptionsProps) => {
   const itemsObject = getObjectFromList(items, undefined, true);
   const conditionItemsInUsageSet = new Set(conditions.map((condition) => condition.itemName));
-  const maxUsedItemIndex = [...conditionItemsInUsageSet].reduce((maxIndex, itemKey) => {
-    const item = itemsObject[itemKey];
-    const itemIndex = item?.index ?? -1;
-    if (!item || (typeof itemIndex === 'number' && itemIndex <= maxIndex)) return maxIndex;
-
-    return itemIndex;
-  }, -1);
+  const maxUsedItemIndex = Math.max(
+    ...[...conditionItemsInUsageSet].map((key) => itemsObject[key]?.index ?? -1),
+  );
 
   return items?.reduce((optionList: { value: string; labelKey: string }[], item, index) => {
     if (!item.responseType || !ITEMS_RESPONSE_TYPES_TO_SHOW.includes(item.responseType))

--- a/src/modules/Builder/features/ActivityItemsFlow_old/ActivityItemsFlow.test.tsx
+++ b/src/modules/Builder/features/ActivityItemsFlow_old/ActivityItemsFlow.test.tsx
@@ -329,15 +329,11 @@ describe('Activity Items Flow', () => {
       fireEvent.mouseDown(
         screen.getByTestId(`${mockedTestid}-0-summary-item`).querySelector('[role="button"]'),
       );
-      fireEvent.click(
+      expect(
         screen
           .getByTestId(`${mockedTestid}-0-summary-item-dropdown`)
-          .querySelector('li:last-child'),
-      );
-
-      await waitFor(() => {
-        expect(screen.queryByTestId(`${mockedTestid}-0-error`)).not.toBeInTheDocument();
-      });
+          .querySelector('li:nth-child(1)'),
+      ).toHaveClass('Mui-disabled');
     });
   });
 });

--- a/src/modules/Builder/features/ActivityItemsFlow_old/ItemFlow/SummaryRow/SummaryRow.types.ts
+++ b/src/modules/Builder/features/ActivityItemsFlow_old/ItemFlow/SummaryRow/SummaryRow.types.ts
@@ -10,6 +10,7 @@ export type SummaryRowProps = {
 export type GetItemsOptionsProps = {
   items: ItemFormValues[];
   itemsInUsage: Set<unknown>;
+  conditions: ConditionalLogic['conditions'];
 };
 
 export type GetItemsInUsageProps = {

--- a/src/modules/Builder/features/ActivityItemsFlow_old/ItemFlow/SummaryRow/SummaryRow.utils.test.tsx
+++ b/src/modules/Builder/features/ActivityItemsFlow_old/ItemFlow/SummaryRow/SummaryRow.utils.test.tsx
@@ -1,6 +1,17 @@
 import { ItemResponseType } from 'shared/consts';
+import { StyledMdPreview } from 'modules/Builder/components/ItemFlowSelectController/StyledMdPreview/StyledMdPreview.styles';
 
 import { getItemsOptions, getItemsInUsage } from './SummaryRow.utils';
+
+jest.mock(
+  'modules/Builder/components/ItemFlowSelectController/StyledMdPreview/StyledMdPreview.styles',
+  () => ({
+    ...jest.requireActual(
+      'modules/Builder/components/ItemFlowSelectController/StyledMdPreview/StyledMdPreview.styles',
+    ),
+    StyledMdPreview: ({ modelValue }: { modelValue: string }) => <div>{modelValue}</div>,
+  }),
+);
 
 describe('SummaryRow.utils', () => {
   describe('getItemsOptions', () => {
@@ -20,6 +31,7 @@ describe('SummaryRow.utils', () => {
         conditionalLogic: {
           itemKey: 'item-1',
         },
+        question: 'item-2',
       },
       {
         id: 'item-3',
@@ -36,6 +48,7 @@ describe('SummaryRow.utils', () => {
         conditionalLogic: {
           itemKey: undefined,
         },
+        question: 'item-4',
       },
       {
         id: 'item-5',
@@ -44,21 +57,32 @@ describe('SummaryRow.utils', () => {
       },
     ];
     const itemsInUsage = new Set(['item-1', 'item-3']);
+    const conditions = [
+      {
+        key: 'key-1',
+        type: 'INCLUDES_OPTION',
+        itemName: 'item-2',
+        payload: {
+          optionValue: 'option-value-1',
+        },
+      },
+    ];
     const result = [
       {
         disabled: true,
         labelKey: 'ss1',
         tooltip:
-          "This item is already selected in another Conditional card's summary row. If multiple conditions are necessary, use the same Conditional card with ALL or ANY conditions.",
+          'This Item appears in the Activity before one of the Items involved in the conditional.',
         value: 'item-1',
         tooltipPlacement: 'right',
       },
       {
-        disabled: false,
+        disabled: true,
         labelKey: 'ms1',
-        tooltip: undefined,
         value: 'item-2',
-        tooltipPlacement: undefined,
+        tooltip:
+          'This Item already defines one of the conditions and cannot be its result at the same time.',
+        tooltipPlacement: 'right',
       },
       {
         disabled: true,
@@ -71,15 +95,15 @@ describe('SummaryRow.utils', () => {
       {
         disabled: false,
         labelKey: 't1',
-        tooltip: undefined,
         value: 'item-4',
-        tooltipPlacement: undefined,
+        tooltip: <StyledMdPreview modelValue="item-4" />,
+        tooltipPlacement: 'right',
       },
     ];
     test('should return options with tooltips and disable statuses for items in usage', () => {
       //eslint-disable-next-line @typescript-eslint/ban-ts-comment
       //@ts-ignore
-      expect(getItemsOptions({ items, itemsInUsage })).toStrictEqual(result);
+      expect(getItemsOptions({ items, itemsInUsage, conditions })).toStrictEqual(result);
     });
   });
 

--- a/src/modules/Builder/features/ActivityItemsFlow_old/ItemFlow/SummaryRow/SummaryRow.utils.tsx
+++ b/src/modules/Builder/features/ActivityItemsFlow_old/ItemFlow/SummaryRow/SummaryRow.utils.tsx
@@ -1,6 +1,8 @@
+import { TooltipProps } from '@mui/material';
+
 import i18n from 'i18n';
 import { ConditionalLogicMatch } from 'shared/consts';
-import { getEntityKey } from 'shared/utils';
+import { getEntityKey, getObjectFromList } from 'shared/utils';
 import { StyledMdPreview } from 'modules/Builder/components/ItemFlowSelectController/StyledMdPreview/StyledMdPreview.styles';
 
 import { ITEMS_RESPONSE_TYPES_TO_SHOW } from './SummaryRow.const';
@@ -19,27 +21,60 @@ export const getMatchOptions = () => [
   },
 ];
 
-export const getItemsOptions = ({ items, itemsInUsage }: GetItemsOptionsProps) =>
-  items?.reduce((optionList: { value: string; labelKey: string }[], item) => {
-    if (item.responseType && ITEMS_RESPONSE_TYPES_TO_SHOW.includes(item.responseType)) {
-      const value = getEntityKey(item);
-      const disabled = itemsInUsage.has(value);
-      const showTooltip = disabled || item.question;
-      const tooltipPlacement: 'right' | undefined = showTooltip ? 'right' : undefined;
-      let tooltip;
-      if (showTooltip) {
-        tooltip = disabled ? (
-          t('conditionalLogicValidation.usageInSummaryRow')
-        ) : (
-          <StyledMdPreview modelValue={item.question ?? ''} />
-        );
-      }
+export const getItemsOptions = ({ items, itemsInUsage, conditions }: GetItemsOptionsProps) => {
+  const itemsObject = getObjectFromList(items, undefined, true);
+  const conditionItemsInUsageSet = new Set(conditions.map((condition) => condition.itemName));
+  const maxUsedItemIndex = Math.max(
+    ...[...conditionItemsInUsageSet].map((key) => itemsObject[key]?.index ?? -1),
+  );
 
-      return [...optionList, { value, labelKey: item.name, disabled, tooltip, tooltipPlacement }];
+  return items?.reduce((optionList: { value: string; labelKey: string }[], item, index) => {
+    if (!item.responseType || !ITEMS_RESPONSE_TYPES_TO_SHOW.includes(item.responseType))
+      return optionList;
+
+    const value = getEntityKey(item);
+    // 1# rule: summaryItemIsTheSameAsRuleItem
+    if (conditionItemsInUsageSet.has(value)) {
+      return [
+        ...optionList,
+        {
+          value,
+          labelKey: item.name,
+          disabled: true,
+          tooltip: t('conditionalLogicValidation.summaryItemIsTheSameAsRuleItem'),
+          tooltipPlacement: 'right' as TooltipProps['placement'],
+        },
+      ];
+    }
+    // 2# rule: summaryItemIsBeforeRuleItemInTheList
+    if (index <= maxUsedItemIndex) {
+      return [
+        ...optionList,
+        {
+          value,
+          labelKey: item.name,
+          disabled: true,
+          tooltip: t('conditionalLogicValidation.summaryItemIsBeforeRuleItemInTheList'),
+          tooltipPlacement: 'right' as TooltipProps['placement'],
+        },
+      ];
     }
 
-    return optionList;
+    // #last rule: usage in other conditionals
+    const disabled = itemsInUsage.has(value);
+    const showTooltip = disabled || item.question;
+    const tooltipPlacement: TooltipProps['placement'] | undefined = showTooltip
+      ? 'right'
+      : undefined;
+    const tooltip = disabled ? (
+      t('conditionalLogicValidation.usageInSummaryRow')
+    ) : (
+      <StyledMdPreview modelValue={item.question ?? ''} />
+    );
+
+    return [...optionList, { value, labelKey: item.name, disabled, tooltip, tooltipPlacement }];
   }, []);
+};
 
 export const getItemsInUsage = ({ conditionalLogic, itemKey }: GetItemsInUsageProps) =>
   (conditionalLogic ?? []).reduce((acc, conditional) => {

--- a/src/modules/Builder/pages/BuilderApplet/BuilderApplet.schema.ts
+++ b/src/modules/Builder/pages/BuilderApplet/BuilderApplet.schema.ts
@@ -6,6 +6,7 @@ import {
   getEntityKey,
   getIsRequiredValidateMessage,
   getMaxLengthValidationError,
+  getObjectFromList,
 } from 'shared/utils';
 import {
   CONDITION_TYPES_TO_HAVE_RANGE_VALUE,
@@ -23,7 +24,7 @@ import {
   ScoreReportType,
 } from 'shared/consts';
 import { RoundTypeEnum } from 'modules/Builder/types';
-import { Condition, Config, Item, ScoreOrSection } from 'shared/state';
+import { Condition, Config, ScoreOrSection } from 'shared/state';
 import { ItemConfigurationSettings } from 'modules/Builder/features/ActivityItems/ItemConfiguration/ItemConfiguration.types';
 import { DEFAULT_NUMBER_SELECT_MIN_VALUE } from 'modules/Builder/consts';
 
@@ -596,21 +597,30 @@ export const ConditionalLogicSchema = (enableItemFlowExtendedItems: boolean) =>
     itemKey: yup
       .string()
       .required(t('fillInAllRequired') as string)
-      .test(
-        'item-flow-contradiction',
-        t('appletHasItemFlowContradictions') as string,
-        (itemKey, context) => {
-          const items = get(context, 'from.1.value.items') ?? [];
-          const conditions = get(context, 'parent.conditions');
-          const itemIds = items?.map((item: Item) => getEntityKey(item));
-          const itemIndex = itemIds?.findIndex((id: string) => id === itemKey);
-          const itemsBefore = itemIds?.slice(0, itemIndex + 1);
+      .test('item-flow-contradiction', function (itemKey) {
+        const { createError, path, parent, from } = this;
+        const items = (get(from, '1.value.items') ?? []) as ItemFormValues[];
+        const conditions = get(parent, 'conditions') as Condition[];
+        const itemsObject = getObjectFromList(items, undefined, true);
 
-          return !conditions?.some(
-            ({ itemName }: Condition) => itemName && !itemsBefore.includes(itemName),
-          );
-        },
-      ),
+        const conditionItemsInUsageSet = new Set(conditions.map((condition) => condition.itemName));
+        const itemIndex = itemsObject[itemKey]?.index ?? -1;
+
+        // 1# rule: summaryItemIsTheSameAsRuleItem
+        if (conditionItemsInUsageSet.has(itemKey)) {
+          return createError({ path, message: t('summaryItemSameAsRuleItem') });
+        }
+
+        // 2# rule: summaryItemIsBeforeRuleItemInTheList
+        const maxUsedItemIndex = Math.max(
+          ...[...conditionItemsInUsageSet].map((key) => itemsObject[key]?.index ?? -1),
+        );
+        if (itemIndex <= maxUsedItemIndex) {
+          return createError({ path, message: t('appletHasItemFlowContradictions') });
+        }
+
+        return true;
+      }),
     conditions: yup
       .array()
       .of(enableItemFlowExtendedItems ? ItemFlowConditionSchema() : ConditionSchema()),

--- a/src/modules/Builder/pages/BuilderApplet/BuilderApplet.schema.ts
+++ b/src/modules/Builder/pages/BuilderApplet/BuilderApplet.schema.ts
@@ -721,10 +721,8 @@ export const SectionSchema = () => ({
       'unique-section-name',
       t('validationMessages.unique', { field: t('sectionName') }) as string,
       (sectionName, context) => {
-        const reports = get(context, 'from.1.value.reports') ?? [];
-        const sections = reports?.filter(
-          ({ type }: ScoreOrSection) => type === ScoreReportType.Section,
-        );
+        const reports = (get(context, 'from.1.value.reports') ?? []) as ScoreOrSection[];
+        const sections = reports?.filter(({ type }) => type === ScoreReportType.Section);
 
         return testFunctionForUniqueness(sectionName ?? '', sections);
       },

--- a/src/modules/Builder/pages/BuilderApplet/BuilderApplet.schema.ts
+++ b/src/modules/Builder/pages/BuilderApplet/BuilderApplet.schema.ts
@@ -683,10 +683,8 @@ export const ScoreSchema = () => ({
       'unique-score-name',
       t('validationMessages.unique', { field: t('scoreName') }) as string,
       (scoreName, context) => {
-        const reports = get(context, 'from.1.value.reports') ?? [];
-        const scores = reports?.filter(
-          ({ type }: ScoreOrSection) => type === ScoreReportType.Score,
-        );
+        const reports = (get(context, 'from.1.value.reports') ?? []) as ScoreOrSection[];
+        const scores = reports?.filter(({ type }) => type === ScoreReportType.Score);
 
         return testFunctionForUniqueness(scoreName ?? '', scores);
       },

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -143,6 +143,7 @@
   "appletHasEmptyRequiredFields": "Please fill in all required fields marked in red",
   "appletHasErrorsInFields": "Please fix the errors in all fields marked in red",
   "appletHasItemFlowContradictions": "Selected position of the Item in the list contradicts the Item Flow",
+  "summaryItemSameAsRuleItem": "This item is already selected as a condition and cannot be selected as a result simultaneously",
   "appletImageDescription": "This image is displayed next to the Applet name in the admin panel, and in the respondent's interface.",
   "appletImg": "Applet Image",
   "appletIsBeingCreated": "Your Applet is being created. Please wait...",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -143,6 +143,7 @@
   "appletHasEmptyRequiredFields": "Veuillez remplir tous les champs requis marqués en rouge",
   "appletHasErrorsInFields": "Veuillez corriger les erreurs dans tous les champs marqués en rouge",
   "appletHasItemFlowContradictions": "La position de l'élément sélectionnée dans la liste contredit le flux d'éléments",
+  "summaryItemSameAsRuleItem": "Cet élément est déjà sélectionné comme condition et ne peut pas être sélectionné simultanément comme résultat",
   "appletImageDescription": "Cette image est affichée à côté du nom de l'applet dans le panneau d'administration et dans l'interface du participant.",
   "appletImg": "Image de l'applet",
   "appletIsBeingCreated": "Votre applet est en cours de création. Veuillez patienter...",


### PR DESCRIPTION
- [x] Tests for the changes have been added
- [x] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

🔗 [Jira Ticket M2-7105](https://mindlogger.atlassian.net/browse/M2-7105)

Changes include:

- Added improvements for SummaryRow in ActivityItemsFlow.
- Added support for validation rules in SummaryRow for ActivityItemsFlow_old:
   - Rule 1: summaryItemIsTheSameAsRuleItem
   - Rule 2: summaryItemIsBeforeRuleItemInTheList
- Added Yup validation for summary items in ActivityItemsFlow and ActivityItemsFlow_old about Rule 1: summaryItemIsTheSameAsRuleItem
- Added unit tests to cover the new functionality

### 📸 Screenshots

| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| <!-- Paste before image/video here --> | https://app.screencast.com/DdzzBvJej0GbR |
