### PR TITLE
feat: Adds Unity (merit) activity as an option on performance tasks (M2-7440)

### DIFF
--- a/src/modules/Builder/features/Activities/Activities.test.tsx
+++ b/src/modules/Builder/features/Activities/Activities.test.tsx
@@ -61,6 +61,7 @@ const mockedMobileTestid = 'builder-activities-add-perf-task-abtrails-mobile';
 const mockedFlankerTestid = 'builder-activities-add-perf-task-flanker';
 const mockedGyroscopeTestid = 'builder-activities-add-perf-task-gyroscope';
 const mockedTouchTestid = 'builder-activities-add-perf-task-touch';
+const mockedUnityTestid = 'builder-activities-add-perf-task-unity';
 
 const mockedUseNavigate = jest.fn();
 
@@ -99,6 +100,8 @@ const addPerfTask = (perfTaskType) => {
       return fireEvent.click(screen.getByTestId(mockedGyroscopeTestid));
     case PerformanceTasks.Touch:
       return fireEvent.click(screen.getByTestId(mockedTouchTestid));
+    case PerformanceTasks.Unity:
+      return fireEvent.click(screen.getByTestId(mockedUnityTestid));
     default:
       return;
   }

--- a/src/modules/Builder/features/Activities/Activities.types.ts
+++ b/src/modules/Builder/features/Activities/Activities.types.ts
@@ -31,4 +31,5 @@ export const enum PerformanceTasks {
   Flanker = 'flanker',
   Gyroscope = 'gyroscope',
   Touch = 'touch',
+  Unity = 'unity',
 }

--- a/src/modules/Builder/features/Activities/ActivitiesHeader/ActivitiesHeader.tsx
+++ b/src/modules/Builder/features/Activities/ActivitiesHeader/ActivitiesHeader.tsx
@@ -8,7 +8,7 @@ import { theme } from 'shared/styles';
 import { falseReturnFunc } from 'shared/utils';
 
 import { ActivitiesHeaderProps } from './ActivitiesHeader.types';
