### PR TITLE
feat: Add By Participant Expanded Views (M2-7921)

### DIFF
--- a/src/modules/Dashboard/api/api.ts
+++ b/src/modules/Dashboard/api/api.ts
@@ -88,6 +88,8 @@ import {
   AppletActivitiesResponse,
   AppletAssignmentsResponse,
   AppletParticipantActivitiesResponse,
+  GetTargetSubjectsByRespondentParams,
+  GetTargetSubjectsByRespondentResponse,
 } from './api.types';
 import { DEFAULT_ROWS_PER_PAGE } from './api.const';
 import { ApiSuccessResponse } from './base.types';
@@ -997,6 +999,14 @@ export const deleteAppletAssignmentsApi = (
         target_subject_id: a.targetSubjectId,
       })),
     },
+    signal,
+  });
+
+export const getTargetSubjectsByRespondentApi = (
+  { subjectId, activityOrFlowId }: GetTargetSubjectsByRespondentParams,
+  signal?: AbortSignal,
+): Promise<AxiosResponse<GetTargetSubjectsByRespondentResponse>> =>
+  authApiClient.get(`/subjects/respondent/${subjectId}/activity-or-flow/${activityOrFlowId}`, {
     signal,
   });
 

--- a/src/modules/Dashboard/api/api.types.ts
+++ b/src/modules/Dashboard/api/api.types.ts
@@ -695,6 +695,23 @@ export type AppletAssignmentsResponse = {
   };
 };
 
+export type GetTargetSubjectsByRespondentParams = SubjectId & {
+  activityOrFlowId: string;
+};
+
+export type TargetSubjectsByRespondent = Array<
+  RespondentDetails &
+    AppletId & {
+      submissionCount: number;
+      currentlyAssigned: boolean;
+    }
+>;
+
+export type GetTargetSubjectsByRespondentResponse = {
+  result: TargetSubjectsByRespondent;
+  count: number;
+};
+
 export type Integration = {
   integrationType: string;
 };

