### PR TITLE
fix: builder - wrong appearance of "Save Changes" popup (M2-6012)

### DIFF
--- a/src/modules/Builder/features/BuilderAppletSettings/BuilderAppletSettings.tsx
+++ b/src/modules/Builder/features/BuilderAppletSettings/BuilderAppletSettings.tsx
@@ -8,24 +8,12 @@ import { getSettings } from './BuilderAppletSettings.utils';
 
 export const BuilderAppletSettings = () => {
   const isNewApplet = useCheckIfNewApplet();
-  const { watch, setValue } = useCustomFormContext();
+  const { watch } = useCustomFormContext();
 
   const isPublished = watch('isPublished');
   const workspaceRoles = workspaces.useRolesData();
   const { result: appletData } = applet.useAppletData() ?? {};
   const { featureFlags } = useFeatureFlags();
-
-  const handleReportConfigSubmit = (values: Record<string, unknown>) => {
-    const keys = [
-      'reportRecipients',
-      'reportIncludeUserId',
-      'reportEmailBody',
-      'reportServerIp',
-      'reportPublicKey',
-    ];
-
-    keys.forEach((key) => setValue(key, values[key]));
-  };
 
   return (
     <>
@@ -37,7 +25,6 @@ export const BuilderAppletSettings = () => {
             isNewApplet,
             isPublished,
             roles: appletData?.id ? workspaceRoles?.data?.[appletData.id] : undefined,
-            onReportConfigSubmit: handleReportConfigSubmit,
             enableLorisIntegration: featureFlags.enableLorisIntegration,
             appletId: appletData?.id,
           })}

--- a/src/modules/Builder/features/BuilderAppletSettings/BuilderAppletSettings.types.ts
+++ b/src/modules/Builder/features/BuilderAppletSettings/BuilderAppletSettings.types.ts
@@ -1,11 +1,9 @@
 import { Roles } from 'shared/consts';
-import { ReportConfigFormValues } from 'modules/Builder/features/ReportConfigSetting';
 
 export type GetSettings = {
   isNewApplet?: boolean;
   isPublished?: boolean;
   roles?: Roles[];
-  onReportConfigSubmit: (values: Partial<ReportConfigFormValues>) => void;
   enableLorisIntegration?: boolean;
   appletId?: string;
 };

--- a/src/modules/Builder/features/BuilderAppletSettings/BuilderAppletSettings.utils.test.tsx
+++ b/src/modules/Builder/features/BuilderAppletSettings/BuilderAppletSettings.utils.test.tsx
@@ -2,7 +2,6 @@ import { Roles } from 'shared/consts';
 
 import { getSettings } from './BuilderAppletSettings.utils';
 
-const onReportConfigSubmitMock = jest.fn();
 const appletId = 'appletId';
 
 describe('getSettings', () => {
@@ -15,7 +14,6 @@ describe('getSettings', () => {
         isNewApplet: false,
         isPublished: true,
         roles,
-        onReportConfigSubmit: onReportConfigSubmitMock,
         appletId,
       }).map((section) => section.label),
     ).toStrictEqual(sections);
@@ -39,7 +37,6 @@ describe('getSettings', () => {
           isNewApplet: false,
           isPublished,
           roles,
-          onReportConfigSubmit: onReportConfigSubmitMock,
           appletId,
         })
           .find((section) => section.label === sectionLabel)
@@ -53,7 +50,6 @@ describe('getSettings', () => {
       isNewApplet: true,
       isPublished: true,
       roles,
-      onReportConfigSubmit: onReportConfigSubmitMock,
       appletId,
     })
       .map((setting) => setting.items)
@@ -88,7 +84,6 @@ describe('getSettings', () => {
           isNewApplet: false,
           isPublished: true,
           roles,
-          onReportConfigSubmit: onReportConfigSubmitMock,
           appletId,
         }).find((section) => section.label === 'sharing')?.isVisible,
       ).toBe(isVisible);

