### PR TITLE
fix: PDF reports for duplicated applets that include Report Server Configuration (M2-8057)

### DIFF
--- a/src/modules/Dashboard/features/Applet/Popups/DuplicatePopups/DuplicatePopups.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/DuplicatePopups/DuplicatePopups.tsx
@@ -112,6 +112,8 @@ export const DuplicatePopups = ({ onCloseCallback }: { onCloseCallback?: () => v
     },
   );
 
+  const resetEncryptionData = () => (encryptionDataRef.current = {});
+
   const { execute: executeDuplicate, isLoading: isDuplicateLoading } = useAsync(
     duplicateAppletApi,
     async (res) => {
@@ -122,9 +124,7 @@ export const DuplicatePopups = ({ onCloseCallback }: { onCloseCallback?: () => v
       if (error?.response?.status === ApiResponseCodes.Forbidden) return;
 
       setErrorModalVisible(true);
-    },
-    () => {
-      encryptionDataRef.current = {};
+      resetEncryptionData();
     },
   );
 
@@ -157,6 +157,7 @@ export const DuplicatePopups = ({ onCloseCallback }: { onCloseCallback?: () => v
 
     onCloseCallback?.();
     duplicatePopupsClose();
+    resetEncryptionData();
 
     Mixpanel.track('Applet Created Successfully', {
       'Applet ID': currentAppletId,


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [ ] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-8057](https://mindlogger.atlassian.net/browse/M2-8057)

This fixes an issue with the new Duplicate Applet functionality when including the Report Server Configuration (implemented in [M2-7729](https://mindlogger.atlassian.net/browse/M2-8057)). The PDF report was not generating successfully with these duplicated applets. 

Determined the cause of this was the Admin Panel sending an empty password to the Report Server during replication (via the report server's `set-password` endpoint). This was because the `encryptionDataRef` was getting reset in the finally clause of the `useAsync` call to `duplicateAppletApi`, _before_ the report server configuration setup had a chance to complete.

Changes include:

- Updates `useAsync` of `duplicateAppletApi` by moving cleanup out of the `finally` callback, and instead handles the `encryptionDataRef` cleanup on both success and error callbacks separately, ensuring cleanup takes place after it is no longer needed. 

### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

https://www.loom.com/share/c2f01f6aa6cf4b91a9d60197b1753214?sid=02575f6e-3b68-4a9e-919c-2bf375814ced

### 🪤 Peer Testing

<!-- If peer testing is not needed, then delete this section -->
<!-- Uncomment out any of the following as needed:           -->
<!-- **Requires `npm install`**     -->
1. Setup an Applet with a single activity and item with scoring
2. Configure the Applet's Report Configuration and use one of the existing Report Servers (recommend [UAT](https://mindlogger.atlassian.net/wiki/spaces/MINDLOGGER1/pages/348684325/Credentials#UAT-env))
3. Configure the activity's Scores & Reports to Generate Report and Show Score Summary, and configure a Score
4. Save & Publish the Applet
5. Complete the activity (feel free to initiate it via Take Now)
6. Confirm a report was received (this is existing functionality)
7. Go back to Admin and duplicate the applet, including Report Server configuration
8. Go to duplicate applet's Report Configuration and enter an email (since it is not duplicated from original applet)
9. Complete the activity of the duplicated applet (feel free to initiate it via Take Now)
10.  **Expected outcome:** a PDF report is received

<!--
Replace this with a series of test steps & expected outcomes.

Example test step:

- This is a test step.  Highlight actions **in bold**.

    **Expected outcome:** This is what to expect after the step
-->

### ✏️ Notes

- https://github.com/ChildMindInstitute/mindlogger-admin/pull/1942

[M2-7729]: https://mindlogger.atlassian.net/browse/M2-7729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