### PR TITLE
feat: disable auto-assigned activities/flows from assignment (M2-7604)

### DIFF
--- a/src/modules/Dashboard/components/ActivityAssignDrawer/ActivitiesList/ActivitiesList.tsx
+++ b/src/modules/Dashboard/components/ActivityAssignDrawer/ActivitiesList/ActivitiesList.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { ListItemIcon, ListItemText } from '@mui/material';
 
-import { Chip, ChipShape, Svg } from 'shared/components';
+import { Chip, ChipShape, Svg, Tooltip } from 'shared/components';
 import { ActivityFlowThumbnail } from 'modules/Dashboard/components';
 import { StyledActivityThumbnailContainer, StyledActivityThumbnailImg } from 'shared/styles';
 import { useFeatureFlags } from 'shared/hooks';
@@ -55,74 +55,86 @@ export const ActivitiesList = ({
   return (
     <StyledList data-testid={dataTestId} sx={isReadOnly ? { height: 'auto', py: 0.5 } : undefined}>
       {flows.map(({ id = '', activities, name, autoAssign }) => (
-        <StyledListItem
-          key={id}
-          secondaryAction={
-            isReadOnly ? undefined : (
-              <ActivityCheckbox
-                checked={flowIds?.includes(id)}
-                onChange={() => handleFlowClick(id)}
-                data-testid={`${dataTestId}-flow-checkbox-${id}`}
-                disabled={enableActivityAssignFlag ? autoAssign : undefined}
-              />
-            )
-          }
-          data-testid={`${dataTestId}-flow-item`}
+        <Tooltip
+          placement="left"
+          tooltipTitle={enableActivityAssignFlag && autoAssign && t('autoAssignFlowDisabled')}
         >
-          <ButtonComponent
-            onClick={isReadOnly ? undefined : () => handleFlowClick(id)}
-            disabled={enableActivityAssignFlag ? autoAssign : undefined}
+          <StyledListItem
+            key={id}
+            secondaryAction={
+              isReadOnly ? undefined : (
+                <ActivityCheckbox
+                  checked={flowIds?.includes(id)}
+                  onChange={() => handleFlowClick(id)}
+                  data-testid={`${dataTestId}-flow-checkbox-${id}`}
+                  disabled={enableActivityAssignFlag ? autoAssign : undefined}
+                />
+              )
+            }
+            data-testid={`${dataTestId}-flow-item`}
           >
-            <ListItemIcon>
-              <StyledActivityThumbnailContainer sx={{ width: '4.8rem', height: '4.8rem' }}>
-                <ActivityFlowThumbnail activities={activities} />
-              </StyledActivityThumbnailContainer>
-            </ListItemIcon>
-            <ListItemText
-              primary={
-                <StyledListItemTextPrimary>
-                  {name}
-                  <Chip
-                    color="secondary"
-                    size="medium"
-                    icon={<Svg aria-hidden id="multiple-activities" height={18} width={18} />}
-                    shape={ChipShape.Rectangular}
-                    title={t('flow')}
-                  />
-                </StyledListItemTextPrimary>
-              }
-            />
-          </ButtonComponent>
-        </StyledListItem>
+            <ButtonComponent
+              onClick={isReadOnly ? undefined : () => handleFlowClick(id)}
+              disabled={enableActivityAssignFlag ? autoAssign : undefined}
+            >
+              <ListItemIcon>
+                <StyledActivityThumbnailContainer sx={{ width: '4.8rem', height: '4.8rem' }}>
+                  <ActivityFlowThumbnail activities={activities} />
+                </StyledActivityThumbnailContainer>
+              </ListItemIcon>
+              <ListItemText
+                primary={
+                  <StyledListItemTextPrimary>
+                    {name}
+                    <Chip
+                      color="secondary"
+                      size="medium"
+                      icon={<Svg aria-hidden id="multiple-activities" height={18} width={18} />}
+                      shape={ChipShape.Rectangular}
+                      title={t('flow')}
+                    />
+                  </StyledListItemTextPrimary>
+                }
+              />
+            </ButtonComponent>
+          </StyledListItem>
+        </Tooltip>
       ))}
 
       {activities.map(({ id = '', name, image, autoAssign }) => (
-        <StyledListItem
-          key={id}
-          secondaryAction={
-            isReadOnly ? undefined : (
-              <ActivityCheckbox
-                checked={activityIds?.includes(id)}
-                onChange={() => handleActivityClick(id)}
-                data-testid={`${dataTestId}-activity-checkbox-${id}`}
-                disabled={enableActivityAssignFlag ? autoAssign : undefined}
-              />
-            )
-          }
-          data-testid={`${dataTestId}-activity-item`}
+        <Tooltip
+          placement="left"
+          tooltipTitle={enableActivityAssignFlag && autoAssign && t('autoAssignActivityDisabled')}
         >
-          <ButtonComponent
-            onClick={isReadOnly ? undefined : () => handleActivityClick(id)}
-            disabled={enableActivityAssignFlag ? autoAssign : undefined}
+          <StyledListItem
+            key={id}
+            secondaryAction={
+              isReadOnly ? undefined : (
+                <ActivityCheckbox
+                  checked={activityIds?.includes(id)}
+                  onChange={() => handleActivityClick(id)}
+                  data-testid={`${dataTestId}-activity-checkbox-${id}`}
+                  disabled={enableActivityAssignFlag ? autoAssign : undefined}
+                />
+              )
+            }
+            data-testid={`${dataTestId}-activity-item`}
           >
-            <ListItemIcon>
-              <StyledActivityThumbnailContainer sx={{ width: '4.8rem', height: '4.8rem' }}>
-                {!!image && <StyledActivityThumbnailImg src={image} alt={name} />}
-              </StyledActivityThumbnailContainer>
-            </ListItemIcon>
-            <ListItemText primary={<StyledListItemTextPrimary>{name}</StyledListItemTextPrimary>} />
-          </ButtonComponent>
-        </StyledListItem>
+            <ButtonComponent
+              onClick={isReadOnly ? undefined : () => handleActivityClick(id)}
+              disabled={enableActivityAssignFlag ? autoAssign : undefined}
+            >
+              <ListItemIcon>
+                <StyledActivityThumbnailContainer sx={{ width: '4.8rem', height: '4.8rem' }}>
+                  {!!image && <StyledActivityThumbnailImg src={image} alt={name} />}
+                </StyledActivityThumbnailContainer>
+              </ListItemIcon>
+              <ListItemText
+                primary={<StyledListItemTextPrimary>{name}</StyledListItemTextPrimary>}
+              />
+            </ButtonComponent>
+          </StyledListItem>
+        </Tooltip>
       ))}
     </StyledList>
   );

--- a/src/modules/Dashboard/components/ActivityAssignDrawer/ActivitiesList/ActivitiesList.tsx
+++ b/src/modules/Dashboard/components/ActivityAssignDrawer/ActivitiesList/ActivitiesList.tsx
@@ -4,6 +4,7 @@ import { ListItemIcon, ListItemText } from '@mui/material';
 import { Chip, ChipShape, Svg } from 'shared/components';
 import { ActivityFlowThumbnail } from 'modules/Dashboard/components';
 import { StyledActivityThumbnailContainer, StyledActivityThumbnailImg } from 'shared/styles';
+import { useFeatureFlags } from 'shared/hooks';
 
 import {
   StyledList,
@@ -26,6 +27,8 @@ export const ActivitiesList = ({
   'data-testid': dataTestId,
 }: ActivitiesListProps) => {
   const { t } = useTranslation('app');
+  const { featureFlags } = useFeatureFlags();
+  const enableActivityAssignFlag = featureFlags.enableActivityAssign;
 
   const handleActivityClick = (id: string) => {
     if (!activityIds || !onChangeActivityIds) return;
@@ -51,7 +54,7 @@ export const ActivitiesList = ({
 
   return (
     <StyledList data-testid={dataTestId} sx={isReadOnly ? { height: 'auto', py: 0.5 } : undefined}>
-      {flows.map(({ id = '', activities, name }) => (
+      {flows.map(({ id = '', activities, name, autoAssign }) => (
         <StyledListItem
           key={id}
           secondaryAction={
@@ -60,12 +63,16 @@ export const ActivitiesList = ({
                 checked={flowIds?.includes(id)}
                 onChange={() => handleFlowClick(id)}
                 data-testid={`${dataTestId}-flow-checkbox-${id}`}
+                disabled={enableActivityAssignFlag ? autoAssign : undefined}
               />
             )
           }
           data-testid={`${dataTestId}-flow-item`}
         >
-          <ButtonComponent onClick={isReadOnly ? undefined : () => handleFlowClick(id)}>
+          <ButtonComponent
+            onClick={isReadOnly ? undefined : () => handleFlowClick(id)}
+            disabled={enableActivityAssignFlag ? autoAssign : undefined}
+          >
             <ListItemIcon>
               <StyledActivityThumbnailContainer sx={{ width: '4.8rem', height: '4.8rem' }}>
                 <ActivityFlowThumbnail activities={activities} />
@@ -89,7 +96,7 @@ export const ActivitiesList = ({
         </StyledListItem>
       ))}
 
-      {activities.map(({ id = '', name, image }) => (
+      {activities.map(({ id = '', name, image, autoAssign }) => (
         <StyledListItem
           key={id}
           secondaryAction={
@@ -98,12 +105,16 @@ export const ActivitiesList = ({
                 checked={activityIds?.includes(id)}
                 onChange={() => handleActivityClick(id)}
                 data-testid={`${dataTestId}-activity-checkbox-${id}`}
+                disabled={enableActivityAssignFlag ? autoAssign : undefined}
               />
             )
           }
           data-testid={`${dataTestId}-activity-item`}
         >
-          <ButtonComponent onClick={isReadOnly ? undefined : () => handleActivityClick(id)}>
+          <ButtonComponent
+            onClick={isReadOnly ? undefined : () => handleActivityClick(id)}
+            disabled={enableActivityAssignFlag ? autoAssign : undefined}
+          >
             <ListItemIcon>
               <StyledActivityThumbnailContainer sx={{ width: '4.8rem', height: '4.8rem' }}>
                 {!!image && <StyledActivityThumbnailImg src={image} alt={name} />}

--- a/src/modules/Dashboard/components/ActivityAssignDrawer/ActivitiesList/ActivitiesList.tsx
+++ b/src/modules/Dashboard/components/ActivityAssignDrawer/ActivitiesList/ActivitiesList.tsx
@@ -4,7 +4,6 @@ import { ListItemIcon, ListItemText } from '@mui/material';
 import { Chip, ChipShape, Svg, Tooltip } from 'shared/components';
 import { ActivityFlowThumbnail } from 'modules/Dashboard/components';
 import { StyledActivityThumbnailContainer, StyledActivityThumbnailImg } from 'shared/styles';
-import { useFeatureFlags } from 'shared/hooks';
 
 import {
   StyledList,
@@ -27,8 +26,6 @@ export const ActivitiesList = ({
   'data-testid': dataTestId,
 }: ActivitiesListProps) => {
   const { t } = useTranslation('app');
-  const { featureFlags } = useFeatureFlags();
-  const enableActivityAssignFlag = featureFlags.enableActivityAssign;
 
   const handleActivityClick = (id: string) => {
     if (!activityIds || !onChangeActivityIds) return;
@@ -55,10 +52,7 @@ export const ActivitiesList = ({
   return (
     <StyledList data-testid={dataTestId} sx={isReadOnly ? { height: 'auto', py: 0.5 } : undefined}>
       {flows.map(({ id = '', activities, name, autoAssign }) => (
-        <Tooltip
-          placement="left"
-          tooltipTitle={enableActivityAssignFlag && autoAssign && t('autoAssignFlowDisabled')}
-        >
+        <Tooltip placement="left" tooltipTitle={autoAssign && t('autoAssignFlowDisabled')}>
           <StyledListItem
             key={id}
             secondaryAction={
@@ -67,7 +61,7 @@ export const ActivitiesList = ({
                   checked={flowIds?.includes(id)}
                   onChange={() => handleFlowClick(id)}
                   data-testid={`${dataTestId}-flow-checkbox-${id}`}
-                  disabled={enableActivityAssignFlag ? autoAssign : undefined}
+                  disabled={autoAssign}
                 />
               )
             }
@@ -75,7 +69,7 @@ export const ActivitiesList = ({
           >
             <ButtonComponent
               onClick={isReadOnly ? undefined : () => handleFlowClick(id)}
-              disabled={enableActivityAssignFlag ? autoAssign : undefined}
+              disabled={autoAssign}
             >
               <ListItemIcon>
                 <StyledActivityThumbnailContainer sx={{ width: '4.8rem', height: '4.8rem' }}>
@@ -102,10 +96,7 @@ export const ActivitiesList = ({
       ))}
 
       {activities.map(({ id = '', name, image, autoAssign }) => (
-        <Tooltip
-          placement="left"
-          tooltipTitle={enableActivityAssignFlag && autoAssign && t('autoAssignActivityDisabled')}
-        >
+        <Tooltip placement="left" tooltipTitle={autoAssign && t('autoAssignActivityDisabled')}>
           <StyledListItem
             key={id}
             secondaryAction={
@@ -114,7 +105,7 @@ export const ActivitiesList = ({
                   checked={activityIds?.includes(id)}
                   onChange={() => handleActivityClick(id)}
                   data-testid={`${dataTestId}-activity-checkbox-${id}`}
-                  disabled={enableActivityAssignFlag ? autoAssign : undefined}
+                  disabled={autoAssign}
                 />
               )
             }
@@ -122,7 +113,7 @@ export const ActivitiesList = ({
           >
             <ButtonComponent
               onClick={isReadOnly ? undefined : () => handleActivityClick(id)}
-              disabled={enableActivityAssignFlag ? autoAssign : undefined}
+              disabled={autoAssign}
             >
               <ListItemIcon>
                 <StyledActivityThumbnailContainer sx={{ width: '4.8rem', height: '4.8rem' }}>

--- a/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityAssignDrawer.test.tsx
+++ b/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityAssignDrawer.test.tsx
@@ -264,7 +264,7 @@ describe('ActivityAssignDrawer', () => {
     });
   });
 
-  it('toggles selection of all activities and flows when toggling Select All', async () => {
+  it('toggles selection of all non-disabled activities and flows when toggling Select All', async () => {
     renderWithProviders(
       <ActivityAssignDrawer appletId={mockedAppletId} open onClose={mockedOnClose} />,
       { preloadedState },
@@ -279,12 +279,22 @@ describe('ActivityAssignDrawer', () => {
 
       fireEvent.click(selectAll);
       [...activities, ...flows].forEach((checkbox) => {
-        expect(within(checkbox).getByRole('checkbox')).toBeChecked();
+        const checkboxElement = within(checkbox).getByRole('checkbox');
+        const itemIsNotDisabled = checkboxElement.getAttribute('disable') === 'false';
+
+        if (itemIsNotDisabled) {
+          expect(checkboxElement).toBeChecked();
+        }
       });
 
       fireEvent.click(selectAll);
       [...activities, ...flows].forEach((checkbox) => {
-        expect(within(checkbox).getByRole('checkbox')).not.toBeChecked();
+        const checkboxElement = within(checkbox).getByRole('checkbox');
+        const itemIsNotDisabled = checkboxElement.getAttribute('disable') === 'false';
+
+        if (itemIsNotDisabled) {
+          expect(checkboxElement).not.toBeChecked();
+        }
       });
     });
   });

--- a/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityAssignDrawer.tsx
+++ b/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityAssignDrawer.tsx
@@ -21,7 +21,7 @@ import {
 } from 'shared/styles';
 import { Spinner, Svg, Tooltip } from 'shared/components';
 import { HydratedActivityFlow } from 'modules/Dashboard/types';
-import { useAsync, useFeatureFlags } from 'shared/hooks';
+import { useAsync } from 'shared/hooks';
 import {
   Assignment,
   getAppletActivitiesApi,
@@ -72,8 +72,6 @@ export const ActivityAssignDrawer = ({
   ...rest
 }: ActivityAssignDrawerProps) => {
   const { t } = useTranslation('app', { keyPrefix: 'activityAssign' });
-  const { featureFlags } = useFeatureFlags();
-  const enableActivityAssignFlag = featureFlags.enableActivityAssign;
 
   const drawerRef = useRef<HTMLDivElement>(null);
   const [showHelpPopup, setShowHelpPopup] = useState(false);
@@ -181,31 +179,18 @@ export const ActivityAssignDrawer = ({
     drawerRef.current?.scrollTo({ top, behavior: 'smooth' });
   };
 
-  // Note: Once 'enableActivityAssignFlag flag is removed, the following variables can be
-  // simplified and replaced by the logic w/in the `if` block.
-  let assignableActivities = activities.map(({ id = '' }) => id);
-  let assignableFlows = flows.map(({ id = '' }) => id);
-  let activitiesCount = activities.length + flows.length;
-  let selectAllIsChecked = selectionCount === activitiesCount;
-  let disableSelectAll;
+  const assignableActivities = activities
+    .map(({ autoAssign, id = '' }) => !autoAssign && id)
+    .filter((activity) => !!activity) as [] | string[];
 
-  if (enableActivityAssignFlag) {
-    assignableActivities = activities
-      .map(({ autoAssign, id = '' }) => !autoAssign && id)
-      .filter((activity) => !!activity) as [] | string[];
+  const assignableFlows = flows
+    .map(({ autoAssign, id = '' }) => !autoAssign && id)
+    .filter((flow) => !!flow) as [] | string[];
 
-    assignableFlows = flows
-      .map(({ autoAssign, id = '' }) => !autoAssign && id)
-      .filter((flow) => !!flow) as [] | string[];
-
-    activitiesCount = assignableActivities.length + assignableFlows.length;
-    selectAllIsChecked = activitiesCount !== 0 && selectionCount === activitiesCount;
-
-    disableSelectAll =
-      activities.every(({ autoAssign }) => autoAssign) &&
-      flows.every(({ autoAssign }) => autoAssign);
-  }
-  // ---
+  const activitiesCount = assignableActivities.length + assignableFlows.length;
+  const selectAllIsChecked = activitiesCount !== 0 && selectionCount === activitiesCount;
+  const disableSelectAll =
+    activities.every(({ autoAssign }) => autoAssign) && flows.every(({ autoAssign }) => autoAssign);
 
   const handleSelectAll = () => {
     if (selectionCount === activitiesCount) {

--- a/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityCheckbox/ActivityCheckbox.tsx
+++ b/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityCheckbox/ActivityCheckbox.tsx
@@ -9,7 +9,9 @@ export const ActivityCheckbox = (props: CheckboxProps) => (
       <Svg
         id="add-circle"
         fill={
-          props.disabled ? variables.palette.outline_variant : variables.palette.on_surface_variant
+          props.disabled
+            ? variables.palette.on_surface_variant_alfa16
+            : variables.palette.on_surface_variant
         }
       />
     }

--- a/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityCheckbox/ActivityCheckbox.tsx
+++ b/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityCheckbox/ActivityCheckbox.tsx
@@ -5,7 +5,14 @@ import { variables } from 'shared/styles';
 
 export const ActivityCheckbox = (props: CheckboxProps) => (
   <Checkbox
-    icon={<Svg id="add-circle" fill={variables.palette.on_surface_variant} />}
+    icon={
+      <Svg
+        id="add-circle"
+        fill={
+          props.disabled ? variables.palette.outline_variant : variables.palette.on_surface_variant
+        }
+      />
+    }
     checkedIcon={<Svg id="check-circle" fill={variables.palette.green} />}
     sx={{ p: 0, m: 0, pointerEvents: 'none' }}
     tabIndex={-1}

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -1622,5 +1622,7 @@
   "autoAssignActivity": "Auto-assign this activity (as self-report)",
   "autoAssignFlow": "Auto-assign this flow (as self-report)",
   "autoAssignTooltip": "Keep this box selected to automatically assign this Activity or Flow to all new Participants. If instead you’d like to manually assign Activities or Flows to your Participants (for either Self-Reporting or Multi-Informant reporting) unselect this box. You’ll then be able to assign Activities or Flows from the Activities Tab in your Applet.",
+  "autoAssignActivityDisabled": "This activity is set to ‘Auto-assign’ in the Activity Builder and therefore cannot be assigned here.",
+  "autoAssignFlowDisabled": "This flow is set to ‘Auto-assign’ in the Activity Flow Builder and therefore cannot be assigned here.",
   "goToDashboard": "Go to Dashboard"
 }

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -1621,5 +1621,7 @@
   "autoAssignActivity": "Attribuer automatiquement cette activité (sous forme d'auto-évaluation)",
   "autoAssignFlow": "Attribuer automatiquement ce flux (sous forme d'auto-évaluation)",
   "autoAssignTooltip": "Gardez cette case cochée pour attribuer automatiquement cette activité ou ce flux à tous les nouveaux participants. Si, à la place, vous souhaitez attribuer manuellement des activités ou des flux à vos participants (pour une déclaration automatique ou une déclaration multi-informateurs), décochez cette case. Vous pourrez ensuite attribuer des activités ou des flux à partir de l'onglet Activités de votre applet.",
+  "autoAssignActivityDisabled": "Cette activité est paramétrée sur « Attribution automatique » dans le générateur d'activités et ne peut donc pas être attribuée ici.",
+  "autoAssignFlowDisabled": "Ce flux est défini sur « Auto-assign » dans l'Activity Flow Builder et ne peut donc pas être affecté ici.",
   "goToDashboard": "Aller au tableau de bord"
 }

--- a/src/shared/styles/variables/palette.ts
+++ b/src/shared/styles/variables/palette.ts
@@ -33,6 +33,7 @@ export const palette = {
   on_surface_alfa38: 'rgba(26, 28, 30, 0.38)',
   on_surface_variant_alfa8: 'rgba(66, 71, 78, 0.08)',
   on_surface_variant_alfa12: 'rgba(66, 71, 78, 0.12)',
+  on_surface_variant_alfa16: 'rgba(66, 71, 78, 0.16)',
   on_primary_container_alfa8: 'rgba(0, 29, 50, 0.08)',
   on_secondary_container_alfa8: 'rgba(14, 29, 42, 0.08)',
   on_secondary_container_alfa12: 'rgba(14, 29, 42, 0.12)',


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added
- [x] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)


### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-7604](https://mindlogger.atlassian.net/browse/M2-7604)

Within our `enableActivityAssign` feature flag, as an admin you should be able to know why activities or flows are disabled in the Assign flow.

Changes include:
- In the Assign Activity panel, from the Select Activities list, **auto-assigned activities/flows are displayed as disabled and can not be selected by default.**
- **A black tooltip appears when hovering over each disabled activity/flow** to provide information on why the activity/flow is disabled.
  - Activity copy: This activity is set to ‘Auto-assign’ in the Activity Builder and therefore cannot be assigned here.
  - Flow copy: This flow is set to ‘Auto-assign’ in the Activity Flow Builder and therefore cannot be assigned here.
  - Note: Added FR translations from google.
- If all of the activities and/or flows in the assign flow are marked as “auto assigned” and therefore d**isabled, the “select all” button should also be disabled.**

### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| https://www.loom.com/share/6099214544384f0a8216d548fe8737f3?sid=62ffb3ac-c31b-4e34-8cf5-b11cee2aa3bc | https://www.loom.com/share/22464dd4f70d4a29b23cb9fbf3ba49c5?sid=95f7ff5d-bbc6-4c90-9aa0-c962135f192f |

### 🪤 Peer Testing

<!-- If peer testing is not needed, then delete this section -->
<!-- Uncomment out any of the following as needed:           -->

<!--
Replace this with a series of test steps & expected outcomes.

Example test step:

- This is a test step.  Highlight actions **in bold**.

    **Expected outcome:** This is what to expect after the step
-->
#### All options disabled:
**Test steps**...
- Create or update two Activities so that `Auto-assign this activity (as self-report)` is checked on both.
- Do the same for flows.
- Navigate to the applet activities tab containing those activities and flows.
- Click on "Assign"

**Expected outcome...**
- "Select All" should be disabled and a light grey.
- All activities and flows should also be disabled and a lighter grey.
- When hovering over an item, you should see a tooltip appear on the left with further details.
  - Changing the lang to 'fr' should update the tooltip text. 

#### Some options disabled:
**Test steps**...
- Update one of the Activities so that `Auto-assign this activity (as self-report)` is **unchecked**
- Do the same for flows.
- Navigate to the applet activities tab containing those activities and flows.
- Click on "Assign"

**Expected outcome...**
- "Select All" should be enabled.
- Clicking on select all should only select the activities / flows that are not marked "auto assign".
  - the summary note aligned with the select all button should note the correct amount of selected items.
- The right activities and flows should be disabled and a lighter grey while the others are active and clickable.
- When hovering over an active item, you should **not** see a tooltip appear on the left with further details.

### ✏️ Notes

<!--
Replace this line with anything else you think may be relevant or related PRs

If there are no notes, then delete this section.
-->

- These feature changes are wrapped in the `enableActivityAssign` flag.