### PR TITLE
Fix: [M2-7169] update admin app "phrasal template" placeholder to "phrase builder"

### DIFF
--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -1040,7 +1040,7 @@
   "photoHint": "Photo capture task",
   "photoResponseDescription": "The respondent will be able to take or upload a photo.",
   "photoResponseTitle": "Photo Response",
-  "phrasalTemplate": "Phrasal Template",
+  "phrasalTemplate": "Phrase Builder",
   "phrasalTemplateItem": {
     "btnAddField": "Add…",
     "btnAddPhrase": "New Phrase",

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -1411,7 +1411,7 @@
       "targetSubjectLabel": "Who are the responses about?",
       "targetSubjectPlaceholder": "Select from participants",
       "loggedInUserLabel": "Who will be inputting the responses?",
-      "loggedInUserPlaceholder": "Select from team members",
+      "loggedInUserPlaceholder": "Select from team members and participants",
       "dropdown": {
         "limitedAccountWarning": "The selected participant is unable to input their own answers. Please select a team member to continue."
       },

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -1039,7 +1039,7 @@
   "photoHint": "Tâche de capture de photo",
   "photoResponseDescription": "Le participant pourra prendre ou uploader une photo.",
   "photoResponseTitle": "Réponse avec Photo",
-  "phrasalTemplate": "Modèle de phrase",
+  "phrasalTemplate": "Constructeur de phrases",
   "phrasalTemplateItem": {
     "btnAddField": "Ajouter…",
     "btnAddPhrase": "Nouvelle phrase",


### PR DESCRIPTION
### 📝 Description
[JIRA M@-7169](https://mindlogger.atlassian.net/browse/M2-7344?atlOrigin=eyJpIjoiZWFjYWM4YTY0NTZiNDU3NThhOGQ3ZGEzYWM0ZjViYTYiLCJwIjoiaiJ9)
[Phrase Builder Item Type] Updates to Copy in Admin App
This ticket addresses the changes requested to copy. This item is being renamed ‘Phrase Builder’ in the Admin app.

Changes include:

- [ ] Changed Phrasal Template to Phrase Builder on app-en.json 
- [ ] Verified Acctivities creation stage on admin app, dropdown. Phrase Builder effectively replace phrasal Template. 


### 📸 Screenshots

<img width="894" alt="image" src="https://github.com/user-attachments/assets/2abca20a-e75a-4906-be59-73930ce0b86c">


### 🪤 Peer Testing

* Create an activity, logged  into the admin app.
* Click the dropdown and go to the bottom. 
* The last entry should say Phrase Builder