--- a/src/modules/Builder/features/BuilderAppletSettings/BuilderAppletSettings.utils.tsx
+++ b/src/modules/Builder/features/BuilderAppletSettings/BuilderAppletSettings.utils.tsx
@@ -23,7 +23,6 @@ export const getSettings = ({
   isNewApplet,
   isPublished,
   roles,
-  onReportConfigSubmit,
   enableLorisIntegration,
   appletId,
 }: GetSettings): ItemNavigation[] => {
@@ -111,12 +110,7 @@ export const getSettings = ({
         {
           icon: <Svg id="configure" />,
           label: 'reportConfiguration',
-          component: (
-            <ReportConfigSetting
-              onSubmitSuccess={onReportConfigSubmit}
-              data-testid={`${dataTestid}-report-config-form`}
-            />
-          ),
+          component: <ReportConfigSetting data-testid={`${dataTestid}-report-config-form`} />,
           param: SettingParam.ReportConfiguration,
           disabled: isNewApplet,
           tooltip,

--- a/src/modules/Builder/features/ReportConfigSetting/ReportConfigSetting.tsx
+++ b/src/modules/Builder/features/ReportConfigSetting/ReportConfigSetting.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, ChangeEvent } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { useForm } from 'react-hook-form';
+import { useForm, useFormContext } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Box } from '@mui/material';
 import { ObjectSchema } from 'yup';
@@ -47,7 +47,6 @@ import { toggleBooleanState } from 'shared/utils/toggleBooleanState';
 import { reportConfig } from 'modules/Builder/state';
 import { useCurrentActivity } from 'modules/Builder/hooks/useCurrentActivity';
 import { useCurrentActivityFlow } from 'modules/Builder/hooks/useCurrentActivityFlow';
-import { useCustomFormContext } from 'modules/Builder/hooks/useCustomFormContext';
 import { TEXTAREA_ROWS_COUNT_SM } from 'shared/consts';
 import { AppletFormValues } from 'modules/Builder/types';
 import { usePrompt } from 'shared/features/AppletSettings/AppletSettings.hooks';
@@ -71,10 +70,7 @@ import { useCheckReportServer, useDefaultValues } from './ReportConfigSetting.ho
 import { REPORT_SERVER_INSTRUCTIONS_LINK } from './ReportConfigSetting.const';
 import { ServerNotConfigured } from './ServerNotConfigured';
 
-export const ReportConfigSetting = ({
-  onSubmitSuccess,
-  'data-testid': dataTestid,
-}: ReportConfigSettingProps) => {
+export const ReportConfigSetting = ({ 'data-testid': dataTestid }: ReportConfigSettingProps) => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
   const { activity, fieldName: activityFieldName } = useCurrentActivity();
@@ -86,8 +82,7 @@ export const ReportConfigSetting = ({
   const isActivity = !!activity;
   const isActivityFlow = !!activityFlow;
   const isActivityOrFlow = isActivity || isActivityFlow;
-  const { setValue: setAppletFormValue, getValues: getAppletFormValues } =
-    useCustomFormContext() || {};
+  const { setValue: setAppletFormValue, getValues: getAppletFormValues } = useFormContext() || {};
   const appletFormValues = getAppletFormValues?.() as AppletFormValues;
   const defaultValues = useDefaultValues(appletFormValues ?? appletData);
 
@@ -103,10 +98,6 @@ export const ReportConfigSetting = ({
   const { accountId = '' } = encryptionInfoFromServer ?? {};
 
   const handleSuccess = () => {
-    if (!onSubmitSuccess) return;
-
-    onSubmitSuccess(getValues());
-
     dispatch(
       banners.actions.addBanner({
         key: 'SaveSuccessBanner',

--- a/src/modules/Builder/features/ReportConfigSetting/ReportConfigSetting.types.ts
+++ b/src/modules/Builder/features/ReportConfigSetting/ReportConfigSetting.types.ts
@@ -33,7 +33,6 @@ export type SetPasswordReportServer = {
 };
 
 export type ReportConfigSettingProps = {
-  onSubmitSuccess?: (values: Partial<ReportConfigFormValues>) => void;
   'data-testid'?: string;
 };
 


### PR DESCRIPTION
- [x] Tests for the changes have been updated
- [x] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

🔗 [Jira Ticket M2-6012](https://mindlogger.atlassian.net/browse/M2-6012)

Changes include:

To update the Report Configuration, there is a separate endpoint. However, the Report Configuration values are saved to the Applet form and are received from the Applet endpoint. Therefore, the duplicated `setValue` call for the Applet form in the builder, which had the `shouldDirty` property set to `true`, was removed. Additionally, the `setValue` call in the report configuration was replaced with `setValue` where `shouldDirty` is set to `false` (which is the default).

### 📸 Screenshots

| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| https://app.screencast.com/KPhkubxifXuiD | https://app.screencast.com/M9K8Bw1OpbqmQ |

