### PR TITLE
feat: Add "Remove Phrase" confirmation dialog (M2-7163)

### DIFF
--- a/src/modules/Builder/components/RemovePhrasePopup/RemovePhrasePopup.tsx
+++ b/src/modules/Builder/components/RemovePhrasePopup/RemovePhrasePopup.tsx
@@ -1,0 +1,31 @@
+import { Button } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+
+import { Modal, ModalProps } from 'shared/components';
+import { StyledFlexAllCenter, StyledFlexTopStart } from 'shared/styles';
+
+export const RemovePhrasePopup = ({
+  onRemove,
+  ...otherProps
+}: Omit<ModalProps, 'title' | 'children'> & { onRemove?: () => void }) => {
+  const { t } = useTranslation('app');
+
+  return (
+    <Modal
+      footer={
+        <StyledFlexAllCenter sx={{ width: '100%' }}>
+          <Button color="error" onClick={onRemove} variant="contained">
+            {t('phrasalTemplateRemovePopup.confirm')}
+          </Button>
+        </StyledFlexAllCenter>
+      }
+      hasActions={false}
+      title={t('phrasalTemplateRemovePopup.title')}
+      {...otherProps}
+    >
+      <StyledFlexTopStart as="p" sx={{ px: 3.2, m: 0, pt: 2.4 }}>
+        {t('phrasalTemplateRemovePopup.areYouSure')}
+      </StyledFlexTopStart>
+    </Modal>
+  );
+};

--- a/src/modules/Builder/components/RemovePhrasePopup/RemovePhrasePopup.tsx
+++ b/src/modules/Builder/components/RemovePhrasePopup/RemovePhrasePopup.tsx
@@ -1,8 +1,7 @@
-import { Button } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 
 import { Modal, ModalProps } from 'shared/components';
