### PR TITLE
feat: restrict PDP list to assigned activities (M2-7475)

### DIFF
--- a/src/modules/Dashboard/api/api.ts
+++ b/src/modules/Dashboard/api/api.ts
@@ -83,6 +83,8 @@ import {
   CreateTemporaryMultiInformantRelation,
   GetAssignmentsParams,
   PostAssignmentsParams,
+  GetSubjectActivitiesParams,
+  AppletSubjectActivitiesResponse,
 } from './api.types';
 import { DEFAULT_ROWS_PER_PAGE } from './api.const';
 import { ApiSuccessResponse } from './base.types';
@@ -917,6 +919,14 @@ export const getAppletActivitiesApi = (
 ) =>
   authApiClient.get(`/activities/applet/${appletId}`, {
     params,
+    signal,
+  });
+
+export const getAppletSubjectActivitiesApi = (
+  { appletId, subjectId }: GetSubjectActivitiesParams,
+  signal?: AbortSignal,
+): Promise<AxiosResponse<AppletSubjectActivitiesResponse>> =>
+  authApiClient.get(`/activities/applet/${appletId}/subject/${subjectId}`, {
     signal,
   });
 

--- a/src/modules/Dashboard/api/api.types.ts
+++ b/src/modules/Dashboard/api/api.types.ts
@@ -1,9 +1,11 @@
 import { ActivityId, AppletId } from 'shared/api';
-import { Activity, Item, SingleApplet, SubscaleSetting } from 'shared/state';
+import { Activity, ActivityFlow, Item, SingleApplet, SubscaleSetting } from 'shared/state';
 import { ParticipantTag, Roles } from 'shared/consts';
 import { RetentionPeriods, EncryptedAnswerSharedProps, ExportActivity } from 'shared/types';
 import { Encryption } from 'shared/utils';
 import { User } from 'modules/Auth/state';
