### PR TITLE
chore: revert reverted feat: add activity/flow auto assign checkbox

### DIFF
--- a/src/modules/Builder/features/Activities/Activities.test.tsx
+++ b/src/modules/Builder/features/Activities/Activities.test.tsx
@@ -26,6 +26,7 @@ const mockedEmptyActivity = {
   responseIsEditable: true,
   isHidden: false,
   isReviewable: false,
+  autoAssign: true,
   items: [],
   scoresAndReports: {
     generateReport: false,

--- a/src/modules/Builder/features/ActivityAbout/ActivityAbout.test.tsx
+++ b/src/modules/Builder/features/ActivityAbout/ActivityAbout.test.tsx
@@ -96,6 +96,7 @@ describe('ActivityAbout', () => {
       'builder-activity-about-skippable',
       'builder-activity-about-response-editable',
       'builder-activity-about-reviewable',
+      'builder-activity-about-auto-assign',
     ];
 
     fieldsDataTestIds.forEach((dataTestId) =>
@@ -124,6 +125,8 @@ describe('ActivityAbout', () => {
       'This Activity is intended for reviewer assessment only',
     );
     expect(isReviewable).not.toBeDisabled();
+    const isAutoAssign = screen.getByLabelText('Auto-assign this activity (as self-report)');
+    expect(isAutoAssign).toBeChecked();
   });
 
   test("shouldn't turn activity to reviewer one", () => {

--- a/src/modules/Builder/features/ActivityAbout/ActivityAbout.tsx
+++ b/src/modules/Builder/features/ActivityAbout/ActivityAbout.tsx
@@ -174,6 +174,20 @@ export const ActivityAbout = () => {
       onCustomChange: handleIsReviewableChange,
       'data-testid': 'builder-activity-about-reviewable',
     },
+    {
+      name: `${fieldName}.autoAssign`,
+      label: (
+        <StyledBodyLarge sx={{ position: 'relative' }}>
+          <span>{t('autoAssignActivity')}</span>
+          <Tooltip tooltipTitle={t('autoAssignTooltip')}>
+            <span>
+              <StyledCheckboxTooltipSvg id="more-info-outlined" />
+            </span>
+          </Tooltip>
+        </StyledBodyLarge>
+      ),
+      'data-testid': 'builder-activity-about-auto-assign',
+    },
   ];
 
   return (
@@ -209,20 +223,9 @@ export const ActivityAbout = () => {
         {t('itemLevelSettings')}
       </StyledTitleMedium>
       <StyledFlexColumn>
-        {checkboxes.map(
-          ({ name, label, isInversed, disabled, 'data-testid': dataTestid, onCustomChange }) => (
-            <CheckboxController
-              key={name}
-              control={control}
-              name={name}
-              label={label}
-              disabled={disabled}
-              isInversed={isInversed}
-              onCustomChange={onCustomChange}
-              data-testid={dataTestid}
-            />
-          ),
-        )}
+        {checkboxes.map((props) => (
+          <CheckboxController {...props} key={props.name} control={control} />
+        ))}
       </StyledFlexColumn>
     </BuilderContainer>
   );

--- a/src/modules/Builder/features/ActivityFlow/ActivityFlow.test.tsx
+++ b/src/modules/Builder/features/ActivityFlow/ActivityFlow.test.tsx
@@ -81,6 +81,7 @@ describe('ActivityFlow', () => {
       isSingleReport: false,
       hideBadge: false,
       isHidden: false,
+      autoAssign: true,
       items: activityFlowData.items,
     });
 

--- a/src/modules/Builder/features/ActivityFlowAbout/ActivityFlowAbout.test.tsx
+++ b/src/modules/Builder/features/ActivityFlowAbout/ActivityFlowAbout.test.tsx
@@ -66,11 +66,12 @@ describe('ActivityFlowAbout', () => {
   });
 
   test.each`
-    testId                                  | hasLabel | label                                   | tooltip                                                           | description
-    ${`${mockedFlowsTestid}-name`}          | ${true}  | ${'Activity Flow Name'}                 | ${''}                                                             | ${'New Activity Flow: Name'}
-    ${`${mockedFlowsTestid}-description`}   | ${true}  | ${'Activity Flow Description'}          | ${''}                                                             | ${'New Activity Flow: Description'}
-    ${`${mockedFlowsTestid}-single-report`} | ${false} | ${'Combine reports into a single file'} | ${''}                                                             | ${'New Activity Flow: Combine Reports'}
-    ${`${mockedFlowsTestid}-hide-badge`}    | ${false} | ${'Hide badge'}                         | ${'The Activity Flow identifier will be hidden from Respondents'} | ${'New Activity Flow: Hide Badge'}
+    testId                                  | hasLabel | label                                       | tooltip                                                           | description
+    ${`${mockedFlowsTestid}-name`}          | ${true}  | ${'Activity Flow Name'}                     | ${''}                                                             | ${'New Activity Flow: Name'}
+    ${`${mockedFlowsTestid}-description`}   | ${true}  | ${'Activity Flow Description'}              | ${''}                                                             | ${'New Activity Flow: Description'}
+    ${`${mockedFlowsTestid}-single-report`} | ${false} | ${'Combine reports into a single file'}     | ${''}                                                             | ${'New Activity Flow: Combine Reports'}
+    ${`${mockedFlowsTestid}-hide-badge`}    | ${false} | ${'Hide badge'}                             | ${'The Activity Flow identifier will be hidden from Respondents'} | ${'New Activity Flow: Hide Badge'}
+    ${`${mockedFlowsTestid}-auto-assign`}   | ${false} | ${'Auto-assign this flow (as self-report)'} | ${''}                                                             | ${'New Activity Flow: Auto-assign'}
   `('$description', async ({ testId, hasLabel, label, tooltip }) => {
     renderNewActivityFlowAbout();
 
@@ -92,6 +93,7 @@ describe('ActivityFlowAbout', () => {
     ${`${mockedFlowsTestid}-description`}   | ${'description'}    | ${'afd'} | ${'Existing Activity Flow: Description'}
     ${`${mockedFlowsTestid}-single-report`} | ${'isSingleReport'} | ${false} | ${'Existing Activity Flow: Combine Reports'}
     ${`${mockedFlowsTestid}-hide-badge`}    | ${'hideBadge'}      | ${false} | ${'Existing Activity Flow: Hide Badge'}
+    ${`${mockedFlowsTestid}-auto-assign`}   | ${'autoAssign'}     | ${true}  | ${'Existing Activity Flow: Auto-assign'}
   `('$description', ({ testId, attribute, value }) => {
     const ref = renderActivityFlowAbout();
 
@@ -108,6 +110,7 @@ describe('ActivityFlowAbout', () => {
     ${`${mockedFlowsTestid}-description`}   | ${'description'}    | ${'textarea'} | ${'Activity Flow Description'} | ${'Change Activity Flow: Description'}
     ${`${mockedFlowsTestid}-single-report`} | ${'isSingleReport'} | ${''}         | ${true}                        | ${'Change Activity Flow: Combine Reports'}
     ${`${mockedFlowsTestid}-hide-badge`}    | ${'hideBadge'}      | ${''}         | ${true}                        | ${'Change Activity Flow: Hide Badge'}
+    ${`${mockedFlowsTestid}-auto-assign`}   | ${'autoAssign'}     | ${''}         | ${false}                       | ${'Change Activity Flow: Auto-assign'}
   `('$description', ({ testId, attribute, inputType, value }) => {
     const ref = renderActivityFlowAbout();
 

--- a/src/modules/Builder/features/ActivityFlowAbout/ActivityFlowAbout.tsx
+++ b/src/modules/Builder/features/ActivityFlowAbout/ActivityFlowAbout.tsx
@@ -93,6 +93,22 @@ export const ActivityFlowAbout = () => {
             }
             data-testid={`${dataTestid}-hide-badge`}
           />
+          <CheckboxController
+            control={control}
+            key={`activityFlows.${activityFlowIndex}.autoAssign`}
+            name={`activityFlows.${activityFlowIndex}.autoAssign`}
+            label={
+              <StyledBodyLarge sx={{ position: 'relative' }}>
+                {t('autoAssignFlow')}
+                <Tooltip tooltipTitle={t('autoAssignTooltip')}>
+                  <span>
+                    <StyledSvg id="more-info-outlined" />
+                  </span>
+                </Tooltip>
+              </StyledBodyLarge>
+            }
+            data-testid={`${dataTestid}-auto-assign`}
+          />
         </StyledFlexColumn>
       </StyledWrapper>
     </BuilderContainer>

--- a/src/modules/Builder/pages/BuilderApplet/BuilderApplet.utils.tsx
+++ b/src/modules/Builder/pages/BuilderApplet/BuilderApplet.utils.tsx
@@ -348,6 +348,7 @@ export const getNewActivity = ({ name, activity }: GetNewActivity) => {
     isSkippable: false,
     responseIsEditable: true,
     isHidden: false,
+    autoAssign: true,
     ...activity,
     isReviewable: false,
     items,
@@ -643,6 +644,7 @@ export const getNewActivityFlow = () => ({
   isSingleReport: false,
   hideBadge: false,
   isHidden: false,
+  autoAssign: true,
 });
 
 const getActivityItemResponseValues = (item: Item) => {

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -1607,5 +1607,8 @@
     "contactSupport": "Contact Support",
     "proceedAnyway": "I wish to proceed anyway"
   },
+  "autoAssignActivity": "Auto-assign this activity (as self-report)",
+  "autoAssignFlow": "Auto-assign this flow (as self-report)",
+  "autoAssignTooltip": "Keep this box selected to automatically assign this Activity or Flow to all new Participants. If instead you’d like to manually assign Activities or Flows to your Participants (for either Self-Reporting or Multi-Informant reporting) unselect this box. You’ll then be able to assign Activities or Flows from the Activities Tab in your Applet.",
   "goToDashboard": "Go to Dashboard"
 }

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -1606,5 +1606,8 @@
     "contactSupport": "Contacter le support",
     "proceedAnyway": "Je souhaite continuer quand même"
   },
+  "autoAssignActivity": "Attribuer automatiquement cette activité (sous forme d'auto-évaluation)",
+  "autoAssignFlow": "Attribuer automatiquement ce flux (sous forme d'auto-évaluation)",
+  "autoAssignTooltip": "Gardez cette case cochée pour attribuer automatiquement cette activité ou ce flux à tous les nouveaux participants. Si, à la place, vous souhaitez attribuer manuellement des activités ou des flux à vos participants (pour une déclaration automatique ou une déclaration multi-informateurs), décochez cette case. Vous pourrez ensuite attribuer des activités ou des flux à partir de l'onglet Activités de votre applet.",
   "goToDashboard": "Aller au tableau de bord"
 }

--- a/src/shared/mock.ts
+++ b/src/shared/mock.ts
@@ -876,6 +876,7 @@ export const mockedAppletFormData = {
         },
       ],
       isReviewable: false,
+      autoAssign: true,
     },
   ],
   activityFlows: [
@@ -883,6 +884,7 @@ export const mockedAppletFormData = {
       name: 'af1',
       description: 'afd',
       isSingleReport: false,
+      autoAssign: true,
       hideBadge: false,
       reportIncludedActivityName: null,
       reportIncludedItemName: null,


### PR DESCRIPTION
https://github.com/ChildMindInstitute/mindlogger-admin/pull/1898 was applied on the release branch to remove M2-7390  (auto-assign checkbox on activity and flow) and was merged to main as part of v.1.36.0 release.

Main was subsequently [merged to dev 
](https://github.com/ChildMindInstitute/mindlogger-admin/pull/1900)

This PR reverts https://github.com/ChildMindInstitute/mindlogger-admin/pull/1898 to ensure M2-7390 is back in. 