-import { StyledFlexAllCenter, StyledFlexTopStart } from 'shared/styles';
+import { StyledModalWrapper } from 'shared/styles';
 
 export const RemovePhrasePopup = ({
   onRemove,
@@ -12,20 +11,13 @@ export const RemovePhrasePopup = ({
 
   return (
     <Modal
-      footer={
-        <StyledFlexAllCenter sx={{ width: '100%' }}>
-          <Button color="error" onClick={onRemove} variant="contained">
-            {t('phrasalTemplateRemovePopup.confirm')}
-          </Button>
-        </StyledFlexAllCenter>
-      }
-      hasActions={false}
+      buttonText={t('phrasalTemplateRemovePopup.confirm')}
+      onSubmit={onRemove}
+      submitBtnColor="error"
       title={t('phrasalTemplateRemovePopup.title')}
       {...otherProps}
     >
-      <StyledFlexTopStart as="p" sx={{ px: 3.2, m: 0, pt: 2.4 }}>
-        {t('phrasalTemplateRemovePopup.areYouSure')}
-      </StyledFlexTopStart>
+      <StyledModalWrapper>{t('phrasalTemplateRemovePopup.areYouSure')}</StyledModalWrapper>
     </Modal>
   );
 };

--- a/src/modules/Builder/components/RemovePhrasePopup/index.ts
+++ b/src/modules/Builder/components/RemovePhrasePopup/index.ts
@@ -1,0 +1,1 @@
+export * from './RemovePhrasePopup';

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/PhrasalTemplate/PhrasalTemplate.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/PhrasalTemplate/PhrasalTemplate.tsx
@@ -37,6 +37,14 @@ export const PhrasalTemplate = ({ name = '' }: { name?: string }) => {
     [currentItemIndex, items],
   );
 
+  const handleRemovePhraseAtIndex = (index: number) => {
+    remove(index);
+
+    if (fields.length <= 1) {
+      handleAddPhrase();
+    }
+  };
+
   const handleAddPhrase = () => {
     append(getNewDefaultPhrase());
   };
@@ -84,12 +92,11 @@ export const PhrasalTemplate = ({ name = '' }: { name?: string }) => {
         <StyledPhrasalTemplateList>
           {fields.map((field, i) => (
             <PhrasalTemplatePhrase
-              canRemovePhrase={fields.length > 1}
               index={i}
               key={field.id}
               name={`${name}.responseValues.phrases.${i}`}
               onRemovePhrase={() => {
-                remove(i);
+                handleRemovePhraseAtIndex(i);
               }}
               responseOptions={responseOptions}
             />

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/PhrasalTemplate/PhrasalTemplatePhrase/PhrasalTemplatePhrase.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/PhrasalTemplate/PhrasalTemplatePhrase/PhrasalTemplatePhrase.tsx
@@ -17,6 +17,7 @@ import {
   variables,
 } from 'shared/styles';
 import { DndDroppable } from 'modules/Builder/components';
+import { RemovePhrasePopup } from 'modules/Builder/components/RemovePhrasePopup';
 
 import { PhrasalTemplateField } from '../PhrasalTemplateField';
 import { PhrasalTemplateImageField } from '../PhrasalTemplateImageField';
@@ -31,13 +32,13 @@ import { getFieldPlaceholders, getNewDefaultField } from '../PhrasalTemplate.uti
 import { KEYWORDS } from '../PhrasalTemplateField/PhrasalTemplateField.const';
 
 export const PhrasalTemplatePhrase = ({
-  canRemovePhrase = false,
   name = '',
   responseOptions = [],
   index = 0,
   onRemovePhrase,
 }: PhrasalTemplatePhraseProps) => {
   const { t } = useTranslation('app');
+  const [removePopupOpen, setRemovePopupOpen] = useState(false);
   const [addItemMenuAnchorEl, setAddItemMenuAnchorEl] = useState<null | HTMLElement>(null);
 
   const phraseFieldsName = `${name}.fields`;
@@ -73,11 +74,15 @@ export const PhrasalTemplatePhrase = ({
     [remove],
   );
 
-  const handleRemovePhrase = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+  const handleShowRemovePopup = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     e.stopPropagation();
 
+    setRemovePopupOpen(true);
+  };
+
+  const handleRemovePhrase = () => {
+    setRemovePopupOpen(false);
     onRemovePhrase?.();
-    console.warn('TODO: M2-7163 — Remove Phrase');
   };
 
   const handlePreviewPhrase = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
@@ -140,7 +145,7 @@ export const PhrasalTemplatePhrase = ({
               {t('phrasalTemplateItem.btnPreviewPhrase')}
             </Button>
 
-            <IconButton color="default" disabled={!canRemovePhrase} onClick={handleRemovePhrase}>
+            <IconButton color="default" onClick={handleShowRemovePopup}>
               <Svg
                 aria-label={t('phrasalTemplateItem.btnRemovePhrase')}
                 fill="currentColor"
@@ -234,6 +239,12 @@ export const PhrasalTemplatePhrase = ({
           ]}
         />
       </StyledAccordionDetails>
+
+      <RemovePhrasePopup
+        open={removePopupOpen}
+        onClose={() => setRemovePopupOpen(false)}
+        onRemove={handleRemovePhrase}
+      />
     </StyledAccordion>
   );
 };

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/PhrasalTemplate/PhrasalTemplatePhrase/PhrasalTemplatePhrase.types.ts
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/PhrasalTemplate/PhrasalTemplatePhrase/PhrasalTemplatePhrase.types.ts
@@ -1,7 +1,6 @@
 import { Item } from 'redux/modules';
 
 export interface PhrasalTemplatePhraseProps {
-  canRemovePhrase?: boolean;
   name?: string;
   onRemovePhrase?: () => void;
   index?: number;

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -1081,6 +1081,11 @@
   "photoResponseDescription": "The respondent will be able to take or upload a photo.",
   "photoResponseTitle": "Photo Response",
   "phrasalTemplate": "Phrase Builder",
+  "phrasalTemplateRemovePopup": {
+    "title": "Remove Phrase",
+    "areYouSure": "Are you sure you want to delete this phrase? This action cannot be undone.",
+    "confirm": "Yes, Remove"
+  },
   "phrasalTemplateItem": {
     "btnAddField": "Add…",
     "btnAddPhrase": "New Phrase",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -1080,6 +1080,11 @@
   "photoResponseDescription": "Le participant pourra prendre ou uploader une photo.",
   "photoResponseTitle": "Réponse avec Photo",
   "phrasalTemplate": "Constructeur de phrases",
+  "phrasalTemplateRemovePopup": {
+    "title": "Supprimer la phrase",
+    "areYouSure": "Êtes-vous sûr de vouloir supprimer cette phrase? Cette action ne peut pas être annulée.",
+    "confirm": "Oui, supprimer"
+  },
   "phrasalTemplateItem": {
     "btnAddField": "Ajouter…",
     "btnAddPhrase": "Nouvelle phrase",


### PR DESCRIPTION
### 📝 Description

🔗 [M2-7163](https://mindlogger.atlassian.net/browse/M2-7163): [FE][Phrase Builder] Delete existing phrases

This PR updates the behaviour for removing an existing phrase from a "Phrase Builder" activity item.

Now, when the "Remove Phrase" button is pressed, a confirmation dialog appears, which the user must acknowledge before the phrase can be removed.

Previously, the "Remove Phrase" button was disabled if only a single phrase existed in the item. Now, the button is enabled, and pressing it shows the same confirmation dialog. When confirmed, the phrase is reset to the "default" state (ie, it contains empty fields for `sentence`, `item_response`, and `sentence` values, in that order).

### 📸 Screenshots

| Before | After |
|-|-|
| ![before](https://github.com/user-attachments/assets/e4aa44d3-a62d-4b1d-84a5-e10bdcc2d7cb) | ![after](https://github.com/user-attachments/assets/0acb98da-295d-426e-accd-d87afcfb35f2) |

### 🪤 Peer Testing

From within the applet builder, for an applet with one or more activities:

* Create a new Item, and select an Item Type of "Phrase Builder"
* Create multiple Phrases for the new Item. (Optional: Save your changes to the applet before proceeding).
* Press the delete button to remove a phrase, and then press "Yes, Remove" in the confirmation dialog.
    * If there are multiple remaining phrases, the phrase will be removed.
    * If there is only one remaining phrase, that phrase's content will be reset to default.
* After removing phrases, pressing save (while the edited item is in a valid state) will persist changes.

[M2-7163]: https://mindlogger.atlassian.net/browse/M2-7163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