-import { getPerformanceTasksMenu } from './ActivitiesHeader.utils';
+import { GetPerformanceTasksMenu } from './ActivitiesHeader.utils';
 
 export const ActivitiesHeader = ({ isSticky, children, headerProps }: ActivitiesHeaderProps) => {
   const { t } = useTranslation('app');
@@ -36,7 +36,7 @@ export const ActivitiesHeader = ({ isSticky, children, headerProps }: Activities
           label={t('addPerformanceTask')}
           anchorEl={anchorEl}
           setAnchorEl={setAnchorEl}
-          menuItems={getPerformanceTasksMenu(
+          menuItems={GetPerformanceTasksMenu(
             headerProps?.onAddActivity || falseReturnFunc,
             setAnchorEl,
           )}

--- a/src/modules/Builder/features/Activities/ActivitiesHeader/ActivitiesHeader.tsx
+++ b/src/modules/Builder/features/Activities/ActivitiesHeader/ActivitiesHeader.tsx
@@ -6,13 +6,17 @@ import { StyledBuilderContainerHeader } from 'shared/features';
 import { ButtonWithMenu, Svg, MenuUiType } from 'shared/components';
 import { theme } from 'shared/styles';
 import { falseReturnFunc } from 'shared/utils';
+import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 
 import { ActivitiesHeaderProps } from './ActivitiesHeader.types';
-import { GetPerformanceTasksMenu } from './ActivitiesHeader.utils';
+import { getPerformanceTasksMenu } from './ActivitiesHeader.utils';
 
 export const ActivitiesHeader = ({ isSticky, children, headerProps }: ActivitiesHeaderProps) => {
   const { t } = useTranslation('app');
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const {
+    featureFlags: { enableMeritActivityType },
+  } = useFeatureFlags();
 
   const handleActivityAdd = () => {
     headerProps?.onAddActivity && headerProps.onAddActivity(null);
@@ -36,9 +40,10 @@ export const ActivitiesHeader = ({ isSticky, children, headerProps }: Activities
           label={t('addPerformanceTask')}
           anchorEl={anchorEl}
           setAnchorEl={setAnchorEl}
-          menuItems={GetPerformanceTasksMenu(
+          menuItems={getPerformanceTasksMenu(
             headerProps?.onAddActivity || falseReturnFunc,
             setAnchorEl,
+            enableMeritActivityType,
           )}
           startIcon={<Svg id="add" width={18} height={18} />}
           menuListWidth="44rem"

--- a/src/modules/Builder/features/Activities/ActivitiesHeader/ActivitiesHeader.utils.tsx
+++ b/src/modules/Builder/features/Activities/ActivitiesHeader/ActivitiesHeader.utils.tsx
@@ -1,6 +1,5 @@
 import i18n from 'i18n';
 import { PerfTaskType } from 'shared/consts';
-import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 
 import { ActivityAddProps, PerformanceTasks } from '../Activities.types';
 
@@ -8,14 +7,11 @@ const { t } = i18n;
 
 const getMenuItemTitle = (perfTask: string) => `performanceTasks.${perfTask}`;
 
-export const GetPerformanceTasksMenu = (
+export const getPerformanceTasksMenu = (
   onAddActivity: (props: ActivityAddProps) => void,
   setAnchorEl: (el: null | HTMLElement) => void,
+  enableMeritActivityType?: boolean,
 ) => {
-  const {
-    featureFlags: { enableMeritActivityType },
-  } = useFeatureFlags();
-
   const getAction = (props: ActivityAddProps) => {
     onAddActivity(props);
     setAnchorEl(null);

--- a/src/modules/Builder/features/Activities/ActivitiesHeader/ActivitiesHeader.utils.tsx
+++ b/src/modules/Builder/features/Activities/ActivitiesHeader/ActivitiesHeader.utils.tsx
@@ -1,5 +1,6 @@
 import i18n from 'i18n';
 import { PerfTaskType } from 'shared/consts';
+import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 
 import { ActivityAddProps, PerformanceTasks } from '../Activities.types';
 
@@ -7,16 +8,35 @@ const { t } = i18n;
 
 const getMenuItemTitle = (perfTask: string) => `performanceTasks.${perfTask}`;
 
-export const getPerformanceTasksMenu = (
+export const GetPerformanceTasksMenu = (
   onAddActivity: (props: ActivityAddProps) => void,
   setAnchorEl: (el: null | HTMLElement) => void,
 ) => {
+  const {
+    featureFlags: { enableMeritActivityType },
+  } = useFeatureFlags();
+
   const getAction = (props: ActivityAddProps) => {
     onAddActivity(props);
     setAnchorEl(null);
   };
 
   return [
+    ...(enableMeritActivityType
+      ? [
+          {
+            title: getMenuItemTitle(PerformanceTasks.Unity),
+            action: () =>
+              getAction({
+                performanceTaskName: t(getMenuItemTitle(PerformanceTasks.Unity)),
+                performanceTaskDesc: t('performanceTasksDesc.unity'),
+                performanceTaskType: PerfTaskType.Unity,
+                isNavigationBlocked: true,
+              }),
+            'data-testid': 'builder-activities-add-perf-task-unity',
+          },
+        ]
+      : []),
     {
       title: getMenuItemTitle(PerformanceTasks.AbTrailsIpad),
       action: () =>

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/PhrasalTemplate/PhrasalTemplateField/PhrasalTemplateField.const.ts
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/PhrasalTemplate/PhrasalTemplateField/PhrasalTemplateField.const.ts
@@ -41,5 +41,6 @@ export const DisplayModeOptions: Record<
   [ItemResponseType.TimeRange]: undefined,
   [ItemResponseType.TouchPractice]: undefined,
   [ItemResponseType.TouchTest]: undefined,
+  [ItemResponseType.UnityFile]: undefined,
   [ItemResponseType.Video]: undefined,
 };

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/Settings/ItemSettingsController/ItemSettingsGroup/ItemSettingsGroup.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/Settings/ItemSettingsController/ItemSettingsGroup/ItemSettingsGroup.tsx
@@ -302,7 +302,8 @@ export const ItemSettingsGroup = ({
                 if (
                   isAlerts &&
                   ~ITEM_TYPES_TO_HAVE_ALERTS.indexOf(inputType as ItemResponseType) &&
-                  inputType !== ItemResponseType.PhrasalTemplate
+                  inputType !== ItemResponseType.PhrasalTemplate &&
+                  inputType !== ItemResponseType.UnityFile
                 ) {
                   const hasAlerts = event.target.checked;
 
@@ -311,7 +312,7 @@ export const ItemSettingsGroup = ({
                     hasAlerts
                       ? [
                           getEmptyAlert({
-                            responseType: inputType as ItemResponseType,
+                            responseType: inputType,
                             responseValues: getValues(`${itemName}.responseValues`),
                             config,
                           }),

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/Settings/ItemSettingsController/ItemSettingsGroup/ItemSettingsGroup.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/Settings/ItemSettingsController/ItemSettingsGroup/ItemSettingsGroup.tsx
@@ -311,7 +311,7 @@ export const ItemSettingsGroup = ({
                     hasAlerts
                       ? [
                           getEmptyAlert({
-                            responseType: inputType,
+                            responseType: inputType as ItemResponseType,
                             responseValues: getValues(`${itemName}.responseValues`),
                             config,
                           }),

--- a/src/modules/Builder/pages/BuilderApplet/BuilderApplet.utils.tsx
+++ b/src/modules/Builder/pages/BuilderApplet/BuilderApplet.utils.tsx
@@ -567,6 +567,20 @@ export const getABTrailsItems = (deviceType: DeviceType) =>
     },
   }));
 
+export const getUnityFileItem = (deviceType: DeviceType) => [
+  {
+    id: undefined,
+    key: uuidv4(),
+    responseType: ItemResponseType.UnityFile,
+    name: `${ItemResponseType.UnityFile}_${deviceType}`,
+    question: t('unityInstructions'),
+    config: {
+      deviceType,
+      orderName: OrderName[ordinalStrings[0] as keyof typeof OrderName],
+    },
+  },
+];
+
 export const getNewPerformanceTask = ({
   name,
   description,
@@ -579,7 +593,7 @@ export const getNewPerformanceTask = ({
     [PerfTaskType.Touch]: getGyroscopeOrTouchItems(GyroscopeOrTouch.Touch),
     [PerfTaskType.ABTrailsMobile]: getABTrailsItems(DeviceType.Mobile),
     [PerfTaskType.ABTrailsTablet]: getABTrailsItems(DeviceType.Tablet),
-    [PerfTaskType.Unity]: getABTrailsItems(DeviceType.Mobile),
+    [PerfTaskType.Unity]: getUnityFileItem(DeviceType.Mobile),
   };
 
   const { items, ...restPerfTaskParams } = performanceTask || {};

--- a/src/modules/Builder/pages/BuilderApplet/BuilderApplet.utils.tsx
+++ b/src/modules/Builder/pages/BuilderApplet/BuilderApplet.utils.tsx
@@ -579,6 +579,7 @@ export const getNewPerformanceTask = ({
     [PerfTaskType.Touch]: getGyroscopeOrTouchItems(GyroscopeOrTouch.Touch),
     [PerfTaskType.ABTrailsMobile]: getABTrailsItems(DeviceType.Mobile),
     [PerfTaskType.ABTrailsTablet]: getABTrailsItems(DeviceType.Tablet),
+    [PerfTaskType.Unity]: getABTrailsItems(DeviceType.Mobile),
   };
 
   const { items, ...restPerfTaskParams } = performanceTask || {};

--- a/src/modules/Builder/types/Builder.types.ts
+++ b/src/modules/Builder/types/Builder.types.ts
@@ -12,6 +12,7 @@ import {
   TouchTestItem,
   ItemCommonType,
   Item,
+  UnityItem,
 } from 'shared/state';
 import { ItemResponseType, PerfTaskType, SubscaleTotalScore } from 'shared/consts';
 import { ArrayElement } from 'shared/types';
@@ -113,6 +114,7 @@ export type GetNewPerformanceTask = {
         | StabilityTrackerItem<ItemFormValuesCommonType>
         | TouchPracticeItem<ItemFormValuesCommonType>
         | TouchTestItem<ItemFormValuesCommonType>
+        | UnityItem<ItemFormValuesCommonType>
       >[]
     >,
     string,
@@ -134,6 +136,7 @@ export type ItemResponseTypeNoPerfTasks = Exclude<
   | ItemResponseType.TouchPractice
   | ItemResponseType.TouchTest
   | ItemResponseType.ABTrails
+  | ItemResponseType.UnityFile
 >;
 
 export enum RoundTypeEnum {

--- a/src/modules/Library/features/AppletsCatalog/AppletsCatalog.utils.tsx
+++ b/src/modules/Library/features/AppletsCatalog/AppletsCatalog.utils.tsx
@@ -72,4 +72,5 @@ export const getItemResponseTypes = (enableParagraphTextItem: boolean) => ({
     icon: <Svg id="fileAlt" />,
     title: ItemResponseType.PhrasalTemplate,
   },
+  [ItemResponseType.UnityFile]: { icon: null, title: ItemResponseType.UnityFile },
 });

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -996,13 +996,16 @@
     "abTrailsMobile": "A/B Trails Mobile",
     "flanker": "Simple & Choice Reaction Time Task Builder",
     "gyroscope": "CST Gyroscope",
-    "touch": "CST Touch"
+    "touch": "CST Touch",
+    "unity": "New Unity Task (Beta)"
   },
   "performanceTasksDesc": {
     "abTrails": "A/B Trails",
     "flanker": "This Activity contains Flanker Item. The timestamps collected for an android are not as accurate as iOS devices.",
     "gyroscope": "This Activity contains Stability Tracker (Gyroscope) Item.",
-    "touch": "This Activity contains Stability Tracker (Touch) Item."
+    "touch": "This Activity contains Stability Tracker (Touch) Item.",
+    "unity": "New Unity Task",
+    "beta": "(beta)"
   },
   "periodRequired": "Period is required",
   "personalInvitation": "Personal Invitation",

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -1441,6 +1441,7 @@
   "tryAgain": "Try again",
   "underline": "Underline",
   "undo": "Undo",
+  "unityInstructions": "Upload Configurations",
   "unorderedList": "Unordered list",
   "unread": "Unread",
   "unselected": "Unselected",

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -1004,8 +1004,7 @@
     "flanker": "This Activity contains Flanker Item. The timestamps collected for an android are not as accurate as iOS devices.",
     "gyroscope": "This Activity contains Stability Tracker (Gyroscope) Item.",
     "touch": "This Activity contains Stability Tracker (Touch) Item.",
-    "unity": "New Unity Task",
-    "beta": "(beta)"
+    "unity": "New Unity Task"
   },
   "periodRequired": "Period is required",
   "personalInvitation": "Personal Invitation",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -1440,6 +1440,7 @@
   "tryAgain": "Réessayer",
   "underline": "Souligner",
   "undo": "Annuler",
+  "unityInstructions": "Upload Configurations",
   "unorderedList": "Liste non ordonnée",
   "unread": "Non lu",
   "unselected": "Non sélectionné",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -995,13 +995,16 @@
     "abTrailsMobile": "A/B Trails Mobile",
     "flanker": "Constructeur de tâches de temps de réaction simple et au choix",
     "gyroscope": "CST Gyroscope",
-    "touch": "CST Touch"
+    "touch": "CST Touch",
+    "unity": "Nouvelle tâche Unity (Beta)"
   },
   "performanceTasksDesc": {
     "abTrails": "Parcours A/B",
     "flanker": "Cette Activité contient un Élément Flanker. Les horodatages collectés pour un appareil Android ne sont pas aussi précis que ceux des appareils iOS.",
     "gyroscope": "Cette Activité contient un Élément de Suivi de Stabilité (Gyroscope).",
-    "touch": "Cette Activité contient un Élément de Suivi de Stabilité (Toucher)."
+    "touch": "Cette Activité contient un Élément de Suivi de Stabilité (Toucher).",
+    "unity": "Nouvelle tâche Unity",
+    "beta": "(beta)"
   },
   "periodRequired": "La période est requise",
   "personalInvitation": "Invitation Personnelle",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -1003,8 +1003,7 @@
     "flanker": "Cette Activité contient un Élément Flanker. Les horodatages collectés pour un appareil Android ne sont pas aussi précis que ceux des appareils iOS.",
     "gyroscope": "Cette Activité contient un Élément de Suivi de Stabilité (Gyroscope).",
     "touch": "Cette Activité contient un Élément de Suivi de Stabilité (Toucher).",
-    "unity": "Nouvelle tâche Unity",
-    "beta": "(beta)"
+    "unity": "Nouvelle tâche Unity"
   },
   "periodRequired": "La période est requise",
   "personalInvitation": "Invitation Personnelle",

--- a/src/shared/consts.tsx
+++ b/src/shared/consts.tsx
@@ -146,6 +146,7 @@ export enum PerfTaskType {
   Gyroscope = 'gyroscope',
   ABTrailsTablet = 'ABTrailsTablet',
   ABTrailsMobile = 'ABTrailsMobile',
+  Unity = 'unity',
 }
 
 export enum GyroscopeOrTouch {

--- a/src/shared/consts.tsx
+++ b/src/shared/consts.tsx
@@ -120,8 +120,8 @@ export enum ItemResponseType {
   TimeRange = 'timeRange',
   TouchPractice = 'touchPractice',
   TouchTest = 'touchTest',
-  Video = 'video',
   UnityFile = 'unityFile',
+  Video = 'video',
 }
 
 export const textLanguageKey = 'shortText';

--- a/src/shared/consts.tsx
+++ b/src/shared/consts.tsx
@@ -121,6 +121,7 @@ export enum ItemResponseType {
   TouchPractice = 'touchPractice',
   TouchTest = 'touchTest',
   Video = 'video',
+  UnityFile = 'unityFile',
 }
 
 export const textLanguageKey = 'shortText';
@@ -192,6 +193,7 @@ export const itemsTypeIcons = {
   [ItemResponseType.TouchTest]: null,
   [ItemResponseType.TouchPractice]: null,
   [ItemResponseType.PhrasalTemplate]: <Svg id="fileAlt" />,
+  [ItemResponseType.UnityFile]: null,
 };
 
 export const enum SubscaleTotalScore {

--- a/src/shared/state/Applet/Applet.schema.ts
+++ b/src/shared/state/Applet/Applet.schema.ts
@@ -525,8 +525,8 @@ export type Item<T = ItemCommonType> =
   | StabilityTrackerItem<T>
   | TouchPracticeItem<T>
   | TouchTestItem<T>
-  | PhrasalTemplateItem<T>
-  | UnityItem<T>;
+  | UnityItem<T>
+  | PhrasalTemplateItem<T>;
 
 export type ItemCommonType = {
   id?: string;
@@ -686,6 +686,7 @@ export type TouchTestItem<T = ItemCommonType> = T & {
 export type PhrasalTemplateItem<T = ItemCommonType> = T & {
   config: PhrasalTemplateConfig;
   responseType: ItemResponseType.PhrasalTemplate;
+  responseValues: null;
 };
 
 export type UnityItem<T = ItemCommonType> = T & {

--- a/src/shared/state/Applet/Applet.schema.ts
+++ b/src/shared/state/Applet/Applet.schema.ts
@@ -525,7 +525,8 @@ export type Item<T = ItemCommonType> =
   | StabilityTrackerItem<T>
   | TouchPracticeItem<T>
   | TouchTestItem<T>
-  | PhrasalTemplateItem<T>;
+  | PhrasalTemplateItem<T>
+  | UnityItem<T>;
 
 export type ItemCommonType = {
   id?: string;
@@ -685,6 +686,11 @@ export type TouchTestItem<T = ItemCommonType> = T & {
 export type PhrasalTemplateItem<T = ItemCommonType> = T & {
   config: PhrasalTemplateConfig;
   responseType: ItemResponseType.PhrasalTemplate;
+};
+
+export type UnityItem<T = ItemCommonType> = T & {
+  responseType: ItemResponseType.UnityFile;
+  config: TouchConfig;
   responseValues: null;
 };
 

--- a/src/shared/types/featureFlags.ts
+++ b/src/shared/types/featureFlags.ts
@@ -16,6 +16,7 @@ export const FeatureFlagsKeys = {
   enableParagraphTextItem: 'enableParagraphTextItem',
   enablePhrasalTemplate: 'enablePhrasalTemplate',
   enableDataExportSpeedUp: 'enableDataExportSpeedUp',
+  enableMeritActivityType: 'enableMeritActivityType',
 };
 
 export type FeatureFlags = Partial<Record<keyof typeof FeatureFlagsKeys, LDFlagValue>>;


### PR DESCRIPTION
- [x] Tests for the changes have been added
(https://mindlogger.atlassian.net/wiki/spaces/MINDLOGGER1/pages/263127186/Admin+Panel+Applet+Builder+Library)
- [x] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

🔗 [Jira Ticket M2-7440](https://mindlogger.atlassian.net/browse/M2-7440)

Adds a new performance activity type for Merit POC to include a Unity Activity.

### 📸 Screenshots
![CleanShot 2024-08-05 at 14 49 30](https://github.com/user-attachments/assets/c33a0a80-6fd7-4a44-a109-4a2e9170b7ee)


### 🪤 Peer Testing

It's necessary to enable the feature flag `enableMeritActivityType` to test the feature.


