### PR TITLE
fix: Add "web only" chips to web-only items in the Applet editor's Item Type dropdown. (M2-8058)

### DIFF
--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/GroupedSelectSearchController/GroupedSelectSearchController.styles.ts
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/GroupedSelectSearchController/GroupedSelectSearchController.styles.ts
@@ -1,4 +1,4 @@
-import { styled, MenuItem, ListItem, Select, Box } from '@mui/material';
+import { styled, MenuItem, ListItem, Select } from '@mui/material';
 
 import { theme, variables } from 'shared/styles';
 import { shouldForwardProp } from 'shared/utils';
@@ -84,11 +84,4 @@ export const StyledListSubheader = styled(ListItem)`
   .svg-checkbox-multiple-filled {
     stroke: ${palette.on_surface_variant};
   }
-`;
-
-export const StyledMobileOnly = styled(Box)`
-  margin-left: ${theme.spacing(1)};
-  padding: ${theme.spacing(0.6, 1.2)};
-  background-color: ${variables.palette.on_surface_variant_alfa8};
-  border-radius: ${variables.borderRadius.xs};
 `;

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/GroupedSelectSearchController/GroupedSelectSearchController.utils.test.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/GroupedSelectSearchController/GroupedSelectSearchController.utils.test.tsx
@@ -1,59 +1,34 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
-import { ItemResponseType } from 'shared/consts';
-
-import { handleSearchKeyDown, getIsOnlyMobileValue } from './GroupedSelectSearchController.utils';
+import { handleSearchKeyDown } from './GroupedSelectSearchController.utils';
 
 describe('handleSearchKeyDown', () => {
-  const stopPropagationMock = jest.fn();
-  const preventDefaultMock = jest.fn();
+  let mockEvent: React.KeyboardEvent;
 
-  const mockEvent = {
-    stopPropagation: stopPropagationMock,
-    preventDefault: preventDefaultMock,
-  };
+  beforeEach(() => {
+    mockEvent = {
+      ...new KeyboardEvent('keypress'),
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn(),
+    } as unknown as React.KeyboardEvent;
+  });
 
   test('nothing is called if key is escape', () => {
     handleSearchKeyDown({ ...mockEvent, key: 'Escape' });
 
-    expect(stopPropagationMock).not.toHaveBeenCalled();
-    expect(preventDefaultMock).not.toHaveBeenCalled();
+    expect(mockEvent.stopPropagation).not.toHaveBeenCalled();
+    expect(mockEvent.preventDefault).not.toHaveBeenCalled();
   });
 
   test('stops propagation if key is neither escape or enter', () => {
     handleSearchKeyDown({ ...mockEvent, key: 'Tab' });
 
-    expect(stopPropagationMock).toHaveBeenCalledTimes(1);
-    expect(preventDefaultMock).not.toHaveBeenCalled();
+    expect(mockEvent.stopPropagation).toHaveBeenCalledTimes(1);
+    expect(mockEvent.preventDefault).not.toHaveBeenCalled();
   });
 
   test('prevents default and stops propagation if key is enter', () => {
     handleSearchKeyDown({ ...mockEvent, key: 'Enter' });
 
-    expect(stopPropagationMock).toHaveBeenCalledTimes(1);
-    expect(preventDefaultMock).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe('getIsOnlyMobileValue', () => {
-  test.each`
-    value                                       | expectedResult
-    ${ItemResponseType.SingleSelectionPerRow}   | ${false}
-    ${ItemResponseType.MultipleSelectionPerRow} | ${false}
-    ${ItemResponseType.SliderRows}              | ${false}
-    ${ItemResponseType.Drawing}                 | ${true}
-    ${ItemResponseType.Photo}                   | ${true}
-    ${ItemResponseType.Video}                   | ${true}
-    ${ItemResponseType.Geolocation}             | ${true}
-    ${ItemResponseType.Audio}                   | ${true}
-    ${ItemResponseType.SingleSelection}         | ${false}
-    ${ItemResponseType.MultipleSelection}       | ${false}
-    ${ItemResponseType.Slider}                  | ${false}
-    ${ItemResponseType.Date}                    | ${false}
-    ${ItemResponseType.Text}                    | ${false}
-    ${ItemResponseType.ParagraphText}           | ${false}
-  `('returns $expectedResult for value $value', ({ value, expectedResult }) => {
-    const result = getIsOnlyMobileValue(value);
-    expect(result).toBe(expectedResult);
+    expect(mockEvent.stopPropagation).toHaveBeenCalledTimes(1);
+    expect(mockEvent.preventDefault).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/GroupedSelectSearchController/GroupedSelectSearchController.utils.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/GroupedSelectSearchController/GroupedSelectSearchController.utils.tsx
@@ -1,7 +1,5 @@
 import { KeyboardEvent } from 'react';
 
-import { ItemResponseType } from 'shared/consts';
-
 export const handleSearchKeyDown = (event: KeyboardEvent) => {
   if (event.key !== 'Escape') {
     event.stopPropagation();
@@ -10,12 +8,3 @@ export const handleSearchKeyDown = (event: KeyboardEvent) => {
     event.preventDefault();
   }
 };
-
-export const getIsOnlyMobileValue = (value: ItemResponseType): boolean =>
-  [
-    ItemResponseType.Drawing,
-    ItemResponseType.Photo,
-    ItemResponseType.Video,
-    ItemResponseType.Geolocation,
-    ItemResponseType.Audio,
-  ].includes(value);

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/ItemConfiguration.const.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/ItemConfiguration.const.tsx
@@ -102,17 +102,14 @@ export const itemsTypeOptions: ItemsOptionGroup[] = [
       {
         value: ItemResponseType.Drawing,
         icon: itemsTypeIcons[ItemResponseType.Drawing],
-        isMobileOnly: true,
       },
       {
         value: ItemResponseType.Photo,
         icon: itemsTypeIcons[ItemResponseType.Photo],
-        isMobileOnly: true,
       },
       {
         value: ItemResponseType.Video,
         icon: itemsTypeIcons[ItemResponseType.Video],
-        isMobileOnly: true,
       },
     ],
   },
@@ -122,12 +119,10 @@ export const itemsTypeOptions: ItemsOptionGroup[] = [
       {
         value: ItemResponseType.Geolocation,
         icon: itemsTypeIcons[ItemResponseType.Geolocation],
-        isMobileOnly: true,
       },
       {
         value: ItemResponseType.Audio,
         icon: itemsTypeIcons[ItemResponseType.Audio],
-        isMobileOnly: true,
       },
     ],
   },

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/ItemConfiguration.types.ts
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/ItemConfiguration.types.ts
@@ -47,7 +47,6 @@ export type Alert = {
 export type ItemsOption = {
   value: ItemResponseTypeNoPerfTasks;
   icon: JSX.Element;
-  isMobileOnly?: boolean;
 };
 
 export type ItemsOptionGroup = {

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -1633,6 +1633,7 @@
   "visibilityDecreasesOverMaxCharacters": "Visibility decreases over {{max}} characters",
   "waitForRespondentDataDownload": "Please wait for the download to complete. It could take up to 5 minutes depending on how much data has been collected. Do not navigate away from this page.",
   "dataProcessing": "Processing {{ percentages }}% ...",
+  "webOnly": "Web Only",
   "week": "Week",
   "weekdays": "Weekdays",
   "weekly": "Weekly",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -1632,6 +1632,7 @@
   "visibilityDecreasesOverMaxCharacters": "La visibilité diminue au-delà de {{max}} caractères",
   "waitForRespondentDataDownload": "Veuillez patienter pendant le téléchargement. Cela peut prendre jusqu'à 5 minutes en fonction de la quantité de données collectées. Ne quittez pas cette page.",
   "dataProcessing": "Traitement de {{ percentages  }}%...",
+  "webOnly": "Web uniquement",
   "week": "Semaine",
   "weekdays": "Jours de la semaine",
   "weekly": "Hebdomadaire",

--- a/src/shared/utils/responseType.test.ts
+++ b/src/shared/utils/responseType.test.ts
@@ -1,27 +1,114 @@
 import { ItemResponseType } from 'shared/consts';
 
-import { getIsWebSupported } from './responseType';
+import { getIsWebSupported, getIsMobileOnly, getIsWebOnly } from './responseType';
 
 describe('getIsWebSupported', () => {
   test.each`
     responseType                                | expected | description
-    ${ItemResponseType.Text}                    | ${true}  | ${'Should return true for Text response type'}
-    ${ItemResponseType.SingleSelection}         | ${true}  | ${'Should return true for SingleSelection response type'}
-    ${ItemResponseType.MultipleSelection}       | ${true}  | ${'Should return true for MultipleSelection response type'}
-    ${ItemResponseType.Slider}                  | ${true}  | ${'Should return true for Slider response type'}
-    ${ItemResponseType.NumberSelection}         | ${true}  | ${'Should return true for NumberSelection response type'}
-    ${ItemResponseType.Message}                 | ${true}  | ${'Should return true for Message response type'}
-    ${ItemResponseType.Date}                    | ${true}  | ${'Should return true for Date response type'}
-    ${ItemResponseType.Time}                    | ${true}  | ${'Should return true for Time response type'}
-    ${ItemResponseType.TimeRange}               | ${true}  | ${'Should return true for TimeRange response type'}
-    ${ItemResponseType.AudioPlayer}             | ${true}  | ${'Should return true for AudioPlayer response type'}
-    ${ItemResponseType.MultipleSelectionPerRow} | ${true}  | ${'Should return true for MultipleSelectionPerRow response type'}
-    ${ItemResponseType.SingleSelectionPerRow}   | ${true}  | ${'Should return true for SingleSelectionPerRow response type'}
-    ${ItemResponseType.SliderRows}              | ${true}  | ${'Should return true for SliderRows response type'}
-    ${'test'}                                   | ${false} | ${'Should return true for other response types'}
-    ${1}                                        | ${false} | ${'Should return true for other response types'}
-    ${false}                                    | ${false} | ${'Should return true for other response types'}
+    ${ItemResponseType.ABTrails}                | ${false} | ${'Returns false for ABTrails'}
+    ${ItemResponseType.Audio}                   | ${false} | ${'Returns false for Audio'}
+    ${ItemResponseType.AudioPlayer}             | ${true}  | ${'Returns true for AudioPlayer'}
+    ${ItemResponseType.Date}                    | ${true}  | ${'Returns true for Date'}
+    ${ItemResponseType.Drawing}                 | ${false} | ${'Returns false for Drawing'}
+    ${ItemResponseType.Flanker}                 | ${false} | ${'Returns false for Flanker'}
+    ${ItemResponseType.Geolocation}             | ${false} | ${'Returns false for Geolocation'}
+    ${ItemResponseType.Message}                 | ${true}  | ${'Returns true for Message'}
+    ${ItemResponseType.MultipleSelection}       | ${true}  | ${'Returns true for MultipleSelection'}
+    ${ItemResponseType.MultipleSelectionPerRow} | ${true}  | ${'Returns true for MultipleSelectionPerRow'}
+    ${ItemResponseType.NumberSelection}         | ${true}  | ${'Returns true for NumberSelection'}
+    ${ItemResponseType.ParagraphText}           | ${true}  | ${'Returns true for ParagraphText'}
+    ${ItemResponseType.Photo}                   | ${false} | ${'Returns false for Photo'}
+    ${ItemResponseType.PhrasalTemplate}         | ${true}  | ${'Returns true for PhrasalTemplate'}
+    ${ItemResponseType.SingleSelection}         | ${true}  | ${'Returns true for SingleSelection'}
+    ${ItemResponseType.SingleSelectionPerRow}   | ${true}  | ${'Returns true for SingleSelectionPerRow'}
+    ${ItemResponseType.Slider}                  | ${true}  | ${'Returns true for Slider'}
+    ${ItemResponseType.SliderRows}              | ${true}  | ${'Returns true for SliderRows'}
+    ${ItemResponseType.StabilityTracker}        | ${false} | ${'Returns false for StabilityTracker'}
+    ${ItemResponseType.Text}                    | ${true}  | ${'Returns true for Text'}
+    ${ItemResponseType.Time}                    | ${true}  | ${'Returns true for Time'}
+    ${ItemResponseType.TimeRange}               | ${true}  | ${'Returns true for TimeRange'}
+    ${ItemResponseType.TouchPractice}           | ${false} | ${'Returns false for TouchPractice'}
+    ${ItemResponseType.TouchTest}               | ${false} | ${'Returns false for TouchTest'}
+    ${ItemResponseType.Unity}                   | ${false} | ${'Returns false for Unity'}
+    ${ItemResponseType.Video}                   | ${false} | ${'Returns false for Video'}
+    ${'test'}                                   | ${false} | ${'Returns false for other response types'}
+    ${1}                                        | ${false} | ${'Returns false for other response types'}
+    ${false}                                    | ${false} | ${'Returns false for other response types'}
   `('$description', ({ responseType, expected }) => {
     expect(getIsWebSupported([{ responseType }])).toEqual(expected);
+  });
+
+  describe('getIsMobileOnly', () => {
+    test.each`
+      responseType                                | expected | description
+      ${ItemResponseType.ABTrails}                | ${true}  | ${'Returns true for ABTrails'}
+      ${ItemResponseType.Audio}                   | ${true}  | ${'Returns true for Audio'}
+      ${ItemResponseType.AudioPlayer}             | ${false} | ${'Returns false for AudioPlayer'}
+      ${ItemResponseType.Date}                    | ${false} | ${'Returns false for Date'}
+      ${ItemResponseType.Drawing}                 | ${true}  | ${'Returns true for Drawing'}
+      ${ItemResponseType.Flanker}                 | ${true}  | ${'Returns true for Flanker'}
+      ${ItemResponseType.Geolocation}             | ${true}  | ${'Returns true for Geolocation'}
+      ${ItemResponseType.Message}                 | ${false} | ${'Returns false for Message'}
+      ${ItemResponseType.MultipleSelection}       | ${false} | ${'Returns false for MultipleSelection'}
+      ${ItemResponseType.MultipleSelectionPerRow} | ${false} | ${'Returns false for MultipleSelectionPerRow'}
+      ${ItemResponseType.NumberSelection}         | ${false} | ${'Returns false for NumberSelection'}
+      ${ItemResponseType.ParagraphText}           | ${false} | ${'Returns false for ParagraphText'}
+      ${ItemResponseType.Photo}                   | ${true}  | ${'Returns true for Photo'}
+      ${ItemResponseType.PhrasalTemplate}         | ${false} | ${'Returns false for PhrasalTemplate'}
+      ${ItemResponseType.SingleSelection}         | ${false} | ${'Returns false for SingleSelection'}
+      ${ItemResponseType.SingleSelectionPerRow}   | ${false} | ${'Returns false for SingleSelectionPerRow'}
+      ${ItemResponseType.Slider}                  | ${false} | ${'Returns false for Slider'}
+      ${ItemResponseType.SliderRows}              | ${false} | ${'Returns false for SliderRows'}
+      ${ItemResponseType.StabilityTracker}        | ${true}  | ${'Returns true for StabilityTracker'}
+      ${ItemResponseType.Text}                    | ${false} | ${'Returns false for Text'}
+      ${ItemResponseType.Time}                    | ${false} | ${'Returns false for Time'}
+      ${ItemResponseType.TimeRange}               | ${false} | ${'Returns false for TimeRange'}
+      ${ItemResponseType.TouchPractice}           | ${false} | ${'Returns false for TouchPractice'}
+      ${ItemResponseType.TouchTest}               | ${false} | ${'Returns false for TouchTest'}
+      ${ItemResponseType.Unity}                   | ${false} | ${'Returns false for Unity'}
+      ${ItemResponseType.Video}                   | ${true}  | ${'Returns true for Video'}
+      ${'test'}                                   | ${false} | ${'Returns false for other response types'}
+      ${1}                                        | ${false} | ${'Returns false for other response types'}
+      ${false}                                    | ${false} | ${'Returns false for other response types'}
+    `('$description', ({ responseType, expected }) => {
+      expect(getIsMobileOnly(responseType)).toEqual(expected);
+    });
+  });
+
+  describe('getIsWebOnly', () => {
+    test.each`
+      responseType                                | expected | description
+      ${ItemResponseType.ABTrails}                | ${false} | ${'Returns false for ABTrails'}
+      ${ItemResponseType.Audio}                   | ${false} | ${'Returns false for Audio'}
+      ${ItemResponseType.AudioPlayer}             | ${false} | ${'Returns false for AudioPlayer'}
+      ${ItemResponseType.Date}                    | ${false} | ${'Returns false for Date'}
+      ${ItemResponseType.Drawing}                 | ${false} | ${'Returns false for Drawing'}
+      ${ItemResponseType.Flanker}                 | ${false} | ${'Returns false for Flanker'}
+      ${ItemResponseType.Geolocation}             | ${false} | ${'Returns false for Geolocation'}
+      ${ItemResponseType.Message}                 | ${false} | ${'Returns false for Message'}
+      ${ItemResponseType.MultipleSelection}       | ${false} | ${'Returns false for MultipleSelection'}
+      ${ItemResponseType.MultipleSelectionPerRow} | ${false} | ${'Returns false for MultipleSelectionPerRow'}
+      ${ItemResponseType.NumberSelection}         | ${false} | ${'Returns false for NumberSelection'}
+      ${ItemResponseType.ParagraphText}           | ${false} | ${'Returns false for ParagraphText'}
+      ${ItemResponseType.Photo}                   | ${false} | ${'Returns false for Photo'}
+      ${ItemResponseType.PhrasalTemplate}         | ${true}  | ${'Returns true for PhrasalTemplate'}
+      ${ItemResponseType.SingleSelection}         | ${false} | ${'Returns false for SingleSelection'}
+      ${ItemResponseType.SingleSelectionPerRow}   | ${false} | ${'Returns false for SingleSelectionPerRow'}
+      ${ItemResponseType.Slider}                  | ${false} | ${'Returns false for Slider'}
+      ${ItemResponseType.SliderRows}              | ${false} | ${'Returns false for SliderRows'}
+      ${ItemResponseType.StabilityTracker}        | ${false} | ${'Returns false for StabilityTracker'}
+      ${ItemResponseType.Text}                    | ${false} | ${'Returns false for Text'}
+      ${ItemResponseType.Time}                    | ${false} | ${'Returns false for Time'}
+      ${ItemResponseType.TimeRange}               | ${false} | ${'Returns false for TimeRange'}
+      ${ItemResponseType.TouchPractice}           | ${false} | ${'Returns false for TouchPractice'}
+      ${ItemResponseType.TouchTest}               | ${false} | ${'Returns false for TouchTest'}
+      ${ItemResponseType.Unity}                   | ${false} | ${'Returns false for Unity'}
+      ${ItemResponseType.Video}                   | ${false} | ${'Returns false for Video'}
+      ${'test'}                                   | ${false} | ${'Returns false for other response types'}
+      ${1}                                        | ${false} | ${'Returns false for other response types'}
+      ${false}                                    | ${false} | ${'Returns false for other response types'}
+    `('$description', ({ responseType, expected }) => {
+      expect(getIsWebOnly(responseType)).toEqual(expected);
+    });
   });
 });

--- a/src/shared/utils/responseType.ts
+++ b/src/shared/utils/responseType.ts
@@ -1,21 +1,50 @@
 import { ItemResponseType } from 'shared/consts';
 
-export const webSupportedResponseTypes = [
-  ItemResponseType.Text,
-  ItemResponseType.ParagraphText,
-  ItemResponseType.SingleSelection,
-  ItemResponseType.MultipleSelection,
-  ItemResponseType.Slider,
-  ItemResponseType.NumberSelection,
-  ItemResponseType.Message,
-  ItemResponseType.Date,
-  ItemResponseType.Time,
-  ItemResponseType.TimeRange,
-  ItemResponseType.AudioPlayer,
-  ItemResponseType.MultipleSelectionPerRow,
-  ItemResponseType.SingleSelectionPerRow,
-  ItemResponseType.SliderRows,
+export const unsupportedResponseTypes = [
+  ItemResponseType.TouchPractice,
+  ItemResponseType.TouchTest,
+  ItemResponseType.Unity,
 ];
 
+export const universalSupportedResponseTypes = [
+  ItemResponseType.AudioPlayer,
+  ItemResponseType.Date,
+  ItemResponseType.Message,
+  ItemResponseType.MultipleSelection,
+  ItemResponseType.MultipleSelectionPerRow,
+  ItemResponseType.NumberSelection,
+  ItemResponseType.ParagraphText,
+  ItemResponseType.SingleSelection,
+  ItemResponseType.SingleSelectionPerRow,
+  ItemResponseType.Slider,
+  ItemResponseType.SliderRows,
+  ItemResponseType.Text,
+  ItemResponseType.Time,
+  ItemResponseType.TimeRange,
+];
+
+export const mobileSupportedResponseTypes = [
+  ItemResponseType.ABTrails,
+  ItemResponseType.Audio,
+  ItemResponseType.Drawing,
+  ItemResponseType.Flanker,
+  ItemResponseType.Geolocation,
+  ItemResponseType.Photo,
+  ItemResponseType.StabilityTracker,
+  ItemResponseType.Video,
+];
+
+export const webSupportedResponseTypes = [ItemResponseType.PhrasalTemplate];
+
 export const getIsWebSupported = (itemResponseTypes: { responseType: ItemResponseType }[] = []) =>
-  itemResponseTypes.every(({ responseType }) => webSupportedResponseTypes.includes(responseType));
+  itemResponseTypes.every(
+    ({ responseType }) =>
+      universalSupportedResponseTypes.includes(responseType) ||
+      webSupportedResponseTypes.includes(responseType),
+  );
+
+export const getIsMobileOnly = (responseType: ItemResponseType) =>
+  mobileSupportedResponseTypes.includes(responseType);
+
+export const getIsWebOnly = (responseType: ItemResponseType) =>
+  webSupportedResponseTypes.includes(responseType);


### PR DESCRIPTION
### 📝 Description

🔗 [M2-8058](https://mindlogger.atlassian.net/browse/M2-8058): [FE][Phrase Builder] Add a “Web Only” tag to the Phrase Builder item type in the Admin app

This PR adds "Web Only" chips to the Item Type dropdown in the Applet editor, for item types that are only accessible in the web app. At the moment, this is just the "Phrase Builder" item type. As part of this change, I:
- [Updated the `GroupedSelectSearchController`](https://github.com/ChildMindInstitute/mindlogger-admin/commit/736d996ca632eeb9a1606b510129d8a5c5da60ba).
  - It now shows "Web Only" chips on responseTypes that are only supported on Web.
  - I also updated how dropdown content was rendered to re-use select value JSX content and minimize custom styling.
    - This results in a minor spacing change: Previously, dropdown items had an unintentionally inconsistent height based on the presence of a "web/mobile only" chip. Now, all dropdown items are the same height.
- [Removed `isMobileOnly` configuration values from `ItemConfiguration`, and the `getIsOnlyMobileValue` function from `GroupedSelectSearchController` utils]((https://github.com/ChildMindInstitute/mindlogger-admin/commit/736d996ca632eeb9a1606b510129d8a5c5da60ba)).
   - The above values were inconsistent with each other, which were themselves inconsistent with the definitions in `shared/utils/responseType`. This resulted in issues like the Applet editor reporting that "Phrase Builder" item types were "Web only", but when the activity was viewed in the Dashboard, the "Take Now" option would be disabled, with a tooltip suggesting the Activity must be completed on mobile devices.
- To fix the above issue, I instead updated the "supportedResponseType" arrays and added new "isXOnly" functions to `/shared/utils/responseType`, which should now serve as the source of truth for these evaluations (at least within the context of the admin app).
- [Added/Updated tests for the above scenarios](https://github.com/ChildMindInstitute/mindlogger-admin/commit/01b2ba07a72cf04cdb4f557eb8bf79f3d512ec8b). This includes:
   - Removing `@ts-nocheck`s and fixed eslint warnings in the test files I modified.
   - Removing redundant tests for removed functionality.
   - Adding new tests for `getIsMobileOnly`/`getIsWebOnly` in `shared/utils/responseType`.
   - Adding new tests for "X-Only" chip rendering in `GroupedSelectSearchController`.

### 📸 Screenshots

| Before | After |
|-|-|
| ![before](https://github.com/user-attachments/assets/3d781759-c69d-4d2a-a01a-c8c37499f618) | ![after](https://github.com/user-attachments/assets/d338dfb8-c262-4803-8869-9a06f9215a7f) |

### 🪤 Peer Testing

While editing an applet...

1. Add a new item to an activity. Select "Phrase Builder" for the item type.
2. Observe that the Phrase Builder item option includes a "Web Only" chip, both in the select menu and when selected.

If you do not already have an activity that includes a Phrase Builder item, fill in the required details and save your changes.

1. Navigate to the Activities page, and open the "Additional Options"/"…" menu for the activity that contains a Phrase Builder item.
2. Observe that the "Take Now" option is enabled. Previously, it would be disabled, with a tooltip indicating that the activity must be completed on mobile.

[M2-8058]: https://mindlogger.atlassian.net/browse/M2-8058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