### PR TITLE
fix: Review and fix banner messages to display accordingly (M2-7580)

### DIFF
--- a/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityAssignDrawer.tsx
+++ b/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityAssignDrawer.tsx
@@ -386,12 +386,12 @@ export const ActivityAssignDrawer = ({
             hasActivity: activityIds.length || flowIds.length,
             isTeamMember,
           });
-        } else if (activityIds.length || flowIds.length) {
-          addBanner('ActivityAutofillBanner');
         } else if (assignments[0]?.targetSubjectId) {
           addBanner('SubjectAutofillBanner', {
             hasActivity: activityIds.length || flowIds.length,
           });
+        } else if (activityIds.length || flowIds.length) {
+          addBanner('ActivityAutofillBanner');
         }
       }, 300);
     } else {

--- a/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityAssignDrawer.tsx
+++ b/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityAssignDrawer.tsx
@@ -386,12 +386,12 @@ export const ActivityAssignDrawer = ({
             hasActivity: activityIds.length || flowIds.length,
             isTeamMember,
           });
+        } else if (activityIds.length || flowIds.length) {
+          addBanner('ActivityAutofillBanner');
         } else if (assignments[0]?.targetSubjectId) {
           addBanner('SubjectAutofillBanner', {
             hasActivity: activityIds.length || flowIds.length,
           });
-        } else if (activityIds.length || flowIds.length) {
-          addBanner('ActivityAutofillBanner');
         }
       }, 300);
     } else {

--- a/src/modules/Dashboard/components/ActivityAssignDrawer/Banners/SubjectAutofillBanner.tsx
+++ b/src/modules/Dashboard/components/ActivityAssignDrawer/Banners/SubjectAutofillBanner.tsx
@@ -14,7 +14,7 @@ export const SubjectAutofillBanner = (props: BannerProps) => {
       duration={8000}
       {...props}
     >
-      {t('subjectAutofill')}
+      {props.hasActivity ? t('subjectActivityAutofill') : t('subjectAutofill')}
     </Banner>
   );
 };


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [ ] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-7580](https://mindlogger.atlassian.net/browse/M2-7580)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->
- QA reported an inconsistency with how the assign activity banners display w/in the assign activity side drawer.
- The issue seemed to stem from an `if` statement short circuiting prior to a more immediate condition being returned.

Changes include:

- Display the correct banner message when assigning an activity using the Activity dataviz/summary card for a Limited Accounts.

### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

Before:

https://github.com/user-attachments/assets/10434cad-4c4d-496c-a114-a3e18347f608

After:

https://github.com/user-attachments/assets/3955da65-541a-43ba-be77-353295448ad7

### 🪤 Peer Testing

<!-- If peer testing is not needed, then delete this section -->
<!-- Uncomment out any of the following as needed:           -->
<!-- **Requires `npm install`**     -->

<!--
Replace this with a series of test steps & expected outcomes.

Example test step:

- This is a test step.  Highlight actions **in bold**.

    **Expected outcome:** This is what to expect after the step
-->

- Please view reproduction steps in [Ticket M2-7580](https://mindlogger.atlassian.net/browse/M2-7580)

### ✏️ Notes

<!--
Replace this line with anything else you think may be relevant or related PRs

If there are no notes, then delete this section.
-->
- Source of truth for banner rendering logic can be found [M2-7135](https://mindlogger.atlassian.net/browse/M2-7135)

[M2-7135]: https://mindlogger.atlassian.net/browse/M2-7135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