### PR TITLE
feat: add Greek option for invitation emails (M2-7665)

### DIFF
--- a/src/modules/Dashboard/features/Applet/Overview/Overview.utils.tsx
+++ b/src/modules/Dashboard/features/Applet/Overview/Overview.utils.tsx
@@ -1,11 +1,11 @@
 import { PropsOf } from '@emotion/react';
 import { Button } from '@mui/material';
-import { formatDistanceStrict } from 'date-fns';
+import { formatDistanceStrict, Locale } from 'date-fns';
 import { enUS, fr } from 'date-fns/locale';
 import { generatePath } from 'react-router-dom';
 
 import i18n from 'i18n';
-import { GetAppletSubmissionsResponse, Languages } from 'api';
+import { GetAppletSubmissionsResponse } from 'api';
 import { ParticipantSnippet } from 'modules/Dashboard/components';
 import { QuickStats } from 'modules/Dashboard/features/Applet/Overview/QuickStats';
 import { Svg } from 'shared/components';
@@ -13,7 +13,13 @@ import { StyledMaybeEmpty } from 'shared/styles/styledComponents/MaybeEmpty';
 import { StyledFlexAllCenter, theme, variables } from 'shared/styles';
 import { page } from 'resources';
 
-const locales = { en: enUS, fr };
+const getI18nLocale = (language: string): Locale => {
+  if (language === 'fr') {
+    return fr;
+  }
+
+  return enUS;
+};
 
 export function mapResponseToQuickStatProps(
   { participantsCount, submissionsCount }: GetAppletSubmissionsResponse = {
@@ -145,7 +151,7 @@ export function mapResponseToSubmissionsTableProps(
                         new Date(),
                         {
                           addSuffix: true,
-                          locale: locales[i18n.language as Languages],
+                          locale: getI18nLocale(i18n.language),
                         },
                       )}
                     </StyledMaybeEmpty>

--- a/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantForm/AddParticipantForm.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantForm/AddParticipantForm.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { useForm } from 'react-hook-form';
 
 import { AccountType } from 'modules/Dashboard/types/Dashboard.types';
-import { Languages } from 'api';
+import { ApiLanguages } from 'api';
 
 import { AddParticipantForm } from './AddParticipantForm';
 import { AddParticipantFormValues } from '../AddParticipantPopup.types';
@@ -16,7 +16,7 @@ const AddParticipantFormTest = ({ accountType }: Pick<AddParticipantFormProps, '
   const { control } = useForm<AddParticipantFormValues>({
     defaultValues: {
       ...defaultValues,
-      language: Languages.EN,
+      language: ApiLanguages.EN,
     },
   });
 

--- a/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantForm/AddParticipantForm.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantForm/AddParticipantForm.tsx
@@ -2,7 +2,7 @@ import { Grid } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 
 import { InputController, SelectController } from 'shared/components/FormComponents';
-import { Languages } from 'api';
+import { ApiLanguages } from 'api';
 import { AccountType } from 'modules/Dashboard/types/Dashboard.types';
 import { PARTICIPANT_TAG_ICONS, USER_SELECTABLE_PARTICIPANT_TAGS } from 'shared/consts';
 import { Svg } from 'shared/components';
@@ -101,7 +101,7 @@ export const AddParticipantForm = ({
             <SelectController
               {...commonProps}
               name={Fields.language}
-              options={Object.values(Languages).map((lang) => ({ labelKey: lang, value: lang }))}
+              options={Object.values(ApiLanguages).map((lang) => ({ labelKey: lang, value: lang }))}
               label={t('invitationLanguage')}
               helperText={t('languageTooltip')}
               data-testid={`${dataTestid}-lang`}

--- a/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.schema.ts
+++ b/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.schema.ts
@@ -2,7 +2,7 @@ import * as yup from 'yup';
 
 import i18n from 'i18n';
 import { EMAIL_REGEXP, USER_SELECTABLE_PARTICIPANT_TAGS } from 'shared/consts';
-import { Languages } from 'api';
+import { ApiLanguages } from 'api';
 import { AccountType } from 'modules/Dashboard/types/Dashboard.types';
 
 export const AddParticipantPopupSchema = () => {
@@ -34,7 +34,7 @@ export const AddParticipantPopupSchema = () => {
       nickname: yup.string(),
       secretUserId: yup.string().required(t('secretUserIdRequired')),
       tag: yup.string().oneOf(USER_SELECTABLE_PARTICIPANT_TAGS),
-      language: yup.string().required().oneOf(Object.values(Languages)),
+      language: yup.string().required().oneOf(Object.values(ApiLanguages)),
     })
     .required();
 };

--- a/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.tsx
@@ -9,7 +9,7 @@ import { StyledErrorText, StyledFlexEnd, StyledModalWrapper } from 'shared/style
 import { useFormError } from 'modules/Dashboard/hooks';
 import { NON_UNIQUE_VALUE_MESSAGE, Roles } from 'shared/consts';
 import { MixpanelProps, Mixpanel, getErrorMessage } from 'shared/utils';
-import { Languages, postAppletInvitationApi, postAppletShellAccountApi } from 'api';
+import { ApiLanguages, postAppletInvitationApi, postAppletShellAccountApi } from 'api';
 import { useAppDispatch } from 'redux/store';
 import { useAsync } from 'shared/hooks';
 import { banners } from 'redux/modules';
@@ -40,7 +40,7 @@ export const AddParticipantPopup = ({
   const { t, i18n } = useTranslation('app');
   const defaults = {
     ...defaultValues,
-    language: i18n.language as Languages,
+    language: i18n.language as ApiLanguages,
   };
   const {
     handleSubmit,

--- a/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.types.ts
+++ b/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.types.ts
@@ -1,4 +1,4 @@
-import { Languages } from 'api';
+import { ApiLanguages } from 'api';
 import { AccountType } from 'modules/Dashboard/types';
 import { UserSelectableParticipantTag } from 'shared/consts';
 
@@ -22,7 +22,7 @@ export type AddParticipantFormValues = {
   nickname?: string;
   secretUserId: string;
   tag?: UserSelectableParticipantTag;
-  language: Languages;
+  language: ApiLanguages;
 };
 
 export const Fields = {

--- a/src/modules/Dashboard/features/Applet/Popups/UpgradeAccountPopup/UpgradeAccountForm/UpgradeAccountForm.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/UpgradeAccountPopup/UpgradeAccountForm/UpgradeAccountForm.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { useForm } from 'react-hook-form';
 
-import { Languages } from 'api';
+import { ApiLanguages } from 'api';
 
 import { UpgradeAccountForm } from './UpgradeAccountForm';
 import { UpgradeAccountFormValues } from '../UpgradeAccountPopup.types';
@@ -13,7 +13,7 @@ const UpgradeAccountFormTest = () => {
   const { control } = useForm<UpgradeAccountFormValues>({
     defaultValues: {
       email: '',
-      language: Languages.EN,
+      language: ApiLanguages.EN,
     },
   });
 

--- a/src/modules/Dashboard/features/Applet/Popups/UpgradeAccountPopup/UpgradeAccountForm/UpgradeAccountForm.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/UpgradeAccountPopup/UpgradeAccountForm/UpgradeAccountForm.tsx
@@ -2,7 +2,7 @@ import { Grid } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 
 import { InputController, SelectController } from 'shared/components/FormComponents';
-import { Languages } from 'api';
+import { ApiLanguages } from 'api';
 
 import { UpgradeAccountFormProps } from './UpgradeAccountForm.types';
 import { Fields } from '../UpgradeAccountPopup.types';
@@ -35,7 +35,7 @@ export const UpgradeAccountForm = ({
           <SelectController
             {...commonProps}
             name={Fields.language}
-            options={Object.values(Languages).map((lang) => ({ labelKey: lang, value: lang }))}
+            options={Object.values(ApiLanguages).map((lang) => ({ labelKey: lang, value: lang }))}
             label={t('invitationLanguage')}
             helperText={t('languageTooltip')}
             data-testid={`${dataTestid}-lang`}

--- a/src/modules/Dashboard/features/Applet/Popups/UpgradeAccountPopup/UpgradeAccountPopup.schema.ts
+++ b/src/modules/Dashboard/features/Applet/Popups/UpgradeAccountPopup/UpgradeAccountPopup.schema.ts
@@ -2,7 +2,7 @@ import * as yup from 'yup';
 
 import i18n from 'i18n';
 import { EMAIL_REGEXP } from 'shared/consts';
-import { Languages } from 'api';
+import { ApiLanguages } from 'api';
 
 export const UpgradeAccountPopupSchema = () => {
   const { t } = i18n;
@@ -19,7 +19,7 @@ export const UpgradeAccountPopupSchema = () => {
 
           return true;
         }),
-      language: yup.string().required().oneOf(Object.values(Languages)),
+      language: yup.string().required().oneOf(Object.values(ApiLanguages)),
     })
     .required();
 };

--- a/src/modules/Dashboard/features/Applet/Popups/UpgradeAccountPopup/UpgradeAccountPopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/UpgradeAccountPopup/UpgradeAccountPopup.tsx
@@ -12,7 +12,7 @@ import {
 } from 'shared/styles';
 import { useFormError } from 'modules/Dashboard/hooks';
 import { Mixpanel, MixpanelProps, getErrorMessage } from 'shared/utils';
-import { Languages, postSubjectInvitationApi } from 'api';
+import { ApiLanguages, postSubjectInvitationApi } from 'api';
 import { useAppDispatch } from 'redux/store';
 import { useAsync } from 'shared/hooks';
 import { banners } from 'redux/modules';
@@ -41,7 +41,7 @@ export const UpgradeAccountPopup = ({
   const { t, i18n } = useTranslation('app');
   const defaultValues = {
     email: '',
-    language: i18n.language as Languages,
+    language: i18n.language as ApiLanguages,
   };
   const {
     handleSubmit,

--- a/src/modules/Dashboard/features/Applet/Popups/UpgradeAccountPopup/UpgradeAccountPopup.types.ts
+++ b/src/modules/Dashboard/features/Applet/Popups/UpgradeAccountPopup/UpgradeAccountPopup.types.ts
@@ -1,4 +1,4 @@
-import { Languages } from 'api';
+import { ApiLanguages } from 'api';
 import { ParticipantSnippetInfo } from 'modules/Dashboard/components';
 
 export type UpgradeAccountPopupProps = {
@@ -11,7 +11,7 @@ export type UpgradeAccountPopupProps = {
 
 export type UpgradeAccountFormValues = {
   email: string;
-  language: Languages;
+  language: ApiLanguages;
 };
 
 export const Fields = {

--- a/src/modules/Dashboard/features/Managers/Popups/AddManagerPopup/AddManagerForm/AddManagerForm.tsx
+++ b/src/modules/Dashboard/features/Managers/Popups/AddManagerPopup/AddManagerForm/AddManagerForm.tsx
@@ -8,7 +8,7 @@ import {
   SelectController,
   TagsAutocompleteController,
 } from 'shared/components/FormComponents';
-import { Languages } from 'api';
+import { ApiLanguages } from 'api';
 import { Roles } from 'shared/consts';
 import { getRespondentName } from 'shared/utils';
 import { Svg, Tooltip } from 'shared/components';
@@ -114,7 +114,7 @@ export const AddManagerForm = ({
           <SelectController
             {...commonProps}
             name={Fields.language}
-            options={Object.values(Languages).map((lang) => ({ labelKey: lang, value: lang }))}
+            options={Object.values(ApiLanguages).map((lang) => ({ labelKey: lang, value: lang }))}
             label={t('invitationLanguage')}
             helperText={t('languageTooltip')}
             data-testid={`${dataTestId}-lang`}

--- a/src/modules/Dashboard/features/Managers/Popups/AddManagerPopup/AddManagerPopup.schema.ts
+++ b/src/modules/Dashboard/features/Managers/Popups/AddManagerPopup/AddManagerPopup.schema.ts
@@ -2,7 +2,7 @@ import * as yup from 'yup';
 
 import i18n from 'i18n';
 import { EMAIL_REGEXP, Roles } from 'shared/consts';
-import { Languages } from 'api';
+import { ApiLanguages } from 'api';
 
 export const AddManagerPopupSchema = (isWorkspaceNameVisible: boolean) => {
   const { t } = i18n;
@@ -17,7 +17,7 @@ export const AddManagerPopupSchema = (isWorkspaceNameVisible: boolean) => {
       firstName: yup.string().required(t('firstNameRequired')),
       lastName: yup.string().required(t('lastNameRequired')),
       title: yup.string(),
-      language: yup.string().required().oneOf(Object.values(Languages)),
+      language: yup.string().required().oneOf(Object.values(ApiLanguages)),
       subjectIds: yup.array().of(yup.string().required()),
       workspaceName: isWorkspaceNameVisible
         ? yup.string().required(t('workspaceNameRequired'))

--- a/src/modules/Dashboard/features/Managers/Popups/AddManagerPopup/AddManagerPopup.tsx
+++ b/src/modules/Dashboard/features/Managers/Popups/AddManagerPopup/AddManagerPopup.tsx
@@ -8,7 +8,7 @@ import { StyledErrorText, StyledModalWrapper } from 'shared/styles';
 import { useFormError } from 'modules/Dashboard/hooks';
 import { Roles } from 'shared/consts';
 import { Mixpanel, MixpanelProps, getErrorMessage, isManagerOrOwner } from 'shared/utils';
-import { Languages, postAppletInvitationApi } from 'api';
+import { ApiLanguages, postAppletInvitationApi } from 'api';
 import { useAppDispatch } from 'redux/store';
 import { useAsync } from 'shared/hooks';
 import { banners, users, workspaces } from 'redux/modules';
@@ -52,7 +52,7 @@ export const AddManagerPopup = ({
 
   const defaults = {
     ...defaultValues(appletRoles),
-    language: i18n.language as Languages,
+    language: i18n.language as ApiLanguages,
     workspaceName: workspaceInfo?.name,
   };
 

--- a/src/modules/Dashboard/features/Managers/Popups/AddManagerPopup/AddManagerPopup.types.ts
+++ b/src/modules/Dashboard/features/Managers/Popups/AddManagerPopup/AddManagerPopup.types.ts
@@ -1,4 +1,4 @@
-import { Languages } from 'api';
+import { ApiLanguages } from 'api';
 import { WorkspaceInfo } from 'modules/Dashboard/types';
 import { Roles } from 'shared/consts';
 
@@ -16,7 +16,7 @@ export type AddManagerFormValues = {
   firstName: string;
   lastName: string;
   title?: string;
-  language: Languages;
+  language: ApiLanguages;
   participants?: { label: string; id: string }[];
   workspaceName?: string;
 };

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -556,6 +556,7 @@
   "elementsAssociatedWithSubscales": "Elements associated with one or more subscales",
   "elementsNotIncludedInSubscale": "Elements not included in any subscale",
   "elementsWithinSubscale": "Elements within subscale",
+  "el": "Greek",
   "email": "Email",
   "emailBody": "Email Body",
   "emailRequired": "Email is required",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -552,6 +552,7 @@
   "editParticipant": "Modifier un participant",
   "editRespondents": "Modifier les participants",
   "editUser": "Modifier l'utilisateur",
+  "el": "Grec",
   "element": "Élément",
   "elementsAssociatedWithSubscales": "Éléments associés à une ou plusieurs sous-échelles",
   "elementsNotIncludedInSubscale": "Éléments non inclus dans une sous-échelle",

--- a/src/shared/api/api.const.ts
+++ b/src/shared/api/api.const.ts
@@ -1,12 +1,8 @@
-export enum Languages {
+export enum ApiLanguages {
   EN = 'en',
   FR = 'fr',
+  EL = 'el',
 }
-
-export const regionalLangFormats = {
-  [Languages.EN]: 'en-US',
-  [Languages.FR]: 'fr-FR',
-};
 
 export const DEFAULT_CONFIG = {
   headers: {
@@ -15,11 +11,6 @@ export const DEFAULT_CONFIG = {
 };
 
 export const BASE_API_URL = process.env.REACT_APP_API_DOMAIN;
-
-export const LANGUAGES: { en: string; fr: string } = {
-  en: 'en_US',
-  fr: 'fr_FR',
-};
 
 export enum ApiResponseCodes {
   SuccessfulResponse = 200,

--- a/src/shared/api/api.utils.ts
+++ b/src/shared/api/api.utils.ts
@@ -2,15 +2,16 @@ import axios, { AxiosError, InternalAxiosRequestConfig } from 'axios';
 
 import { authStorage } from 'shared/utils/authStorage';
 import { LocalStorageKeys, storage } from 'shared/utils/storage';
+import { UiLanguages, regionalLangFormats } from 'shared/ui';
 
-import { apiRoutesToSkip, BASE_API_URL, Languages, regionalLangFormats } from './api.const';
+import { apiRoutesToSkip, BASE_API_URL } from './api.const';
 import { signInRefreshTokenApi } from './api';
 
 export const getCommonConfig = (config: InternalAxiosRequestConfig) => {
   config.baseURL = BASE_API_URL || '';
-  const langFromStorage = storage.getItem(LocalStorageKeys.Language) || Languages.EN;
+  const langFromStorage = storage.getItem(LocalStorageKeys.Language) || UiLanguages.EN;
   config.headers['Content-Language'] =
-    regionalLangFormats[langFromStorage as Languages] || (langFromStorage as string);
+    regionalLangFormats[langFromStorage as UiLanguages] || langFromStorage;
 
   return config;
 };

--- a/src/shared/components/Footer/Language/Language.const.tsx
+++ b/src/shared/components/Footer/Language/Language.const.tsx
@@ -1,17 +1,17 @@
 import { Svg } from 'shared/components/Svg';
-import { Languages } from 'shared/api';
+import { UiLanguages } from 'shared/ui';
 
 import { LanguageItem } from './Language.types';
 
 export const languages: LanguageItem[] = [
   {
-    value: Languages.EN,
+    value: UiLanguages.EN,
     label: 'English',
     type: 'United States',
     component: <Svg id="us" width={32} height={24} />,
   },
   {
-    value: Languages.FR,
+    value: UiLanguages.FR,
     label: 'Français',
     type: 'France',
     component: <Svg id="france" width={32} height={24} />,

--- a/src/shared/components/Footer/Language/Language.tsx
+++ b/src/shared/components/Footer/Language/Language.tsx
@@ -4,7 +4,7 @@ import { Box } from '@mui/material';
 
 import { StyledLabelMedium, variables } from 'shared/styles';
 import { LocalStorageKeys, storage } from 'shared/utils/storage';
-import { Languages } from 'shared/api';
+import { UiLanguages } from 'shared/ui';
 
 import { SelectLanguage } from './SelectLanguage';
 import { LanguageItem } from './Language.types';
@@ -13,7 +13,7 @@ import { languages } from './Language.const';
 
 export const Language = () => {
   const { i18n } = useTranslation('app');
-  const langFromStorage = storage.getItem(LocalStorageKeys.Language) || Languages.EN;
+  const langFromStorage = storage.getItem(LocalStorageKeys.Language) || UiLanguages.EN;
   const language = languages.find((lang) => lang.value === langFromStorage) as LanguageItem;
 
   const [currentLanguage, setCurrentLanguage] = useState(language);

--- a/src/shared/components/Footer/Language/Language.types.tsx
+++ b/src/shared/components/Footer/Language/Language.types.tsx
@@ -1,7 +1,7 @@
-import { Languages } from 'shared/api';
+import { UiLanguages } from 'shared/ui';
 
 export type LanguageItem = {
-  value: Languages;
+  value: UiLanguages;
   label: string;
   type: string;
   component: JSX.Element;

--- a/src/shared/components/Footer/Language/SelectLanguage/SelectLanguage.test.tsx
+++ b/src/shared/components/Footer/Language/SelectLanguage/SelectLanguage.test.tsx
@@ -3,7 +3,7 @@
 import { screen, fireEvent } from '@testing-library/react';
 
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
-import { Languages } from 'shared/api';
+import { ApiLanguages } from 'shared/api';
 
 import { SelectLanguage } from './SelectLanguage';
 import { languages } from '../Language.const';
@@ -13,7 +13,7 @@ const props = {
   open: true,
   onClose,
   currentLanguage: {
-    value: Languages.EN,
+    value: ApiLanguages.EN,
   },
 };
 
@@ -52,7 +52,7 @@ describe('SelectLanguage', () => {
     fireEvent.click(okButton);
 
     expect(onClose).toBeCalledWith({
-      value: Languages.EN,
+      value: ApiLanguages.EN,
     });
 
     const close = screen.getByTestId(`${dataTestid}-close-button`);

--- a/src/shared/components/Footer/Language/SelectLanguage/SelectLanguage.test.tsx
+++ b/src/shared/components/Footer/Language/SelectLanguage/SelectLanguage.test.tsx
@@ -3,7 +3,7 @@
 import { screen, fireEvent } from '@testing-library/react';
 
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
-import { ApiLanguages } from 'shared/api';
+import { UiLanguages } from 'shared/ui';
 
 import { SelectLanguage } from './SelectLanguage';
 import { languages } from '../Language.const';
@@ -13,7 +13,7 @@ const props = {
   open: true,
   onClose,
   currentLanguage: {
-    value: ApiLanguages.EN,
+    value: UiLanguages.EN,
   },
 };
 
@@ -52,7 +52,7 @@ describe('SelectLanguage', () => {
     fireEvent.click(okButton);
 
     expect(onClose).toBeCalledWith({
-      value: ApiLanguages.EN,
+      value: UiLanguages.EN,
     });
 
     const close = screen.getByTestId(`${dataTestid}-close-button`);

--- a/src/shared/hooks/useTimeAgo.ts
+++ b/src/shared/hooks/useTimeAgo.ts
@@ -3,7 +3,7 @@ import TimeAgo from 'javascript-time-ago';
 import en from 'javascript-time-ago/locale/en';
 import fr from 'javascript-time-ago/locale/fr';
 
-import { LANGUAGES } from 'shared/api/api.const';
+import { regionalLangFormats, UiLanguages } from 'shared/ui';
 
 TimeAgo.addLocale(en);
 TimeAgo.addLocale(fr);
@@ -11,5 +11,5 @@ TimeAgo.addLocale(fr);
 export const useTimeAgo = () => {
   const { i18n } = useTranslation('app');
 
-  return new TimeAgo(LANGUAGES[i18n.language as keyof typeof LANGUAGES].replace('_', '-'));
+  return new TimeAgo(regionalLangFormats[i18n.language as UiLanguages]);
 };

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -1,0 +1,1 @@
+export * from './ui.const';

--- a/src/shared/ui/ui.const.ts
+++ b/src/shared/ui/ui.const.ts
@@ -1,0 +1,9 @@
+export enum UiLanguages {
+  EN = 'en',
+  FR = 'fr',
+}
+
+export const regionalLangFormats = {
+  [UiLanguages.EN]: 'en-US',
+  [UiLanguages.FR]: 'fr-FR',
+};


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-7665](https://mindlogger.atlassian.net/browse/M2-7665)

This PR adds a "Greek" language option for invitation emails.

This PR also refactors some of the language-related code to make a clear distinction between:
* Languages supported by the API; vs ...
* Languages supported by the UI

Previously, both context uses the same enum, which contained English and French. With this PR, we're adding Greek to only the list of languages supported by the API, with the UI continuing to support only English and French.

Regardless if the 2 contexts would eventually support the same list of language or not, the 2 contexts are nonetheless for different purposes, and therefore the 2 enum should not conflate with each other.

### 📸 Screenshots

Add participants screen

<img width="779" alt="Screenshot 2024-10-15 at 2 49 32 PM" src="https://github.com/user-attachments/assets/419efda2-1bdb-4cef-ab28-aded67cf1235">

Add team member screen (which hits the same endpoint)

<img width="774" alt="Screenshot 2024-10-15 at 2 49 45 PM" src="https://github.com/user-attachments/assets/5adbd506-a391-4a75-a020-abe3a9b920a2">
  
### 🪤 Peer Testing

1. Create an applet
2. Attempt to invite a participant with a full-account
  * The language dropdown should now contain "Greek" as an option
3. Attempt to add a team member
  * The language dropdown should now contain "Greek" as an option

### ✏️ Notes

The corresponding BE PR is here: https://github.com/ChildMindInstitute/mindlogger-backend-refactor/pull/1624