### PR TITLE
chore: wrap activity/flow auto-assign checkbox in feature flag (M2-7390)

### DIFF
--- a/src/modules/Builder/features/Activities/Activities.test.tsx
+++ b/src/modules/Builder/features/Activities/Activities.test.tsx
@@ -26,6 +26,7 @@ const mockedEmptyActivity = {
   responseIsEditable: true,
   isHidden: false,
   isReviewable: false,
+  autoAssign: true,
   items: [],
   scoresAndReports: {
     generateReport: false,

--- a/src/modules/Builder/features/ActivityAbout/ActivityAbout.test.tsx
+++ b/src/modules/Builder/features/ActivityAbout/ActivityAbout.test.tsx
@@ -96,6 +96,7 @@ describe('ActivityAbout', () => {
       'builder-activity-about-skippable',
       'builder-activity-about-response-editable',
       'builder-activity-about-reviewable',
+      'builder-activity-about-auto-assign',
     ];
 
     fieldsDataTestIds.forEach((dataTestId) =>
@@ -124,6 +125,8 @@ describe('ActivityAbout', () => {
       'This Activity is intended for reviewer assessment only',
     );
     expect(isReviewable).not.toBeDisabled();
+    const isAutoAssign = screen.getByLabelText('Auto-assign this activity (as self-report)');
+    expect(isAutoAssign).toBeChecked();
   });
 
   test("shouldn't turn activity to reviewer one", () => {

--- a/src/modules/Builder/features/ActivityAbout/ActivityAbout.tsx
+++ b/src/modules/Builder/features/ActivityAbout/ActivityAbout.tsx
@@ -174,6 +174,20 @@ export const ActivityAbout = () => {
       onCustomChange: handleIsReviewableChange,
       'data-testid': 'builder-activity-about-reviewable',
     },
+    {
+      name: `${fieldName}.autoAssign`,
+      label: (
+        <StyledBodyLarge sx={{ position: 'relative' }}>
+          <span>{t('autoAssignActivity')}</span>
+          <Tooltip tooltipTitle={t('autoAssignTooltip')}>
+            <span>
+              <StyledCheckboxTooltipSvg id="more-info-outlined" />
+            </span>
+          </Tooltip>
+        </StyledBodyLarge>
+      ),
+      'data-testid': 'builder-activity-about-auto-assign',
+    },
   ];
 
   return (
@@ -209,20 +223,9 @@ export const ActivityAbout = () => {
         {t('itemLevelSettings')}
       </StyledTitleMedium>
       <StyledFlexColumn>
-        {checkboxes.map(
-          ({ name, label, isInversed, disabled, 'data-testid': dataTestid, onCustomChange }) => (
-            <CheckboxController
-              key={name}
-              control={control}
-              name={name}
-              label={label}
-              disabled={disabled}
-              isInversed={isInversed}
-              onCustomChange={onCustomChange}
-              data-testid={dataTestid}
-            />
-          ),
-        )}
+        {checkboxes.map((props) => (
+          <CheckboxController {...props} key={props.name} control={control} />
+        ))}
       </StyledFlexColumn>
     </BuilderContainer>
   );

--- a/src/modules/Builder/features/ActivityAbout/ActivityAbout.tsx
+++ b/src/modules/Builder/features/ActivityAbout/ActivityAbout.tsx
@@ -29,6 +29,7 @@ import {
   useCustomFormContext,
 } from 'modules/Builder/hooks';
 import { getUpdatedActivityFlows } from 'modules/Builder/utils';
+import { useFeatureFlags } from 'shared/hooks';
 
 import { Uploads } from '../../components';
 import { StyledContainer } from './ActivityAbout.styles';
@@ -44,6 +45,7 @@ import {
 
 export const ActivityAbout = () => {
   const { t } = useTranslation();
+  const { featureFlags } = useFeatureFlags();
 
   useRedirectIfNoMatchedActivity();
 
@@ -174,20 +176,24 @@ export const ActivityAbout = () => {
       onCustomChange: handleIsReviewableChange,
       'data-testid': 'builder-activity-about-reviewable',
     },
-    {
-      name: `${fieldName}.autoAssign`,
-      label: (
-        <StyledBodyLarge sx={{ position: 'relative' }}>
-          <span>{t('autoAssignActivity')}</span>
-          <Tooltip tooltipTitle={t('autoAssignTooltip')}>
-            <span>
-              <StyledCheckboxTooltipSvg id="more-info-outlined" />
-            </span>
-          </Tooltip>
-        </StyledBodyLarge>
-      ),
-      'data-testid': 'builder-activity-about-auto-assign',
-    },
+    ...(featureFlags.enableActivityAssign
+      ? [
+          {
+            name: `${fieldName}.autoAssign`,
+            label: (
+              <StyledBodyLarge sx={{ position: 'relative' }}>
+                <span>{t('autoAssignActivity')}</span>
+                <Tooltip tooltipTitle={t('autoAssignTooltip')}>
+                  <span>
+                    <StyledCheckboxTooltipSvg id="more-info-outlined" />
+                  </span>
+                </Tooltip>
+              </StyledBodyLarge>
+            ),
+            'data-testid': 'builder-activity-about-auto-assign',
+          },
+        ]
+      : []),
   ];
 
   return (

--- a/src/modules/Builder/features/ActivityFlow/ActivityFlow.test.tsx
+++ b/src/modules/Builder/features/ActivityFlow/ActivityFlow.test.tsx
@@ -81,6 +81,7 @@ describe('ActivityFlow', () => {
       isSingleReport: false,
       hideBadge: false,
       isHidden: false,
+      autoAssign: true,
       items: activityFlowData.items,
     });
 

--- a/src/modules/Builder/features/ActivityFlowAbout/ActivityFlowAbout.test.tsx
+++ b/src/modules/Builder/features/ActivityFlowAbout/ActivityFlowAbout.test.tsx
@@ -10,6 +10,7 @@ import { mockedAppletFormData } from 'shared/mock';
 import { getEntityKey } from 'shared/utils';
 import { renderWithAppletFormData } from 'shared/utils/renderWithAppletFormData';
 import { getNewActivityFlow } from 'modules/Builder/pages/BuilderApplet/BuilderApplet.utils';
+import { useFeatureFlags } from 'shared/hooks';
 
 import { ActivityFlowAbout } from './ActivityFlowAbout';
 
@@ -60,9 +61,21 @@ const renderNewActivityFlowAbout = () => renderActivityFlowAbout(mockedAppletFor
 const renderActivityFlowAboutWithTwoFlows = () =>
   renderActivityFlowAbout(mockedAppletFormDataWithTwoFlows);
 
+jest.mock('shared/hooks/useFeatureFlags', () => ({
+  useFeatureFlags: jest.fn(),
+}));
+
+const mockUseFeatureFlags = jest.mocked(useFeatureFlags);
+
 describe('ActivityFlowAbout', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseFeatureFlags.mockReturnValue({
+      featureFlags: {
+        enableActivityAssign: true,
+      },
+      resetLDContext: jest.fn(),
+    });
   });
 
   test.each`
@@ -138,6 +151,21 @@ describe('ActivityFlowAbout', () => {
     await waitFor(() => {
       expect(screen.getByText(error)).toBeVisible();
     });
+  });
+
+  test('should hide auto assign checkbox based on feature flag', () => {
+    mockUseFeatureFlags.mockReturnValue({
+      featureFlags: {
+        enableActivityAssign: false,
+      },
+      resetLDContext: jest.fn(),
+    });
+
+    renderActivityFlowAbout();
+
+    const field = screen.queryByTestId(`${mockedFlowsTestid}-auto-assign`);
+
+    expect(field).toBeNull();
   });
 
   test('Validations: activity flow with existing name', async () => {

--- a/src/modules/Builder/features/ActivityFlowAbout/ActivityFlowAbout.test.tsx
+++ b/src/modules/Builder/features/ActivityFlowAbout/ActivityFlowAbout.test.tsx
@@ -66,11 +66,12 @@ describe('ActivityFlowAbout', () => {
   });
 
   test.each`
-    testId                                  | hasLabel | label                                   | tooltip                                                           | description
-    ${`${mockedFlowsTestid}-name`}          | ${true}  | ${'Activity Flow Name'}                 | ${''}                                                             | ${'New Activity Flow: Name'}
-    ${`${mockedFlowsTestid}-description`}   | ${true}  | ${'Activity Flow Description'}          | ${''}                                                             | ${'New Activity Flow: Description'}
-    ${`${mockedFlowsTestid}-single-report`} | ${false} | ${'Combine reports into a single file'} | ${''}                                                             | ${'New Activity Flow: Combine Reports'}
-    ${`${mockedFlowsTestid}-hide-badge`}    | ${false} | ${'Hide badge'}                         | ${'The Activity Flow identifier will be hidden from Respondents'} | ${'New Activity Flow: Hide Badge'}
+    testId                                  | hasLabel | label                                       | tooltip                                                           | description
+    ${`${mockedFlowsTestid}-name`}          | ${true}  | ${'Activity Flow Name'}                     | ${''}                                                             | ${'New Activity Flow: Name'}
+    ${`${mockedFlowsTestid}-description`}   | ${true}  | ${'Activity Flow Description'}              | ${''}                                                             | ${'New Activity Flow: Description'}
+    ${`${mockedFlowsTestid}-single-report`} | ${false} | ${'Combine reports into a single file'}     | ${''}                                                             | ${'New Activity Flow: Combine Reports'}
+    ${`${mockedFlowsTestid}-hide-badge`}    | ${false} | ${'Hide badge'}                             | ${'The Activity Flow identifier will be hidden from Respondents'} | ${'New Activity Flow: Hide Badge'}
+    ${`${mockedFlowsTestid}-auto-assign`}   | ${false} | ${'Auto-assign this flow (as self-report)'} | ${''}                                                             | ${'New Activity Flow: Auto-assign'}
   `('$description', async ({ testId, hasLabel, label, tooltip }) => {
     renderNewActivityFlowAbout();
 
@@ -92,6 +93,7 @@ describe('ActivityFlowAbout', () => {
     ${`${mockedFlowsTestid}-description`}   | ${'description'}    | ${'afd'} | ${'Existing Activity Flow: Description'}
     ${`${mockedFlowsTestid}-single-report`} | ${'isSingleReport'} | ${false} | ${'Existing Activity Flow: Combine Reports'}
     ${`${mockedFlowsTestid}-hide-badge`}    | ${'hideBadge'}      | ${false} | ${'Existing Activity Flow: Hide Badge'}
+    ${`${mockedFlowsTestid}-auto-assign`}   | ${'autoAssign'}     | ${true}  | ${'Existing Activity Flow: Auto-assign'}
   `('$description', ({ testId, attribute, value }) => {
     const ref = renderActivityFlowAbout();
 
@@ -108,6 +110,7 @@ describe('ActivityFlowAbout', () => {
     ${`${mockedFlowsTestid}-description`}   | ${'description'}    | ${'textarea'} | ${'Activity Flow Description'} | ${'Change Activity Flow: Description'}
     ${`${mockedFlowsTestid}-single-report`} | ${'isSingleReport'} | ${''}         | ${true}                        | ${'Change Activity Flow: Combine Reports'}
     ${`${mockedFlowsTestid}-hide-badge`}    | ${'hideBadge'}      | ${''}         | ${true}                        | ${'Change Activity Flow: Hide Badge'}
+    ${`${mockedFlowsTestid}-auto-assign`}   | ${'autoAssign'}     | ${''}         | ${false}                       | ${'Change Activity Flow: Auto-assign'}
   `('$description', ({ testId, attribute, inputType, value }) => {
     const ref = renderActivityFlowAbout();
 

--- a/src/modules/Builder/features/ActivityFlowAbout/ActivityFlowAbout.tsx
+++ b/src/modules/Builder/features/ActivityFlowAbout/ActivityFlowAbout.tsx
@@ -16,12 +16,15 @@ import { MAX_DESCRIPTION_LENGTH, MAX_NAME_LENGTH, TEXTAREA_ROWS_COUNT_SM } from 
 import { BuilderContainer } from 'shared/features';
 import { AppletFormValues } from 'modules/Builder/types';
 import { useRedirectIfNoMatchedActivityFlow } from 'modules/Builder/hooks';
+import { useFeatureFlags } from 'shared/hooks';
 
 import { getActivityFlowIndex } from '../ActivityFlowBuilder/ActivityFlowBuilder.utils';
 import { StyledWrapper, StyledSvg } from './ActivityFlowAbout.styles';
 
 export const ActivityFlowAbout = () => {
   const { t } = useTranslation();
+  const { featureFlags } = useFeatureFlags();
+
   const { control, watch } = useCustomFormContext();
   const { activityFlowId } = useParams();
 
@@ -93,22 +96,24 @@ export const ActivityFlowAbout = () => {
             }
             data-testid={`${dataTestid}-hide-badge`}
           />
-          <CheckboxController
-            control={control}
-            key={`activityFlows.${activityFlowIndex}.autoAssign`}
-            name={`activityFlows.${activityFlowIndex}.autoAssign`}
-            label={
-              <StyledBodyLarge sx={{ position: 'relative' }}>
-                {t('autoAssignFlow')}
-                <Tooltip tooltipTitle={t('autoAssignTooltip')}>
-                  <span>
-                    <StyledSvg id="more-info-outlined" />
-                  </span>
-                </Tooltip>
-              </StyledBodyLarge>
-            }
-            data-testid={`${dataTestid}-auto-assign`}
-          />
+          {featureFlags.enableActivityAssign && (
+            <CheckboxController
+              control={control}
+              key={`activityFlows.${activityFlowIndex}.autoAssign`}
+              name={`activityFlows.${activityFlowIndex}.autoAssign`}
+              label={
+                <StyledBodyLarge sx={{ position: 'relative' }}>
+                  {t('autoAssignFlow')}
+                  <Tooltip tooltipTitle={t('autoAssignTooltip')}>
+                    <span>
+                      <StyledSvg id="more-info-outlined" />
+                    </span>
+                  </Tooltip>
+                </StyledBodyLarge>
+              }
+              data-testid={`${dataTestid}-auto-assign`}
+            />
+          )}
         </StyledFlexColumn>
       </StyledWrapper>
     </BuilderContainer>

--- a/src/modules/Builder/features/ActivityFlowAbout/ActivityFlowAbout.tsx
+++ b/src/modules/Builder/features/ActivityFlowAbout/ActivityFlowAbout.tsx
@@ -93,6 +93,22 @@ export const ActivityFlowAbout = () => {
             }
             data-testid={`${dataTestid}-hide-badge`}
           />
+          <CheckboxController
+            control={control}
+            key={`activityFlows.${activityFlowIndex}.autoAssign`}
+            name={`activityFlows.${activityFlowIndex}.autoAssign`}
+            label={
+              <StyledBodyLarge sx={{ position: 'relative' }}>
+                {t('autoAssignFlow')}
+                <Tooltip tooltipTitle={t('autoAssignTooltip')}>
+                  <span>
+                    <StyledSvg id="more-info-outlined" />
+                  </span>
+                </Tooltip>
+              </StyledBodyLarge>
+            }
+            data-testid={`${dataTestid}-auto-assign`}
+          />
         </StyledFlexColumn>
       </StyledWrapper>
     </BuilderContainer>

--- a/src/modules/Builder/pages/BuilderApplet/BuilderApplet.utils.tsx
+++ b/src/modules/Builder/pages/BuilderApplet/BuilderApplet.utils.tsx
@@ -349,6 +349,7 @@ export const getNewActivity = ({ name, activity }: GetNewActivity) => {
     isSkippable: false,
     responseIsEditable: true,
     isHidden: false,
+    autoAssign: true,
     ...activity,
     isReviewable: false,
     items,
@@ -644,6 +645,7 @@ export const getNewActivityFlow = () => ({
   isSingleReport: false,
   hideBadge: false,
   isHidden: false,
+  autoAssign: true,
 });
 
 const getActivityItemResponseValues = (item: Item) => {

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -1613,5 +1613,8 @@
     "contactSupport": "Contact Support",
     "proceedAnyway": "I wish to proceed anyway"
   },
+  "autoAssignActivity": "Auto-assign this activity (as self-report)",
+  "autoAssignFlow": "Auto-assign this flow (as self-report)",
+  "autoAssignTooltip": "Keep this box selected to automatically assign this Activity or Flow to all new Participants. If instead you’d like to manually assign Activities or Flows to your Participants (for either Self-Reporting or Multi-Informant reporting) unselect this box. You’ll then be able to assign Activities or Flows from the Activities Tab in your Applet.",
   "goToDashboard": "Go to Dashboard"
 }

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -1612,5 +1612,8 @@
     "contactSupport": "Contacter le support",
     "proceedAnyway": "Je souhaite continuer quand même"
   },
+  "autoAssignActivity": "Attribuer automatiquement cette activité (sous forme d'auto-évaluation)",
+  "autoAssignFlow": "Attribuer automatiquement ce flux (sous forme d'auto-évaluation)",
+  "autoAssignTooltip": "Gardez cette case cochée pour attribuer automatiquement cette activité ou ce flux à tous les nouveaux participants. Si, à la place, vous souhaitez attribuer manuellement des activités ou des flux à vos participants (pour une déclaration automatique ou une déclaration multi-informateurs), décochez cette case. Vous pourrez ensuite attribuer des activités ou des flux à partir de l'onglet Activités de votre applet.",
   "goToDashboard": "Aller au tableau de bord"
 }

--- a/src/shared/mock.ts
+++ b/src/shared/mock.ts
@@ -876,6 +876,7 @@ export const mockedAppletFormData = {
         },
       ],
       isReviewable: false,
+      autoAssign: true,
     },
   ],
   activityFlows: [
@@ -883,6 +884,7 @@ export const mockedAppletFormData = {
       name: 'af1',
       description: 'afd',
       isSingleReport: false,
+      autoAssign: true,
       hideBadge: false,
       reportIncludedActivityName: null,
       reportIncludedItemName: null,


### PR DESCRIPTION
- [x] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to MindLogger [open source credit page](https://mindlogger.atlassian.net/wiki/spaces/MINDLOGGER1/pages/263127186/Admin+Panel+Applet+Builder+Library)
- [x] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

## Do not merge until release [1.37.0](https://github.com/ChildMindInstitute/mindlogger-admin/tree/release/1.37.0) has been deployed and merged back to `develop`
This PR reverts a [revert](https://github.com/ChildMindInstitute/mindlogger-admin/commit/3f9f0823295edbb798c6c20f2f944a62d0dfb563), bringing back the auto-assign checkbox, and now wrapped with a feature flag.

If you'd like to review this now before the above release is merged back to dev, ignore all commits except the last two:
- reverts the revert: 4ea6d1909ae18ab4261b6ea4a033a5297b797f18
- adds the feature flag: 44a0a9708ae32969f55d2e114694b282edd051fc

### 📝 Description

🔗 [Jira Ticket M2-7390](https://mindlogger.atlassian.net/browse/M2-7390)

This PR follows up on the initial [PR](https://github.com/ChildMindInstitute/mindlogger-admin/pull/1894) of [Jira Ticket M2-7390](https://mindlogger.atlassian.net/browse/M2-7390) to enable/disable the "auto assign" checkboxes on the "About Activity" and the "About Activity Flow" screens with a feature flag

### 📸 Screenshots

n/a

### 🪤 Peer Testing

Either in LaunchDarkly or by making a change locally in `src/shared/hooks/useFeatureFlags.ts`, change the `enableActivityAssign` flag value to true or false.
```
  const featureFlags = () => {
    const keys = Object.keys(FeatureFlagsKeys) as (keyof typeof FeatureFlagsKeys)[];
    const features: FeatureFlags = {};
    keys.forEach((key) => (features[key] = flags[FeatureFlagsKeys[key]]));
    features['enableActivityAssign'] = false;

    return features;
  };
``` 

1. Create an applet
2. Add an activity, and confirm the auto-assign checkbox is visible depending on the flag value
3. Add an activity flow, keeping the "auto assign" checkbox is visible depending on the flag value
4. When flag is off, confirm Applet can still be Saved & Published


### ✏️ Notes

N/A