### PR TITLE
fix: substitute Phrasal Template to Phrase Builder on tiitleHint

### DIFF
--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -1063,7 +1063,7 @@
     "imageLabel": "Add a header image for this phrase (optional)",
     "lede": "The respondent will see the content below displayed in a downloadable card.",
     "phraseOrder": "Phrase {{order}}",
-    "titleHint": "Displayed in the header of the Phrasal Template output, alongside the Applet name and image.",
+    "titleHint": "Displayed in the header of the Phrase Builder output, alongside the Applet name and image.",
     "titleHintLabel": "See more details",
     "titleLabel": "Card Title (Required)",
     "titlePlaceholder": "Example: Action Plan",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -1062,7 +1062,7 @@
     "imageLabel": "Ajouter une image d'en-tête pour cette phrase (facultatif)",
     "lede": "Le répondant verra le contenu ci-dessous affiché dans une carte téléchargeable.",
     "phraseOrder": "Phrase {{order}}",
-    "titleHint": "Affiché dans l'en-tête de la sortie du modèle de phrase, à côté du nom et de l'image de l'applet.",
+    "titleHint": "Affiché dans l'en-tête du Constructeur de phrases, à côté du nom et de l'image de l'applet.",
     "titleHintLabel": "Voir plus de détails",
     "titleLabel": "Titre de la carte (obligatoire)",
     "titlePlaceholder": "Exemple: Plan d'action",


### PR DESCRIPTION
### 📝 Description

[Jira Ticket M2-7344](https://mindlogger.atlassian.net/jira/software/c/projects/M2/boards/4?assignee=712020%3A6322a990-2eaf-42f4-9fed-30af94baf20e&selectedIssue=M2-7344)

Substitute Phrasal Template to Phrase Builder on tiitleHint. The original text was: 
    "titleHint": "Displayed in the header of the Phrasal Template output, alongside the Applet name and image.",
 Replaced to:
    "titleHint": "Displayed in the header of the Phrase Builder output, alongside the Applet name and image.",

displayed on card Title and phrase instructions

- [Changes english version]
- [Changed french version]

### 📸 Screenshots

<img width="980" alt="image" src="https://github.com/user-attachments/assets/5c88797f-8ac5-40dd-a91a-f5d72caad4e7">
<img width="980" alt="image" src="https://github.com/user-attachments/assets/4014c3b9-16d0-48cd-8ae6-8332af8cd6b8">


### 🪤 Peer Testing

* Create an new Phrase Builder Item.
* On the Phrase Builder form click on the question mar to diplay the new message

### ✏️ Notes

* Checked for any additional Phrasal Template inside the code (strings)
* There aren't any 'Phrasal Template' mentions inside the app. 