### PR TITLE
Revert "fix: data export with large number of media files (M2-7626) (…

### DIFF
--- a/src/shared/utils/exportData/exportDataSucceed.test.ts
+++ b/src/shared/utils/exportData/exportDataSucceed.test.ts
@@ -123,7 +123,7 @@ describe('exportDataSucceed', () => {
     expect(exportMediaZipUtils.exportMediaZip).toHaveBeenNthCalledWith(
       1,
       [],
-      'media-responses-Sat Jan 01 2000-test',
+      'media-responses-Sat Jan 01 2000-test.zip',
     );
   };
 

--- a/src/shared/utils/exportData/exportDataSucceed.ts
+++ b/src/shared/utils/exportData/exportDataSucceed.ts
@@ -15,7 +15,7 @@ import {
 import { exportTemplate } from '../exportTemplate';
 import { exportCsvZip } from './exportCsvZip';
 import { exportMediaZip } from './exportMediaZip';
-import { getReportStringName, getReportZipName, ZipFile } from './getReportName';
+import { getReportZipName, ZipFile } from './getReportName';
 import { ExportDataFilters, prepareEncryptedData, prepareDecryptedData } from './prepareData';
 
 const exportProcessedData = async ({
@@ -44,7 +44,7 @@ const exportProcessedData = async ({
     exportCsvZip(stabilityTrackerItemsData, getReportZipName(ZipFile.StabilityTracker, suffix)),
     exportCsvZip(abTrailsItemsData, getReportZipName(ZipFile.ABTrails, suffix)),
     exportCsvZip(flankerItemsData, getReportZipName(ZipFile.Flanker, suffix)),
-    exportMediaZip(mediaData, getReportStringName(ZipFile.Media, suffix)),
+    exportMediaZip(mediaData, getReportZipName(ZipFile.Media, suffix)),
   ]);
 };
 

--- a/src/shared/utils/exportData/exportMediaZip.ts
+++ b/src/shared/utils/exportData/exportMediaZip.ts
@@ -2,56 +2,31 @@ import { ExportMediaData } from 'shared/types';
 
 import { exportZip } from './exportZip';
 
-const chunkArray = <T>(array: T[], size: number): T[][] => {
-  const result: T[][] = [];
-  let index = 0;
-  while (index < array.length) {
-    result.push(array.slice(index, index + size));
-    index += size;
-  }
-
-  return result;
-};
-
 export const exportMediaZip = async (mediaData: ExportMediaData[], reportName: string) => {
-  const mediaDataLength = mediaData.length;
-  if (!mediaDataLength) return;
-
-  const CHUNK_SIZE = 5;
-  const mediaChunks = chunkArray(mediaData, CHUNK_SIZE);
+  if (!mediaData.length) return;
 
   try {
-    for (let index = 0; index < mediaChunks.length; index++) {
-      const chunk = mediaChunks[index];
-      const settledFetchDataList = await Promise.allSettled(chunk.map(({ url }) => fetch(url)));
+    const settledFetchDataList = await Promise.allSettled(mediaData.map(({ url }) => fetch(url)));
+    const settledBlobDataList = await Promise.allSettled(
+      settledFetchDataList.map((settledFetchData) => {
+        if (settledFetchData.status === 'rejected') return Promise.reject(null);
 
-      const settledBlobDataList = await Promise.allSettled(
-        settledFetchDataList.map((settledFetchData) => {
-          if (settledFetchData.status === 'rejected') return Promise.reject(null);
+        return settledFetchData.value.blob();
+      }),
+    );
+    const mediaFiles = settledBlobDataList
+      .map((settledBlobData, index) => {
+        const { fileName } = mediaData[index];
+        if (settledBlobData.status === 'rejected') return null;
 
-          return settledFetchData.value.blob();
-        }),
-      );
+        return {
+          fileName,
+          file: settledBlobData.value,
+        };
+      })
+      .filter(Boolean);
 
-      const mediaFiles = settledBlobDataList
-        .map((settledBlobData, index) => {
-          const { fileName } = chunk[index];
-          if (settledBlobData.status === 'rejected') return null;
-
-          return {
-            fileName,
-            file: settledBlobData.value,
-          };
-        })
-        .filter(Boolean);
-
-      await exportZip(
-        mediaFiles as NonNullable<Parameters<typeof exportZip>[0]>,
-        `${reportName}-${mediaDataLength > CHUNK_SIZE ? index + 1 : ''}.zip`,
-      );
-
-      chunk.length = 0;
-    }
+    await exportZip(mediaFiles as NonNullable<Parameters<typeof exportZip>[0]>, reportName);
   } catch (error) {
     console.warn(error);
   }

--- a/src/shared/utils/exportData/getReportName.ts
+++ b/src/shared/utils/exportData/getReportName.ts
@@ -8,10 +8,8 @@ export const enum ZipFile {
   Flanker = 'flanker',
 }
 
-export const getReportStringName = (name: ZipFile, suffix: string) =>
-  `${name}-responses-${new Date().toDateString()}${suffix}`;
 export const getReportZipName = (name: ZipFile, suffix: string) =>
-  `${getReportStringName(name, suffix)}.zip`;
+  `${name}-responses-${new Date().toDateString()}${suffix}.zip`;
 
 export const getStabilityTrackerCsvName = (
   item: DecryptedAnswerData,


### PR DESCRIPTION
Reverts https://github.com/ChildMindInstitute/mindlogger-admin/pull/1896 [M2-7626](https://mindlogger.atlassian.net/browse/M2-7626) as it introduced an unwanted behavior during export, causing a large number of files to be downloaded instead of a single archive.

This reverts commit b68679f0b908a5ca2c605b40941b72c690ba5245.

[M2-7626]: https://mindlogger.atlassian.net/browse/M2-7626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