--- a/src/modules/Dashboard/components/ActivityAssignDrawer/AssignmentsTable/AssignmentsTable.tsx
+++ b/src/modules/Dashboard/components/ActivityAssignDrawer/AssignmentsTable/AssignmentsTable.tsx
@@ -205,9 +205,6 @@ export const AssignmentsTable = ({
         columns={getHeadCells(isReadOnly)}
         rows={rows}
         enablePagination={false}
-        handleRequestSort={() => {}}
-        order="asc"
-        orderBy="respondentSubjectId"
         data-testid={dataTestId}
       />
       {showAddButton && (

--- a/src/modules/Dashboard/components/ActivityUnassignDrawer/AssignmentsTable/AssignmentsTable.tsx
+++ b/src/modules/Dashboard/components/ActivityUnassignDrawer/AssignmentsTable/AssignmentsTable.tsx
@@ -112,9 +112,6 @@ export const AssignmentsTable = ({
       columns={getHeadCells()}
       rows={rows}
       enablePagination={false}
-      handleRequestSort={() => {}}
-      order="asc"
-      orderBy="id"
       data-testid={dataTestId}
     />
   );

--- a/src/modules/Dashboard/components/DashboardTable/DashboardTable.test.tsx
+++ b/src/modules/Dashboard/components/DashboardTable/DashboardTable.test.tsx
@@ -75,9 +75,6 @@ describe('DashboardTable component tests', () => {
           columns={mockColumns}
           rows={getMockRows()}
           enablePagination={false}
-          handleRequestSort={() => {}}
-          order="desc"
-          orderBy=""
         />,
       );
     });

--- a/src/modules/Dashboard/components/DashboardTable/DashboardTable.types.ts
+++ b/src/modules/Dashboard/components/DashboardTable/DashboardTable.types.ts
@@ -8,13 +8,13 @@ interface DashboardTableCommonProps {
   className?: string;
   columns: HeadCell[];
   emptyComponent?: JSX.Element | string;
-  handleRequestSort: (event: MouseEvent<unknown>, property: string) => void;
+  handleRequestSort?: (event: MouseEvent<unknown>, property: string) => void;
   hasColFixedWidth?: boolean;
   keyExtractor?: (item: Row, index: number) => string;
   maxHeight?: string;
   onScroll?: (event: UIEvent<HTMLDivElement>) => void;
-  order: Order;
-  orderBy: string;
+  order?: Order;
+  orderBy?: string;
   rows?: Row[];
   searchValue?: string;
   uiType?: UiType;

--- a/src/modules/Dashboard/features/Applet/Overview/Overview.utils.tsx
+++ b/src/modules/Dashboard/features/Applet/Overview/Overview.utils.tsx
@@ -66,9 +66,6 @@ export function mapResponseToSubmissionsTableProps(
       { id: 'subject', label: i18n.t('appletOverview.columnSubject') },
       { id: 'submissionDate', label: i18n.t('appletOverview.columnSubmissionDate') },
     ],
-    handleRequestSort: () => {},
-    order: 'desc' as const,
-    orderBy: '',
     rows:
       submissions.length > 0
         ? submissions.map(

--- a/src/modules/Dashboard/features/Participant/Assignments/AboutParticipant/AboutParticipant.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/AboutParticipant/AboutParticipant.tsx
@@ -79,15 +79,13 @@ const AboutParticipant = () => {
           count={fetchedActivities?.data.count ?? 0}
         >
           {activities.map((activity, index) => (
-            <ActivityListItem
-              key={activity.id}
-              activityOrFlow={activity}
-              onClick={() => handleClickNavigateToData(activity)}
-            >
+            <ActivityListItem key={activity.id} activityOrFlow={activity}>
               <Button
                 variant="outlined"
                 onClick={() => handleClickNavigateToData(activity)}
                 sx={{ mr: 0.4 }}
+                className="primary-button"
+                disableRipple
                 data-testid={`${dataTestId}-${index}-view-data`}
               >
                 <Svg id="chart" width="18" height="18" fill="currentColor" />

--- a/src/modules/Dashboard/features/Participant/Assignments/ActivityListItem/ActivityListItem.styles.ts
+++ b/src/modules/Dashboard/features/Participant/Assignments/ActivityListItem/ActivityListItem.styles.ts
@@ -34,9 +34,13 @@ export const StyledActivityListItemInner = styled(StyledFlexTopCenter)`
   position: relative;
   background-color: ${variables.palette.surface};
 
+  [aria-label] > .MuiChip-root,
   button:not(.primary-button) {
+    position: relative;
     z-index: 1;
+  }
 
+  button:not(.primary-button) {
     /* Add click slop for secondary buttons */
     &::after {
       content: '';

--- a/src/modules/Dashboard/features/Participant/Assignments/ActivityListItem/ActivityListItem.styles.ts
+++ b/src/modules/Dashboard/features/Participant/Assignments/ActivityListItem/ActivityListItem.styles.ts
@@ -31,18 +31,39 @@ export const StyledActivityListItemInner = styled(StyledFlexTopCenter)`
   padding: ${theme.spacing(1.5)};
   column-gap: ${theme.spacing(4.8)};
   row-gap: ${theme.spacing(0.8)};
+  position: relative;
   background-color: ${variables.palette.surface};
-  transition: ${variables.transitions.bgColor};
 
-  ${({ onClick }: { onClick?: () => void }) =>
-    onClick
-      ? `cursor: pointer;
+  button:not(.primary-button) {
+    z-index: 1;
 
-        &:hover,
-        &:focus {
-          background-color: ${variables.palette.on_surface_variant_alfa8};
-        }`
-      : ''}
+    /* Add click slop for secondary buttons */
+    &::after {
+      content: '';
+      position: absolute;
+      inset: -${theme.spacing(0.8)};
+    }
+  }
+
+  .primary-button {
+    position: static;
+
+    &::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background-color: transparent;
+      transition: ${variables.transitions.bgColor};
+    }
+
+    &:hover::after,
+    &:focus::after {
+      background-color: ${variables.palette.on_surface_variant_alfa8};
+    }
+  }
+
+  button {
+    position: relative;
   }
 `;
 

--- a/src/modules/Dashboard/features/Participant/Assignments/ActivityListItem/ActivityListItem.styles.ts
+++ b/src/modules/Dashboard/features/Participant/Assignments/ActivityListItem/ActivityListItem.styles.ts
@@ -1,4 +1,4 @@
-import { styled } from '@mui/material';
+import { Box, styled } from '@mui/material';
 
 import {
   ellipsisTextCss,
@@ -8,15 +8,11 @@ import {
   variables,
 } from 'shared/styles';
 
-export const StyledActivityListItem = styled(StyledFlexTopCenter)(
+export const StyledActivityListItem = styled(Box)(
   ({ onClick }: { onClick?: () => void }) => `
-  flex-wrap: wrap;
-  padding: ${theme.spacing(1.5)};
-  gap: ${theme.spacing(0.8, 4.8)};
   border: ${variables.borderWidth.md} solid ${variables.palette.surface_variant};
   border-radius: ${variables.borderRadius.lg2};
-  background-color: ${variables.palette.surface};
-  transition: ${variables.transitions.bgColor};
+  overflow: hidden;
 
   ${
     onClick &&
@@ -29,6 +25,26 @@ export const StyledActivityListItem = styled(StyledFlexTopCenter)(
   }
 `,
 );
+
+export const StyledActivityListItemInner = styled(StyledFlexTopCenter)`
+  flex-wrap: wrap;
+  padding: ${theme.spacing(1.5)};
+  column-gap: ${theme.spacing(4.8)};
+  row-gap: ${theme.spacing(0.8)};
+  background-color: ${variables.palette.surface};
+  transition: ${variables.transitions.bgColor};
+
+  ${({ onClick }: { onClick?: () => void }) =>
+    onClick
+      ? `cursor: pointer;
+
+        &:hover,
+        &:focus {
+          background-color: ${variables.palette.on_surface_variant_alfa8};
+        }`
+      : ''}
+  }
+`;
 
 export const StyledActivityName = styled(StyledTitleLargish)`
   ${ellipsisTextCss}

--- a/src/modules/Dashboard/features/Participant/Assignments/ActivityListItem/ActivityListItem.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/ActivityListItem/ActivityListItem.tsx
@@ -1,33 +1,96 @@
+import { useState } from 'react';
+import { CircularProgress, Collapse, IconButton } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { TransitionGroup } from 'react-transition-group';
+
 import {
   StyledActivityThumbnailContainer,
   StyledActivityThumbnailImg,
   StyledFlexTopCenter,
+  variables,
 } from 'shared/styles';
 import { ActivityFlowThumbnail, ActivityStatusChip } from 'modules/Dashboard/components';
-import { FlowChip } from 'shared/components';
+import { FlowChip, Svg } from 'shared/components';
 
 import { ActivityListItemProps } from './ActivityListItem.types';
-import { StyledActivityListItem, StyledActivityName } from './ActivityListItem.styles';
+import {
+  StyledActivityListItem,
+  StyledActivityListItemInner,
+  StyledActivityName,
+} from './ActivityListItem.styles';
 
 export const ActivityListItem = ({
-  activityOrFlow: { isFlow, images, name, status },
+  activityOrFlow,
   onClick,
+  onClickToggleExpandedView,
+  expandedView,
+  isLoadingExpandedView,
   children,
-}: ActivityListItemProps) => (
-  <StyledActivityListItem as={onClick ? 'a' : 'div'} onClick={onClick}>
-    <StyledFlexTopCenter sx={{ gap: 0.8 }}>
-      <StyledActivityThumbnailContainer sx={{ width: '5.6rem', height: '5.6rem', mr: 0.8 }}>
-        {isFlow ? (
-          <ActivityFlowThumbnail activities={images} />
-        ) : (
-          images[0] && <StyledActivityThumbnailImg src={images[0]} alt={name} />
-        )}
-      </StyledActivityThumbnailContainer>
-      <StyledActivityName>{name}</StyledActivityName>
-      {isFlow && <FlowChip size="small" />}
-      <ActivityStatusChip status={status} />
-    </StyledFlexTopCenter>
+}: ActivityListItemProps) => {
+  const { t } = useTranslation('app', { keyPrefix: 'participantDetails' });
+  const { isFlow, images, name, status } = activityOrFlow;
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isExpandComplete, setIsExpandComplete] = useState(false);
 
-    <StyledFlexTopCenter sx={{ gap: 0.8, ml: 'auto' }}>{children}</StyledFlexTopCenter>
-  </StyledActivityListItem>
-);
+  const handleClickToggleExpandedView = () => {
+    setIsExpanded(!isExpanded);
+    onClickToggleExpandedView?.(!isExpanded);
+  };
+
+  const handleClick = onClick ?? (expandedView ? handleClickToggleExpandedView : undefined);
+
+  return (
+    <StyledActivityListItem>
+      <StyledActivityListItemInner as={handleClick ? 'a' : 'div'} onClick={handleClick}>
+        <StyledFlexTopCenter sx={{ gap: 0.8 }}>
+          <StyledActivityThumbnailContainer sx={{ width: '5.6rem', height: '5.6rem', mr: 0.8 }}>
+            {isFlow ? (
+              <ActivityFlowThumbnail activities={images} />
+            ) : (
+              images[0] && <StyledActivityThumbnailImg src={images[0]} alt={name} />
+            )}
+          </StyledActivityThumbnailContainer>
+          <StyledActivityName>{name}</StyledActivityName>
+          {isFlow && <FlowChip size="small" />}
+          <ActivityStatusChip status={status} />
+        </StyledFlexTopCenter>
+
+        <StyledFlexTopCenter sx={{ gap: 0.8, ml: 'auto' }}>
+          {children}
+
+          {expandedView && (
+            <IconButton
+              onClick={handleClickToggleExpandedView}
+              color="outlined"
+              sx={{ ml: 0.8 }}
+              disabled={isLoadingExpandedView}
+            >
+              {isLoadingExpandedView && !isExpandComplete ? (
+                <CircularProgress size={24} />
+              ) : (
+                <Svg
+                  aria-label={t('reviewToggleButton')}
+                  id={isExpanded ? 'navigate-up' : 'navigate-down'}
+                  fill={variables.palette.on_surface_variant}
+                />
+              )}
+            </IconButton>
+          )}
+        </StyledFlexTopCenter>
+      </StyledActivityListItemInner>
+
+      {expandedView && (
+        <TransitionGroup>
+          {isExpanded && (!isLoadingExpandedView || isExpandComplete) ? (
+            <Collapse
+              onEntered={() => setIsExpandComplete(true)}
+              onExit={() => setIsExpandComplete(false)}
+            >
+              {expandedView}
+            </Collapse>
+          ) : undefined}
+        </TransitionGroup>
+      )}
+    </StyledActivityListItem>
+  );
+};

--- a/src/modules/Dashboard/features/Participant/Assignments/ActivityListItem/ActivityListItem.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/ActivityListItem/ActivityListItem.tsx
@@ -19,6 +19,14 @@ import {
   StyledActivityName,
 } from './ActivityListItem.styles';
 
+/**
+ * Generic container for displaying an activity or flow in any of the lists shown on the
+ * Participant Details page.
+ *
+ * If it's desirable for a button being passed in the `children` to cause the entire list item to be
+ * clickable, make sure to assign it the CSS class `primary-button`. It's advised to add the
+ * `disableRipple` prop to such a button for a better user experience.
+ */
 export const ActivityListItem = ({
   activityOrFlow,
   onClickToggleExpandedView,

--- a/src/modules/Dashboard/features/Participant/Assignments/ActivityListItem/ActivityListItem.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/ActivityListItem/ActivityListItem.tsx
@@ -21,7 +21,6 @@ import {
 
 export const ActivityListItem = ({
   activityOrFlow,
-  onClick,
   onClickToggleExpandedView,
   expandedView,
   isLoadingExpandedView,
@@ -37,11 +36,9 @@ export const ActivityListItem = ({
     onClickToggleExpandedView?.(!isExpanded);
   };
 
-  const handleClick = onClick ?? (expandedView ? handleClickToggleExpandedView : undefined);
-
   return (
     <StyledActivityListItem>
-      <StyledActivityListItemInner as={handleClick ? 'a' : 'div'} onClick={handleClick}>
+      <StyledActivityListItemInner>
         <StyledFlexTopCenter sx={{ gap: 0.8 }}>
           <StyledActivityThumbnailContainer sx={{ width: '5.6rem', height: '5.6rem', mr: 0.8 }}>
             {isFlow ? (
@@ -63,6 +60,8 @@ export const ActivityListItem = ({
               onClick={handleClickToggleExpandedView}
               color="outlined"
               sx={{ ml: 0.8 }}
+              className="primary-button"
+              disableRipple
               disabled={isLoadingExpandedView}
             >
               {isLoadingExpandedView && !isExpandComplete ? (

--- a/src/modules/Dashboard/features/Participant/Assignments/ActivityListItem/ActivityListItem.types.ts
+++ b/src/modules/Dashboard/features/Participant/Assignments/ActivityListItem/ActivityListItem.types.ts
@@ -1,8 +1,11 @@
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, ReactNode } from 'react';
 
 import { ParticipantActivityOrFlow } from 'api';
 
 export type ActivityListItemProps = PropsWithChildren<{
   activityOrFlow: ParticipantActivityOrFlow;
   onClick?: () => void;
+  onClickToggleExpandedView?: (isExpanded: boolean) => void;
+  expandedView?: ReactNode;
+  isLoadingExpandedView?: boolean;
 }>;

--- a/src/modules/Dashboard/features/Participant/Assignments/ActivityListItem/ActivityListItem.types.ts
+++ b/src/modules/Dashboard/features/Participant/Assignments/ActivityListItem/ActivityListItem.types.ts
@@ -8,9 +8,11 @@ export type ActivityListItemProps = {
   expandedView?: ReactNode;
   isLoadingExpandedView?: boolean;
   /**
-   * For non-expandable list items: to make the list item clickable, in `children`, include a button
-   * with class `primary-button`. That button will have a pseudo-element added that will make the
-   * whole list item clickable.
+   * For non-expandable list items:
+   *
+   * If it's desirable for a button being passed in the `children` to cause the entire list item to
+   * be clickable, make sure to assign it the CSS class `primary-button`. It's advised to add the
+   * `disableRipple` prop to such a button for a better user experience.
    */
   children?: ReactNode;
 };

--- a/src/modules/Dashboard/features/Participant/Assignments/ActivityListItem/ActivityListItem.types.ts
+++ b/src/modules/Dashboard/features/Participant/Assignments/ActivityListItem/ActivityListItem.types.ts
@@ -1,11 +1,16 @@
-import { PropsWithChildren, ReactNode } from 'react';
+import { ReactNode } from 'react';
 
 import { ParticipantActivityOrFlow } from 'api';
 
-export type ActivityListItemProps = PropsWithChildren<{
+export type ActivityListItemProps = {
   activityOrFlow: ParticipantActivityOrFlow;
-  onClick?: () => void;
   onClickToggleExpandedView?: (isExpanded: boolean) => void;
   expandedView?: ReactNode;
   isLoadingExpandedView?: boolean;
-}>;
+  /**
+   * For non-expandable list items: to make the list item clickable, in `children`, include a button
+   * with class `primary-button`. That button will have a pseudo-element added that will make the
+   * whole list item clickable.
+   */
+  children?: ReactNode;
+};

--- a/src/modules/Dashboard/features/Participant/Assignments/AssignmentsTab/AssignmentsTab.hooks.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/AssignmentsTab/AssignmentsTab.hooks.tsx
@@ -165,8 +165,18 @@ export const useAssignmentsTab = ({
     [targetSubject],
   );
 
+  /**
+   * Returns action menu items for the given activity or flow, based on activity and assignment
+   * status and user permissions.
+   *
+   * If `targetSubjectArg` is omitted, assumes general tab context (main activity/flow list of
+   * either the About Participant or By Participant tab).
+   *
+   * If `targetSubjectArg` is provided, assumes expanded view context (list of target subjects for
+   * the current respondent).
+   */
   const getActionsMenu = useCallback(
-    (activityOrFlow: ParticipantActivityOrFlow) => {
+    (activityOrFlow: ParticipantActivityOrFlow, targetSubjectArg = targetSubject) => {
       const { id, autoAssign, assignments, isFlow, performanceTaskType, status } = activityOrFlow;
 
       // TODO: Remove extra steps below after supportedPlatforms prop is returned by API
@@ -180,17 +190,19 @@ export const useAssignmentsTab = ({
       );
       const isWebSupported = getIsWebSupported(items);
 
+      const isExpandedViewContext = !!respondentSubject && !!targetSubjectArg;
       const isEditDisplayed =
+        !isExpandedViewContext &&
         canEdit &&
         (isFlow ||
           !activityOrFlow.isPerformanceTask ||
           EditablePerformanceTasks.includes(performanceTaskType ?? ''));
       const isAssignable =
         status === ActivityAssignmentStatus.Active || status === ActivityAssignmentStatus.Inactive;
-      const isTargetTeamMember = targetSubject?.tag === 'Team';
+      const isTargetTeamMember = targetSubjectArg?.tag === 'Team';
       const isAssigned = !!assignments?.some(
         (a) =>
-          a.targetSubject.id === targetSubject?.id ||
+          a.targetSubject.id === targetSubjectArg?.id ||
           a.respondentSubject.id === respondentSubject?.id,
       );
       const isAssignDisplayed =
@@ -228,11 +240,11 @@ export const useAssignmentsTab = ({
           disabled: !id,
           icon: <Svg id="export" />,
           title: t('exportData'),
-          isDisplayed: canAccessData && !!targetSubject,
+          isDisplayed: canAccessData && !!targetSubjectArg,
         },
         {
           'data-testid': `${dataTestId}-assign`,
-          action: () => onClickAssign(activityOrFlow),
+          action: () => onClickAssign(activityOrFlow, targetSubjectArg),
           icon: <Svg id="file-plus" />,
           title: isFlow ? t('assignFlow') : t('assignActivity'),
           isDisplayed: isAssignDisplayed,
@@ -261,13 +273,11 @@ export const useAssignmentsTab = ({
               sourceSubject: respondentSubject && {
                 ...respondentSubject,
                 secretId: respondentSubject.secretUserId,
-                userId: respondentSubject.userId,
                 isTeamMember: respondentSubject.tag === 'Team',
               },
-              targetSubject: targetSubject && {
-                ...targetSubject,
-                secretId: targetSubject.secretUserId,
-                userId: targetSubject.userId,
+              targetSubject: targetSubjectArg && {
+                ...targetSubjectArg,
+                secretId: targetSubjectArg.secretUserId,
                 isTeamMember: isTargetTeamMember,
               },
             }),

--- a/src/modules/Dashboard/features/Participant/Assignments/AssignmentsTab/AssignmentsTab.hooks.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/AssignmentsTab/AssignmentsTab.hooks.tsx
@@ -317,19 +317,21 @@ export const useAssignmentsTab = ({
         onSubmitHandler={() => navigateToData(selectedActivityOrFlow, selectedTargetSubjectId)}
       />
 
-      <DataExportPopup
-        chosenAppletData={appletData}
-        filters={{
-          activityId: selectedActivityOrFlow?.id,
-          targetSubjectId: selectedTargetSubjectId,
-        }}
-        isAppletSetting
-        popupVisible={showExportData}
-        setPopupVisible={() => {
-          setShowExportData(false);
-          setSelectedActivityOrFlow(undefined);
-        }}
-      />
+      {showExportData && (
+        <DataExportPopup
+          chosenAppletData={appletData}
+          filters={{
+            activityId: selectedActivityOrFlow?.id,
+            targetSubjectId: selectedTargetSubjectId,
+          }}
+          isAppletSetting
+          popupVisible={showExportData}
+          setPopupVisible={() => {
+            setShowExportData(false);
+            setSelectedActivityOrFlow(undefined);
+          }}
+        />
+      )}
 
       <ActivityAssignDrawer
         appletId={appletId}

--- a/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ByParticipant.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ByParticipant.tsx
@@ -72,7 +72,7 @@ const ByParticipant = () => {
 
     // Refresh target subject data for any expanded views
     Object.entries(expandedViewsData).forEach(([id, viewData]) => {
-      if (viewData) handleRefetchExpandedView(id);
+      if (viewData) void handleRefetchExpandedView(id);
     });
   }, [handleRefetchActivities, expandedViewsData, handleRefetchExpandedView]);
 
@@ -103,7 +103,7 @@ const ByParticipant = () => {
       if (!respondentSubject) return;
 
       if (isExpanded) {
-        handleRefetchExpandedView(activityOrFlowId);
+        void handleRefetchExpandedView(activityOrFlowId);
       } else {
         // If expanded view is closed, remove data to free up memory and minimize refetches
         // (after delay to account for transition)

--- a/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ByParticipant.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ByParticipant.tsx
@@ -28,7 +28,7 @@ const ByParticipant = () => {
   const isLoadingRespondentSubject = useSubjectStatus() !== 'success';
   const { result: respondentSubject } = useSubject() ?? {};
   const [expandedViewsData, setExpandedViewsData] = useState<
-    Record<string, TargetSubjectsByRespondent | undefined>
+    Record<string, TargetSubjectsByRespondent>
   >({});
   const [expandedViewsLoading, setExpandedViewsLoading] = useState<Record<string, boolean>>({});
 
@@ -71,9 +71,7 @@ const ByParticipant = () => {
     handleRefetchActivities();
 
     // Refresh target subject data for any expanded views
-    Object.entries(expandedViewsData).forEach(([id, viewData]) => {
-      if (viewData) void handleRefetchExpandedView(id);
-    });
+    Object.entries(expandedViewsData).forEach(([id]) => void handleRefetchExpandedView(id));
   }, [handleRefetchActivities, expandedViewsData, handleRefetchExpandedView]);
 
   const {
@@ -108,7 +106,11 @@ const ByParticipant = () => {
         // If expanded view is closed, remove data to free up memory and minimize refetches
         // (after delay to account for transition)
         setTimeout(() => {
-          setExpandedViewsData((prev) => ({ ...prev, [activityOrFlowId]: undefined }));
+          setExpandedViewsData((prev) => {
+            const { [activityOrFlowId]: _, ...rest } = prev;
+
+            return rest;
+          });
         }, 300);
       }
     },
@@ -159,7 +161,7 @@ const ByParticipant = () => {
                   data-test-id={`${dataTestId}-${index}`}
                 />
               }
-              isLoadingExpandedView={!!expandedViewsLoading[activity.id]}
+              isLoadingExpandedView={expandedViewsLoading[activity.id]}
             >
               <ActionsMenu
                 anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}

--- a/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ByParticipant.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ByParticipant.tsx
@@ -1,25 +1,36 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 import { useAsync } from 'shared/hooks';
-import { getAppletRespondentSubjectActivitiesApi } from 'api';
+import {
+  getAppletRespondentSubjectActivitiesApi,
+  getTargetSubjectsByRespondentApi,
+  ParticipantActivityOrFlow,
+  TargetSubjectsByRespondent,
+} from 'api';
 import { users } from 'redux/modules';
 import { ActionsMenu, Spinner } from 'shared/components';
+import { RespondentDetails } from 'modules/Dashboard/types';
 
 import { AssignmentsTab, useAssignmentsTab } from '../AssignmentsTab';
 import { ActivitiesList } from '../ActivitiesList';
 import { ActivityListItem } from '../ActivityListItem';
 import { EmptyState } from '../EmptyState';
+import { ExpandedView } from './ExpandedView';
 
 const dataTestId = 'participant-details-about-participant';
 
 const ByParticipant = () => {
   const { t } = useTranslation('app');
-  const { appletId, subjectId } = useParams();
+  const { appletId, subjectId: respondentSubjectId } = useParams();
   const { useSubject, useSubjectStatus } = users;
-  const isLoadingSubject = useSubjectStatus() !== 'success';
+  const isLoadingRespondentSubject = useSubjectStatus() !== 'success';
   const { result: respondentSubject } = useSubject() ?? {};
+  const [expandedViewsData, setExpandedViewsData] = useState<
+    Record<string, TargetSubjectsByRespondent | undefined>
+  >({});
+  const [expandedViewsLoading, setExpandedViewsLoading] = useState<Record<string, boolean>>({});
 
   const {
     execute: fetchActivities,
@@ -29,35 +40,86 @@ const ByParticipant = () => {
 
   const activities = fetchedActivities?.data.result ?? [];
 
-  const handleRefetch = useCallback(() => {
-    // Avoid fetching activities for respondent if respondent is a limited account
-    if (!appletId || !subjectId || !respondentSubject?.userId) return;
+  const handleRefetchExpandedView = useCallback(
+    async (activityOrFlowId: string) => {
+      if (!respondentSubjectId) return;
 
-    fetchActivities({ appletId, subjectId });
-  }, [appletId, fetchActivities, respondentSubject?.userId, subjectId]);
+      setExpandedViewsLoading((prev) => ({ ...prev, [activityOrFlowId]: true }));
+
+      try {
+        const { data } = await getTargetSubjectsByRespondentApi({
+          activityOrFlowId,
+          subjectId: respondentSubjectId,
+        });
+        // Add or update the correspondent element in expandedViewsData
+        setExpandedViewsData((prev) => ({ ...prev, [activityOrFlowId]: data.result }));
+      } finally {
+        setExpandedViewsLoading((prev) => ({ ...prev, [activityOrFlowId]: false }));
+      }
+    },
+    [respondentSubjectId],
+  );
+
+  const handleRefetchActivities = useCallback(() => {
+    // Avoid fetching activities for respondent if respondent is a limited account
+    if (!appletId || !respondentSubject?.id || !respondentSubject.userId) return;
+
+    fetchActivities({ appletId, subjectId: respondentSubject.id });
+  }, [appletId, fetchActivities, respondentSubject]);
+
+  const handleRefetchAll = useCallback(() => {
+    handleRefetchActivities();
+
+    // Refresh target subject data for any expanded views
+    Object.entries(expandedViewsData).forEach(([id, viewData]) => {
+      if (viewData) handleRefetchExpandedView(id);
+    });
+  }, [handleRefetchActivities, expandedViewsData, handleRefetchExpandedView]);
 
   const {
     getActionsMenu,
     onClickAssign,
+    onClickNavigateToData,
     isLoading: isLoadingHook,
     modals,
-  } = useAssignmentsTab({ appletId, respondentSubject, handleRefetch, dataTestId });
+  } = useAssignmentsTab({
+    appletId,
+    respondentSubject,
+    handleRefetch: handleRefetchAll,
+    dataTestId,
+  });
 
-  /*
-  TODO: Handler for navigating to data when card is expanded
-  https://mindlogger.atlassian.net/browse/M2-7921
-  const handleClickNavigateToData = (activityOrFlow: ParticipantActivityOrFlow, targetSubject: RespondentDetails) => {
+  const handleClickNavigateToData = (
+    activityOrFlow: ParticipantActivityOrFlow,
+    targetSubject: RespondentDetails,
+  ) => {
     if (!respondentSubject) return;
 
     onClickNavigateToData(activityOrFlow, targetSubject.id);
   };
-  */
+
+  const handleClickToggleExpandedView = useCallback(
+    (isExpanded: boolean, activityOrFlowId: string) => {
+      if (!respondentSubject) return;
+
+      if (isExpanded) {
+        handleRefetchExpandedView(activityOrFlowId);
+      } else {
+        // If expanded view is closed, remove data to free up memory and minimize refetches
+        // (after delay to account for transition)
+        setTimeout(() => {
+          setExpandedViewsData((prev) => ({ ...prev, [activityOrFlowId]: undefined }));
+        }, 300);
+      }
+    },
+    [handleRefetchExpandedView, respondentSubject],
+  );
 
   useEffect(() => {
-    handleRefetch();
-  }, [handleRefetch]);
+    handleRefetchActivities();
+  }, [handleRefetchActivities]);
 
-  const isLoading = isLoadingSubject || isLoadingActivities || isLoadingHook;
+  const isLoading = isLoadingRespondentSubject || isLoadingActivities || isLoadingHook;
   const isRespondentLimited = !respondentSubject?.userId;
 
   return (
@@ -76,13 +138,29 @@ const ByParticipant = () => {
         />
       )}
 
-      {!!activities.length && (
+      {!!activities.length && respondentSubject && (
         <ActivitiesList
           title={t('participantDetails.activitiesAndFlows')}
           count={fetchedActivities?.data.count ?? 0}
         >
           {activities.map((activity, index) => (
-            <ActivityListItem key={activity.id} activityOrFlow={activity}>
+            <ActivityListItem
+              key={activity.id}
+              activityOrFlow={activity}
+              onClickToggleExpandedView={(isExpanded) =>
+                handleClickToggleExpandedView(isExpanded, activity.id)
+              }
+              expandedView={
+                <ExpandedView
+                  activityOrFlow={activity}
+                  targetSubjects={expandedViewsData[activity.id]}
+                  getActionsMenu={getActionsMenu}
+                  onClickViewData={handleClickNavigateToData}
+                  data-test-id={`${dataTestId}-${index}`}
+                />
+              }
+              isLoadingExpandedView={!!expandedViewsLoading[activity.id]}
+            >
               <ActionsMenu
                 anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
                 transformOrigin={{ vertical: -6, horizontal: 'right' }}
@@ -90,9 +168,6 @@ const ByParticipant = () => {
                 menuItems={getActionsMenu(activity)}
                 data-testid={`${dataTestId}-${index}`}
               />
-
-              {/* TODO: Add expand/collapse button
-                  https://mindlogger.atlassian.net/browse/M2-7921 */}
             </ActivityListItem>
           ))}
 

--- a/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ExpandedView/ExpandedView.styles.ts
+++ b/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ExpandedView/ExpandedView.styles.ts
@@ -1,0 +1,28 @@
+import { styled } from '@mui/material';
+
+import { DashboardTable } from 'modules/Dashboard/components';
+import { theme, variables } from 'shared/styles';
+
+export const StyledDashboardTable = styled(DashboardTable)`
+  border: 0;
+  border-radius: 0;
+
+  .MuiTable-root {
+    padding-top: ${theme.spacing(1.2)};
+    border-top: ${variables.borderWidth.md} solid ${variables.palette.surface_variant};
+  }
+
+  && {
+    .MuiTable-root,
+    .MuiTableHead-root,
+    .MuiTableCell-root {
+      background-color: ${variables.palette.surface};
+    }
+
+    .MuiTableHead-root tr th:first-of-type,
+    td.MuiTableCell-root:first-of-type {
+      min-width: 28rem;
+      padding-left: ${theme.spacing(1.6)};
+    }
+  }
+`;

--- a/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ExpandedView/ExpandedView.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ExpandedView/ExpandedView.tsx
@@ -1,0 +1,86 @@
+import { useTranslation } from 'react-i18next';
+import { useMemo } from 'react';
+import { Button } from '@mui/material';
+
+import { ParticipantSnippet } from 'modules/Dashboard/components';
+import { ActionsMenu, Row, Svg } from 'shared/components';
+import { StyledFlexTopCenter } from 'shared/styles';
+
+import { ExpandedViewProps } from './ExpandedView.types';
+import { getHeadCells } from './ExpandedView.utils';
+import { StyledDashboardTable } from './ExpandedView.styles';
+
+export const ExpandedView = ({
+  activityOrFlow,
+  targetSubjects = [],
+  getActionsMenu,
+  onClickViewData,
+  'data-test-id': dataTestId,
+}: ExpandedViewProps) => {
+  const { t } = useTranslation('app');
+
+  const rows: Row[] = useMemo(
+    () =>
+      targetSubjects.map(({ submissionCount, currentlyAssigned, ...subject }, index) => ({
+        id: {
+          value: subject.id,
+          content: () => <ParticipantSnippet {...subject} secretId={subject.secretUserId} />,
+        },
+        submissionCount: {
+          value: String(submissionCount),
+          content: () => String(submissionCount),
+        },
+        currentlyAssigned: {
+          value: String(currentlyAssigned),
+          content: () => (currentlyAssigned ? t('yes') : t('no')),
+        },
+        actions: {
+          value: '',
+          content: () => {
+            // Filter assignments attached to this activity/flow by target subject before
+            // passing to `getActionsMenu()` so that the Unassign action only prompts user to
+            // unassign for the specific target subject.
+            const filteredActivityOrFlow = {
+              ...activityOrFlow,
+              assignments: activityOrFlow.assignments.filter(
+                ({ targetSubject }) => targetSubject.id === subject.id,
+              ),
+            };
+
+            return (
+              <StyledFlexTopCenter sx={{ gap: 0.8 }}>
+                <Button
+                  variant="outlined"
+                  onClick={() => onClickViewData(activityOrFlow, subject)}
+                  sx={{ mr: 0.4 }}
+                  data-testid={`${dataTestId}-subject-${index}-view-data`}
+                >
+                  <Svg id="chart" width="18" height="18" fill="currentColor" />
+                  {t('viewData')}
+                </Button>
+
+                <ActionsMenu
+                  anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                  transformOrigin={{ vertical: -6, horizontal: 'right' }}
+                  buttonColor="secondary"
+                  menuItems={getActionsMenu(filteredActivityOrFlow, subject)}
+                  data-testid={`${dataTestId}-subject-${index}`}
+                />
+              </StyledFlexTopCenter>
+            );
+          },
+        },
+      })),
+    [activityOrFlow, dataTestId, getActionsMenu, onClickViewData, t, targetSubjects],
+  );
+
+  return (
+    <StyledDashboardTable
+      columns={getHeadCells()}
+      rows={rows}
+      keyExtractor={({ id }) => `row-${id.value}`}
+      enablePagination={false}
+      data-testid={dataTestId}
+    />
+  );
+};

--- a/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ExpandedView/ExpandedView.types.ts
+++ b/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ExpandedView/ExpandedView.types.ts
@@ -1,0 +1,21 @@
+import { ParticipantActivityOrFlow, TargetSubjectsByRespondent } from 'api';
+import { RespondentDetails } from 'modules/Dashboard/types';
+import { MenuItem } from 'shared/components';
+
+export type ExpandedViewProps = {
+  activityOrFlow: ParticipantActivityOrFlow;
+  targetSubjects?: TargetSubjectsByRespondent;
+  getActionsMenu: (
+    activityOrFlow: ParticipantActivityOrFlow,
+    targetSubjectArg?: RespondentDetails,
+  ) => MenuItem<unknown>[];
+  onClickViewData: (
+    activityOrFlow: ParticipantActivityOrFlow,
+    targetSubject: RespondentDetails,
+  ) => void;
+  'data-test-id': string;
+};
+
+export type ExpandedViewHandle = {
+  refetch: () => void;
+};

--- a/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ExpandedView/ExpandedView.utils.ts
+++ b/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ExpandedView/ExpandedView.utils.ts
@@ -1,0 +1,32 @@
+import i18n from 'i18n';
+
+export const getHeadCells = () => {
+  const { t } = i18n;
+
+  return [
+    {
+      id: 'id',
+      label: t('participantDetails.subjectOfActivity'),
+      width: '40%',
+      enableSort: false,
+    },
+    {
+      id: 'submissionCount',
+      label: t('participantDetails.submissions'),
+      maxWidth: '9rem',
+      enableSort: false,
+    },
+    {
+      id: 'currentlyAssigned',
+      label: t('participantDetails.currentlyAssigned'),
+      maxWidth: '9rem',
+      enableSort: false,
+    },
+    {
+      id: 'actions',
+      label: '',
+      width: '1%',
+      enableSort: false,
+    },
+  ];
+};

--- a/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ExpandedView/index.ts
+++ b/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ExpandedView/index.ts
@@ -1,0 +1,1 @@
+export * from './ExpandedView';

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -1055,7 +1055,11 @@
     "byParticipantEmptyLimitedAccount": "This Participant has a Limited Account and cannot be assigned to complete Activities.",
     "aboutParticipantEmptyTeamMember": "This Participant is a Team Member and Activities cannot be completed about them.",
     "assignActivityButton": "Assign Activity",
-    "activitiesAndFlows": "Activities & Flows"
+    "activitiesAndFlows": "Activities & Flows",
+    "toggleSubjectsView": "Toggle Subjects View",
+    "subjectOfActivity": "Subject of Activity",
+    "submissions": "Submissions",
+    "currentlyAssigned": "Currently Assigned"
   },
   "password": "Password",
   "passwordBlankSpaces": "Password must not contain spaces.",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -1054,7 +1054,11 @@
     "byParticipantEmpty": "Aucune activité n'est attribuée à ce participant pour être complétée.",
     "byParticipantEmptyLimitedAccount": "Ce participant a un compte limité et ne peut pas être assigné pour compléter des activités.",
     "assignActivityButton": "Attribuer une activité",
-    "activitiesAndFlows": "Activités & Flux"
+    "activitiesAndFlows": "Activités & Flux",
+    "toggleSubjectsView": "Basculer la vue des sujets",
+    "subjectOfActivity": "Sujet de l'activité",
+    "submissions": "Soumissions",
+    "currentlyAssigned": "Actuellement assigné"
   },
   "password": "Mot de passe",
   "passwordBlankSpaces": "Le mot de passe ne doit pas contenir d'espaces.",

--- a/src/shared/components/Table/TableHead/TableHead.tsx
+++ b/src/shared/components/Table/TableHead/TableHead.tsx
@@ -17,7 +17,7 @@ export const TableHead = ({
   tableHeadBg,
 }: TableHeadProps) => {
   const createSortHandler = (property: string) => (event: MouseEvent<unknown>) =>
-    onRequestSort(event, property);
+    onRequestSort?.(event, property);
 
   return (
     <StyledTableHead

--- a/src/shared/components/Table/TableHead/TableHead.types.ts
+++ b/src/shared/components/Table/TableHead/TableHead.types.ts
@@ -6,8 +6,8 @@ export type TableHeadProps = {
   className?: string;
   tableHeader: JSX.Element | null;
   headCells: HeadCell[];
-  onRequestSort: (event: React.MouseEvent<unknown>, property: string) => void;
-  order: Order;
+  onRequestSort?: (event: React.MouseEvent<unknown>, property: string) => void;
+  order?: Order;
   orderBy?: string;
   uiType?: UiType;
   hasColFixedWidth?: boolean;


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- ~~[ ] Tests for the changes have been added~~ **(unit tests to be added in separate task)**
- [ ] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-7921](https://mindlogger.atlassian.net/browse/M2-7921)

This PR adds the expanded Subjects view to each Activity/Flow on the PDP's new By Participant tab. It includes these changes:

- Adding API support for the `/subjects/respondent/{subject_id}/activity-or-flow/{activity_or_flow_id}` endpoint, consumed by this expanded view
- Adding the `ExpandedView` sub-component of the `ByParticipant` screen component
- Adjusting the PDP's generic `ActivityListItem` component to be able to support custom expanded view content
- In the `ByParticipant` component, passing an instance of `ExpandedView` to each `ActivityListItem`, and handling fetching/refetching of data from the new endpoint to populate the `ExpandedView` and handle loading states gracefully

### 📸 Screenshots

https://github.com/user-attachments/assets/c7d0207c-7397-44da-842d-3cd97efea4d8

### 🪤 Peer Testing

> [!TIP]
> Ensure the `enableActivityAssign` feature flag is enabled in the environment you are testing from.

Review the AC of the [Jira ticket](https://mindlogger.atlassian.net/browse/M2-7921) to ensure behaviour of expanded view is in alignment. Specifically be sure to test this screen where:

- The Participant whose PDP you're on is manually assigned as a respondent to activities/flows about either themselves or other Participants
- The Participant whose PDP you're on is auto-assigned to certain activities/flows
- The Participant whose PDP you're on is **not** assigned to certain activities/flows, but has submitted answer data as a respondent in the past, about either themselves or other Participants
- Ensure that after creating assignments or removing assignments by clicking Assign/Unassign from any of the action menus on this screen causes data to be refreshed so that the screen is always up-to-date