### PR TITLE
fix:[M2-7169] Replaced Phrasal Template for Phrase Builder

### DIFF
--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -1040,7 +1040,7 @@
   "photoHint": "Photo capture task",
   "photoResponseDescription": "The respondent will be able to take or upload a photo.",
   "photoResponseTitle": "Photo Response",
-  "phrasalTemplate": "Phrasal Template",
+  "phrasalTemplate": "Phrase Builder",
   "phrasalTemplateItem": {
     "btnAddField": "Add…",
     "btnAddPhrase": "New Phrase",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -1039,7 +1039,7 @@
   "photoHint": "Tâche de capture de photo",
   "photoResponseDescription": "Le participant pourra prendre ou uploader une photo.",
   "photoResponseTitle": "Réponse avec Photo",
-  "phrasalTemplate": "Modèle de phrase",
+  "phrasalTemplate": "Constructeur de phrases",
   "phrasalTemplateItem": {
     "btnAddField": "Ajouter…",
     "btnAddPhrase": "Nouvelle phrase",


### PR DESCRIPTION
📝 Description
[JIRA M2-7169](https://mindlogger.atlassian.net/browse/M2-7344?atlOrigin=eyJpIjoiZWFjYWM4YTY0NTZiNDU3NThhOGQ3ZGEzYWM0ZjViYTYiLCJwIjoiaiJ9)
[Phrase Builder Item Type] Updates to Copy in Admin App
This ticket addresses the changes requested to copy. This item is being renamed ‘Phrase Builder’ in the Admin app.

Changes include:

 Changed Phrasal Template to Phrase Builder on app-en.json
  Changed Phrasal Template to Phrase Builder on app-fr.json

 Verified Acctivities creation stage on admin app, dropdown. Phrase Builder effectively replace phrasal Template.
📸 Screenshots

![image](https://github.com/user-attachments/assets/37bc84b7-4861-4386-92b4-31a289dfefef)

🪤 Peer Testing
Create an activity, logged into the admin app.
Click the dropdown and go to the bottom.
The last entry should say Phrase Builder