### PR TITLE
feat: Add By Participant view (M2-7798)

### DIFF
--- a/src/modules/Dashboard/api/api.ts
+++ b/src/modules/Dashboard/api/api.ts
@@ -941,6 +941,14 @@ export const getAppletTargetSubjectActivitiesApi = (
     signal,
   });
 
+export const getAppletRespondentSubjectActivitiesApi = (
+  { appletId, subjectId }: GetSubjectActivitiesParams,
+  signal?: AbortSignal,
+): Promise<AxiosResponse<AppletParticipantActivitiesResponse>> =>
+  authApiClient.get(`/activities/applet/${appletId}/respondent/${subjectId}`, {
+    signal,
+  });
+
 export const createTemporaryMultiInformantRelationApi = (
   { subjectId, sourceSubjectId }: CreateTemporaryMultiInformantRelation,
   signal?: AbortSignal,

--- a/src/modules/Dashboard/features/Participant/Assignments/ActivityListItem/ActivityListItem.styles.ts
+++ b/src/modules/Dashboard/features/Participant/Assignments/ActivityListItem/ActivityListItem.styles.ts
@@ -8,7 +8,8 @@ import {
   variables,
 } from 'shared/styles';
 
-export const StyledActivityListItem = styled(StyledFlexTopCenter)`
+export const StyledActivityListItem = styled(StyledFlexTopCenter)(
+  ({ onClick }: { onClick?: () => void }) => `
   flex-wrap: wrap;
   padding: ${theme.spacing(1.5)};
   gap: ${theme.spacing(0.8, 4.8)};
@@ -16,13 +17,18 @@ export const StyledActivityListItem = styled(StyledFlexTopCenter)`
   border-radius: ${variables.borderRadius.lg2};
   background-color: ${variables.palette.surface};
   transition: ${variables.transitions.bgColor};
-  cursor: pointer;
 
-  &:hover,
-  &:focus {
-    background-color: ${variables.palette.on_surface_variant_alfa8};
+  ${
+    onClick &&
+    `cursor: pointer;
+
+    &:hover,
+    &:focus {
+      background-color: ${variables.palette.on_surface_variant_alfa8};
+    }`
   }
-`;
+`,
+);
 
 export const StyledActivityName = styled(StyledTitleLargish)`
   ${ellipsisTextCss}

--- a/src/modules/Dashboard/features/Participant/Assignments/ActivityListItem/ActivityListItem.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/ActivityListItem/ActivityListItem.tsx
@@ -14,7 +14,7 @@ export const ActivityListItem = ({
   onClick,
   children,
 }: ActivityListItemProps) => (
-  <StyledActivityListItem as="button" onClick={onClick}>
+  <StyledActivityListItem as={onClick ? 'a' : 'div'} onClick={onClick}>
     <StyledFlexTopCenter sx={{ gap: 0.8 }}>
       <StyledActivityThumbnailContainer sx={{ width: '5.6rem', height: '5.6rem', mr: 0.8 }}>
         {isFlow ? (

--- a/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ByParticipant.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ByParticipant.tsx
@@ -1,5 +1,106 @@
-import { AssignmentsTab } from '../AssignmentsTab';
+import { useCallback, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 
-const ByParticipant = () => <AssignmentsTab />;
+import { useAsync } from 'shared/hooks';
+import { getAppletRespondentSubjectActivitiesApi } from 'api';
+import { users } from 'redux/modules';
+import { ActionsMenu, Spinner } from 'shared/components';
+
+import { AssignmentsTab, useAssignmentsTab } from '../AssignmentsTab';
+import { EmptyState } from './EmptyState';
+import { ActivitiesList } from '../ActivitiesList';
+import { ActivityListItem } from '../ActivityListItem';
+
+const dataTestId = 'participant-details-about-participant';
+
+const ByParticipant = () => {
+  const { t } = useTranslation('app');
+  const { appletId, subjectId } = useParams();
+  const { useSubject, useSubjectStatus } = users;
+  const isLoadingSubject = useSubjectStatus() !== 'success';
+  const { result: respondentSubject } = useSubject() ?? {};
+
+  const {
+    execute: fetchActivities,
+    isLoading: isLoadingActivities,
+    value: fetchedActivities,
+  } = useAsync(getAppletRespondentSubjectActivitiesApi, { retainValue: true });
+
+  const activities = fetchedActivities?.data.result ?? [];
+
+  const handleRefetch = useCallback(() => {
+    // Avoid fetching activities for respondent if respondent is a limited account
+    if (!appletId || !subjectId || !respondentSubject?.userId) return;
+
+    fetchActivities({ appletId, subjectId });
+  }, [appletId, fetchActivities, respondentSubject?.userId, subjectId]);
+
+  const {
+    getActionsMenu,
+    onClickAssign,
+    isLoading: isLoadingHook,
+    modals,
+  } = useAssignmentsTab({ appletId, respondentSubject, handleRefetch, dataTestId });
+
+  /*
+  TODO: Handler for navigating to data when card is expanded
+  https://mindlogger.atlassian.net/browse/M2-7921
+  const handleClickNavigateToData = (activityOrFlow: ParticipantActivityOrFlow, targetSubject: RespondentDetails) => {
+    if (!respondentSubject) return;
+
+    onClickNavigateToData(activityOrFlow, targetSubject.id);
+  };
+  */
+
+  useEffect(() => {
+    handleRefetch();
+  }, [handleRefetch]);
+
+  const isLoading = isLoadingSubject || isLoadingActivities || isLoadingHook;
+
+  return (
+    <AssignmentsTab>
+      {isLoading && <Spinner />}
+
+      {!isLoading && !activities.length && (
+        <EmptyState onClickAssign={onClickAssign} isLimitedAccount={!respondentSubject?.userId} />
+      )}
+
+      {!!activities.length && (
+        <ActivitiesList
+          title={t('participantDetails.activitiesAndFlows')}
+          count={fetchedActivities?.data.count ?? 0}
+        >
+          {activities.map((activity, index) => (
+            <ActivityListItem key={activity.id} activityOrFlow={activity}>
+              <ActionsMenu
+                anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                transformOrigin={{ vertical: -6, horizontal: 'right' }}
+                buttonColor="secondary"
+                menuItems={getActionsMenu(activity)}
+                data-testid={`${dataTestId}-${index}`}
+              />
+
+              {/* TODO: Add expand/collapse button
+                  https://mindlogger.atlassian.net/browse/M2-7921 */}
+            </ActivityListItem>
+          ))}
+
+          {/* TODO: Add lazy load button
+              https://mindlogger.atlassian.net/browse/M2-7827 */}
+        </ActivitiesList>
+      )}
+
+      {/* TODO: Add deleted entries
+          https://mindlogger.atlassian.net/browse/M2-7827
+          <ActivitiesList title={t('deleted')} count={deleted.length}>
+            {deleted.map(…)}
+          </ActivitiesList> */}
+
+      {modals}
+    </AssignmentsTab>
+  );
+};
 
 export default ByParticipant;

--- a/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/EmptyState/EmptyState.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/EmptyState/EmptyState.tsx
@@ -1,0 +1,27 @@
+import { Button } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+
+import { Svg } from 'shared/components';
+import { StyledFlexAllCenter, StyledFlexColumn, StyledHeadline, variables } from 'shared/styles';
+
+import { EmptyStateProps } from './EmptyState.types';
+
+export const EmptyState = ({ onClickAssign, isLimitedAccount }: EmptyStateProps) => {
+  const { t } = useTranslation('app', { keyPrefix: 'participantDetails' });
+
+  return (
+    <StyledFlexAllCenter sx={{ flexDirection: 'column', flex: 1, m: 'auto', textAlign: 'center' }}>
+      <StyledFlexColumn sx={{ alignItems: 'center', gap: 1.6, maxWidth: '50.7rem' }}>
+        <Svg id="by-participant" width="80" height="80" fill={variables.palette.outline} />
+        <StyledHeadline as="h2" sx={{ color: variables.palette.outline, m: 0 }}>
+          {isLimitedAccount ? t('byParticipantEmptyLimitedAccount') : t('byParticipantEmpty')}
+        </StyledHeadline>
+      </StyledFlexColumn>
+      {!isLimitedAccount && (
+        <Button variant="contained" color="primary" onClick={onClickAssign} sx={{ mt: 2.4 }}>
+          {t('assignActivityButton')}
+        </Button>
+      )}
+    </StyledFlexAllCenter>
+  );
+};

--- a/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/EmptyState/EmptyState.types.ts
+++ b/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/EmptyState/EmptyState.types.ts
@@ -1,0 +1,4 @@
+export type EmptyStateProps = {
+  onClickAssign: () => void;
+  isLimitedAccount: boolean;
+};

--- a/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/EmptyState/index.ts
+++ b/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/EmptyState/index.ts
@@ -1,0 +1,1 @@
+export * from './EmptyState';

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -1050,6 +1050,8 @@
     "byParticipant": "By Participant",
     "aboutParticipant": "About Participant",
     "aboutParticipantEmpty": "No Activities are assigned to be completed about this Participant.",
+    "byParticipantEmpty": "No Activities are assigned for this Participant to complete.",
+    "byParticipantEmptyLimitedAccount": "This Participant has a Limited Account and cannot be assigned to complete Activities.",
     "aboutParticipantEmptyTeamMember": "This Participant is a Team Member and Activities cannot be completed about them.",
     "assignActivityButton": "Assign Activity",
     "activitiesAndFlows": "Activities & Flows"

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -1050,6 +1050,8 @@
     "aboutParticipant": "Concernant le participant",
     "aboutParticipantEmpty": "Aucune activité n'est attribuée à être complétée à propos de ce participant.",
     "aboutParticipantEmptyTeamMember": "Ce participant est un membre de l'équipe et les activités ne peuvent pas être complétées à son sujet.",
+    "byParticipantEmpty": "Aucune activité n'est attribuée à ce participant pour être complétée.",
+    "byParticipantEmptyLimitedAccount": "Ce participant a un compte limité et ne peut pas être assigné pour compléter des activités.",
     "assignActivityButton": "Attribuer une activité",
     "activitiesAndFlows": "Activités & Flux"
   },


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [ ] Tests for the changes have been added **(in progress)**
- [ ] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-7798](https://mindlogger.atlassian.net/browse/M2-7798)

> [!NOTE]
> I've selected the Activity Status Tags branch (#1937) as the target branch for this PR, which it is dependent on. Please review this work as if that branch were already merged to `develop`. I'll rebase and re-target this branch accordingly after #1937 has been merged.

This PR adds the By Participant view to the PDP, including:

- Support to call new API endpoint for By Participant view, `/activities/applet/${appletId}/respondent/${subjectId}`
- Empty states for By Participant view (full account, limited account)
- Adjustments to `ActivityListItem` component to support the new view

Also fixed some menu item logic to detect assignments correctly from the new view and handle disabled menu items properly for hidden activities/flows.

### 📸 Screenshots

#### Full Account/Team Member Empty State

![CleanShot 2024-10-09 at 15 06 52@2x](https://github.com/user-attachments/assets/92d1b57c-1a64-4097-a958-d037bbfa5382)

#### Limited Account Empty State

![CleanShot 2024-10-09 at 15 04 11@2x](https://github.com/user-attachments/assets/15ffe174-0b9e-42c2-921d-4e835681b4c9)

#### List of Activities/Flows for which Participant is Respondent

![CleanShot 2024-10-09 at 15 04 31@2x](https://github.com/user-attachments/assets/bde1912e-0152-4a5e-83e2-abaac479f7a7)

### 🪤 Peer Testing

> [!TIP]
> Ensure the `enableActivityAssign` feature flag is enabled in the environment you are testing from.

1. For a given Participant, ensure you have activities or flows created with these characteristics:
    - One that is manually assigned to the Participant as the Respondent
    - One that is auto-assigned to the Participant as the Respondent
    - One that is not assigned to the Participant, but has submissions for them as the Respondent (e.g., via Take Now, or via a previous assignment that as since been removed)
    - One that is hidden
2. From that Participant's PDP, ensure each of the activities/flows is listed in the By Participant view according to designs, taking into account the out-of-scope portions of the design as described in the AC of the [ticket](https://mindlogger.atlassian.net/browse/M2-7798).
3. Create a new Limited Account and a new Full Account, and ensure there are no activities/flows that are auto-assigned.
4. Open the PDP > By Participant view for the Limited Account, and ensure the Limited Account empty state is shown.
5. Open the PDP > By Participant view for the Full Account, and ensure the Full Account empty state is shown.