### PR TITLE
feat: add Message ItemType support in SummaryRow (M2-7981)

### DIFF
--- a/src/modules/Builder/features/ActivityItemsFlow_old/ActivityItemsFlow.test.tsx
+++ b/src/modules/Builder/features/ActivityItemsFlow_old/ActivityItemsFlow.test.tsx
@@ -80,6 +80,7 @@ const mockedOrderedSummaryItemItems = [
   mockedTextActivityItem,
   mockedTimeActivityItem,
   mockedSliderActivityItem,
+  mockedMessageActivityItem,
   mockedTimeRangeActivityItem,
   mockedParagraphTextActivityItem,
 ];
@@ -257,7 +258,7 @@ describe('Activity Items Flow', () => {
     });
   });
 
-  test('Summary Item: only SingleSelect/MultiSelect/Slider/Text/ParagraphText/Time/TimeRange are available', () => {
+  test('Summary Item: only SingleSelect/MultiSelect/Slider/Text/ParagraphText/Time/TimeRange/Message are available', () => {
     renderActivityItemsFlow(mockedAppletWithAllItemTypes);
 
     fireEvent.click(screen.getByTestId(`${mockedTestid}-add`));
@@ -269,7 +270,7 @@ describe('Activity Items Flow', () => {
     expect(itemDropdown).toBeVisible();
 
     const items = itemDropdown.querySelectorAll('li');
-    expect(items).toHaveLength(7);
+    expect(items).toHaveLength(8);
 
     items.forEach((item, index) => {
       expect(item).toHaveAttribute('data-value', mockedOrderedSummaryItemItems[index].id);

--- a/src/modules/Builder/features/ActivityItemsFlow_old/ActivityItemsFlow.test.tsx
+++ b/src/modules/Builder/features/ActivityItemsFlow_old/ActivityItemsFlow.test.tsx
@@ -80,7 +80,6 @@ const mockedOrderedSummaryItemItems = [
   mockedTextActivityItem,
   mockedTimeActivityItem,
   mockedSliderActivityItem,
-  mockedMessageActivityItem,
   mockedTimeRangeActivityItem,
   mockedParagraphTextActivityItem,
 ];
@@ -258,7 +257,7 @@ describe('Activity Items Flow', () => {
     });
   });
 
-  test('Summary Item: only SingleSelect/MultiSelect/Slider/Text/ParagraphText/Time/TimeRange/Message are available', () => {
+  test('Summary Item: only SingleSelect/MultiSelect/Slider/Text/ParagraphText/Time/TimeRange are available', () => {
     renderActivityItemsFlow(mockedAppletWithAllItemTypes);
 
     fireEvent.click(screen.getByTestId(`${mockedTestid}-add`));
@@ -270,7 +269,7 @@ describe('Activity Items Flow', () => {
     expect(itemDropdown).toBeVisible();
 
     const items = itemDropdown.querySelectorAll('li');
-    expect(items).toHaveLength(8);
+    expect(items).toHaveLength(7);
 
     items.forEach((item, index) => {
       expect(item).toHaveAttribute('data-value', mockedOrderedSummaryItemItems[index].id);

--- a/src/modules/Builder/features/ActivityItemsFlow_old/ItemFlow/SummaryRow/SummaryRow.const.ts
+++ b/src/modules/Builder/features/ActivityItemsFlow_old/ItemFlow/SummaryRow/SummaryRow.const.ts
@@ -8,4 +8,5 @@ export const ITEMS_RESPONSE_TYPES_TO_SHOW = [
   ItemResponseType.ParagraphText,
   ItemResponseType.Time,
   ItemResponseType.TimeRange,
+  ItemResponseType.Message,
 ];

--- a/src/modules/Builder/features/ActivityItemsFlow_old/ItemFlow/SummaryRow/SummaryRow.const.ts
+++ b/src/modules/Builder/features/ActivityItemsFlow_old/ItemFlow/SummaryRow/SummaryRow.const.ts
@@ -8,5 +8,4 @@ export const ITEMS_RESPONSE_TYPES_TO_SHOW = [
   ItemResponseType.ParagraphText,
   ItemResponseType.Time,
   ItemResponseType.TimeRange,
-  ItemResponseType.Message,
 ];


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-7981](https://mindlogger.atlassian.net/browse/M2-7981)

Allows using a Message item type in the summary row for conditional logic, without requiring the entire changes from the `enable-item-flow-extended-items` feature flag.

- Added `.Message` to available types in the Summary Row


### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| ![CleanShot 2024-10-03 at 11 06 57](https://github.com/user-attachments/assets/bd848878-1020-4f5a-b7d8-c4e7c8889c18) | ![CleanShot 2024-10-03 at 11 04 51](https://github.com/user-attachments/assets/f8b31e13-c709-41f1-8a0d-177e6387048f) |

### 🪤 Peer Testing

- Create an Applet with 3 or more Items, at least 1 should be `Message` type
- Add conditional logic to navigate to the Message item type
- Applet should be saved correctly
- Test Applet with conditional logic using Web or Mobile apps
- Applet should navigate to the correct item based on conditional logic


Note: reverts previously merged PR for QA testing