+
+import { RespondentDetails } from '../types';
 
 export type GetAppletsParams = {
   params: {
@@ -29,6 +31,23 @@ export type GetActivitiesParams = {
     appletId: string;
     hasScore?: boolean;
     hasSubmitted?: boolean;
+  };
+};
+
+export type GetSubjectActivitiesParams = AppletId & SubjectId;
+
+export type HydratedAssignment = {
+  id: string;
+  activityId: string;
+  activityFlowId: string;
+  respondentSubject: RespondentDetails;
+  targetSubject: RespondentDetails;
+};
+
+export type AppletSubjectActivitiesResponse = {
+  result: {
+    activities: Array<Activity & { assignments: HydratedAssignment[] }>;
+    activityFlows: Array<ActivityFlow & { assignments: HydratedAssignment[] }>;
   };
 };
 

--- a/src/modules/Dashboard/components/ActivityGrid/ActivityGrid.tsx
+++ b/src/modules/Dashboard/components/ActivityGrid/ActivityGrid.tsx
@@ -14,13 +14,19 @@ export const ActivityGrid = ({
   onClickItem,
 }: ActivityGridProps) => {
   const { t } = useTranslation('app');
-  const { appletId } = useParams();
+  const { appletId, subjectId } = useParams();
 
   const isEmpty = !rows?.length;
 
   const getEmptyComponent = () => {
     if (isEmpty) {
-      return appletId ? t('noActivitiesForApplet') : t('noActivities');
+      if (subjectId) {
+        return t('noActivitiesForParticipant');
+      } else if (appletId) {
+        return t('noActivitiesForApplet');
+      } else {
+        return t('noActivities');
+      }
     }
   };
 

--- a/src/modules/Dashboard/features/Participant/Activities/Activities.tsx
+++ b/src/modules/Dashboard/features/Participant/Activities/Activities.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { generatePath, useNavigate, useParams } from 'react-router-dom';
 
-import { getAppletActivitiesApi } from 'api';
+import { getAppletSubjectActivitiesApi } from 'api';
 import { useAsync, useEncryptionStorage } from 'shared/hooks';
 import {
   ActivityActionProps,
@@ -47,17 +47,15 @@ export const Activities = () => {
   const workspaceRoles = workspaces.useRolesData();
   const roles = appletId ? workspaceRoles?.data?.[appletId] : undefined;
 
-  // TODO M2-6223: Update this call to include a `subject_id` param
   const {
     execute,
     isLoading: isLoadingActivities,
     value,
     previousValue,
-  } = useAsync(getAppletActivitiesApi);
-  const flows: ActivityFlow[] =
-    (value ?? previousValue)?.data?.result?.appletDetail?.activityFlows ?? [];
+  } = useAsync(getAppletSubjectActivitiesApi);
+  const flows: ActivityFlow[] = (value ?? previousValue)?.data?.result.activityFlows ?? [];
   const activities: Activity[] = useMemo(
-    () => (value ?? previousValue)?.data?.result?.activitiesDetails ?? [],
+    () => (value ?? previousValue)?.data?.result.activities ?? [],
     [value, previousValue],
   );
 
@@ -82,18 +80,17 @@ export const Activities = () => {
 
   const isLoadingSubject = subjectLoadingStatus === 'loading' || subjectLoadingStatus === 'idle';
   const isLoading = isLoadingActivities || isLoadingSubject;
-  const showContent =
-    (isLoading && previousValue?.data?.result?.activitiesDetails?.length > 0) || !isLoading;
+  const showContent = (isLoading && previousValue?.data?.result.activities?.length) || !isLoading;
 
   useEffect(() => {
-    if (!appletId) return;
+    if (!appletId || !subjectId) return;
 
-    execute({ params: { appletId } });
-  }, [appletId, execute]);
+    execute({ appletId, subjectId });
+  }, [appletId, execute, subjectId]);
 
   const formattedActivities = useMemo(
     () =>
-      (activities ?? []).map((activity) => {
+      activities.map((activity) => {
         const actions = {
           ...defaultActions,
           takeNow: ({ context }: MenuActionProps<ActivityActionProps>) => {

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataHeader/RespondentDataHeader.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataHeader/RespondentDataHeader.test.tsx
@@ -38,6 +38,8 @@ const mockedSubject: RespondentDetails = {
   userId: mockedRespondentId,
   ...mockedRespondent,
   id: mockedRespondentId,
+  firstName: 'John',
+  lastName: 'Doe',
 };
 
 const mockedActivity = {

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.test.tsx
@@ -67,6 +67,8 @@ const preloadedState = {
           lastSeen: '2023-12-15T23:29:36.150182',
           tag: 'Child' as ParticipantTag,
           userId: mockedRespondentId,
+          firstName: 'John',
+          lastName: 'Doe',
         },
       },
     },

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewMenu/ReviewMenu.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewMenu/ReviewMenu.test.tsx
@@ -59,6 +59,8 @@ const preloadedState = {
           lastSeen: null,
           tag: 'Child' as ParticipantTag,
           userId: null,
+          firstName: 'John',
+          lastName: 'Doe',
         },
       },
     },

--- a/src/modules/Dashboard/types/Dashboard.types.ts
+++ b/src/modules/Dashboard/types/Dashboard.types.ts
@@ -77,6 +77,8 @@ export type RespondentDetails = {
   lastSeen: string | null;
   tag?: ParticipantTag | null;
   userId: string | null;
+  firstName: string;
+  lastName: string;
 };
 
 export enum AccountType {

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -1600,6 +1600,7 @@
   "noAccessDescription": "To refresh the data, please click the button below.",
   "noActivities": "No activities found",
   "noActivitiesForApplet": "Applet has no activities",
+  "noActivitiesForParticipant": "No activities available for this participant",
   "noPermissionToViewData": "You do not have permission to view this data",
   "notInvited": "Not invited",
   "pending": "Pending",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -1597,6 +1597,7 @@
   "appletNameExists": "Ce nom d'Applet existe déjà",
   "noActivities": "Aucune activité trouvée",
   "noActivitiesForApplet": "L'applet n'a aucune activité",
+  "noActivitiesForParticipant": "Aucune activité disponible pour ce participant",
   "noAccessTitle": "Pas d'accès à l'applet",
   "noAccessDescription": "Pour rafraîchir les données, veuillez cliquer sur le bouton ci-dessous.",
   "noPermissionToViewData": "Vous n'avez pas la permission de voir ces données",

--- a/src/shared/mock.ts
+++ b/src/shared/mock.ts
@@ -47,6 +47,48 @@ export const mockedApplet = {
   encryption: mockedEncryption,
 } as Applet;
 
+export const mockedOwnerSubject = {
+  id: '123e4567-e89b-12d3-a456-426614174000',
+  secretUserId: 'mockedOwnerSecretId',
+  nickname: `${mockedUserData.firstName} ${mockedUserData.lastName}`,
+  lastSeen: null,
+  tag: 'Team' as ParticipantTag,
+  userId: null,
+  firstName: mockedUserData.firstName,
+  lastName: mockedUserData.lastName,
+};
+
+export const mockedOwnerRespondent = {
+  id: mockedUserData.id,
+  nicknames: [mockedOwnerSubject.nickname],
+  secretIds: [mockedOwnerSubject.secretUserId],
+  isAnonymousRespondent: false,
+  lastSeen: new Date().toDateString(),
+  isPinned: false,
+  accessId: '912e17b8-195f-4685-b77b-137539b9054d',
+  role: Roles.Owner,
+  details: [
+    {
+      appletId: mockedApplet.id,
+      appletDisplayName: mockedApplet.displayName,
+      appletImage: '',
+      accessId: '912e17b8-195f-4685-b77b-137539b9054d',
+      respondentNickname: mockedOwnerSubject.nickname,
+      respondentSecretId: mockedOwnerSubject.secretUserId,
+      hasIndividualSchedule: false,
+      encryption: mockedApplet.encryption,
+      subjectId: mockedOwnerSubject.id,
+      subjectTag: mockedOwnerSubject.tag,
+      subjectFirstName: mockedOwnerSubject.firstName,
+      subjectLastName: mockedOwnerSubject.lastName,
+      subjectCreatedAt: '2023-09-26T12:11:46.162083',
+      invitation: null,
+    },
+  ],
+  status: RespondentStatus.Invited,
+  email: mockedUserData.email,
+};
+
 export const mockedIdentifiers = [
   {
     identifier: '09a0bbf7994d5cf408292d7fb35dce18:e8051724b3f422950c1b0eb9c7013c72',

--- a/src/shared/state/Applet/Applet.schema.ts
+++ b/src/shared/state/Applet/Applet.schema.ts
@@ -45,6 +45,7 @@ export type ActivityFlow = {
   createdAt?: string;
   reportIncludedItemName?: string;
   reportIncludedActivityName?: string;
+  autoAssign?: boolean;
 };
 
 export type TextInputConfig = {
@@ -781,6 +782,7 @@ export type Activity = {
   performanceTaskType?: PerfTaskType | null;
   createdAt?: string;
   reportIncludedItemName?: string;
+  autoAssign?: boolean;
 };
 
 type Theme = {

--- a/src/shared/utils/axios-mocks.ts
+++ b/src/shared/utils/axios-mocks.ts
@@ -23,7 +23,7 @@ export const mockGetRequestResponses = (
 
       return Promise.resolve(responses[url]);
     } else {
-      return Promise.reject(`No response provided for ${url}`);
+      throw new Error(`No response provided for ${url}`);
     }
   });
 };


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to MindLogger [open source credit page](https://mindlogger.atlassian.net/wiki/spaces/MINDLOGGER1/pages/263127186/Admin+Panel+Applet+Builder+Library)
- [ ] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-7475](https://mindlogger.atlassian.net/browse/M2-7475)

This PR does a first-pass of incorporating MI Assign into the Participant Details Page (PDP). It calls the newly introduced endpoint, `/activities/applet/{applet_id}/subject/{subject_id}`, to restrict that page to only those activities/flows that are assigned to the current participant, either as the respondent or the target subject.

Also updated tests to reflect this change. In doing so, moved definition of `mockedOwnerSubject` to the shared `mock.ts` file, and aligned the subject details in the `preloadedState` with that subject. This required making small tweaks to two tests.

### 📸 Screenshots

N/A

### 🪤 Peer Testing

Refer to [AC of ticket](https://mindlogger.atlassian.net/browse/M2-7475) in Jira.