### PR TITLE
fix: changed  loggedInUnserPlaceholder from the src/resources/app-en.…

### DIFF
--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -1411,7 +1411,7 @@
       "targetSubjectLabel": "Who are the responses about?",
       "targetSubjectPlaceholder": "Select from participants",
       "loggedInUserLabel": "Who will be inputting the responses?",
-      "loggedInUserPlaceholder": "Select from team members",
+      "loggedInUserPlaceholder": "Select from team members and participants",
       "dropdown": {
         "limitedAccountWarning": "The selected participant is unable to input their own answers. Please select a team member to continue."
       },

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -1410,7 +1410,7 @@
       "targetSubjectLabel": "De qui s’adressent les réponses?",
       "targetSubjectPlaceholder": "Sélectionnez parmi les participants",
       "loggedInUserLabel": "Qui saisira les réponses ?",
-      "loggedInUserPlaceholder": "Sélectionnez parmi les membres de l'équipe",
+      "loggedInUserPlaceholder": "Sélectionnez parmi les membres de l'équipe et les participant",
       "dropdown": {
         "limitedAccountWarning": "Le participant sélectionné ne peut pas saisir ses propres réponses. Veuillez sélectionner un membre de l'équipe pour continuer."
       },


### PR DESCRIPTION
### 📝 Description

Modiffied  text of  loggedInUnserPlaceholder from the src/resources/app-en.json to to "Select from team members and participants"


🔗 [Jira Ticket M2-7077](https://mindlogger.atlassian.net/browse/M2-7077?atlOrigin=eyJpIjoiZGY3ODg1N2QzNjJjNGZjNjhmNzRhMmIxNDMzODgzNDQiLCJwIjoiaiJ9)
[Take Now R2] The 'Who Will Input Responses' dropdown list is missing the 'and participants' text.


𝐏𝐫𝐞𝐜𝐨𝐧𝐝𝐢𝐭𝐢𝐨𝐧𝐬:

 Applet with Activities 

𝐒𝐭𝐞𝐩𝐬 𝐭𝐨 𝐫𝐞𝐩𝐫𝐨𝐝𝐮𝐜𝐞:

Login to the Admin and Select and Applet

- Select an Activity
- Click over 'Take Now'
- Click over the 'Who will be providing the responses' dropdown
- Select a Full Account as responder
- Uncheck the 'This person will be inputting their own responses' checkbox
- Review the text from 'Who will be inputting the responses?' dropdown list 
- Change: The previous text was: “Select from team members'
- R𝐞𝐬𝐮𝐥𝐭: new place holder "Select from team members and participants"

### 🪤 Peer Testing

Repeat steps and review chnages on