### PR TITLE
feature: paragraph response_type for phrase builder response options (M2-7762)

### DIFF
--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/PhrasalTemplate/PhrasalTemplate.test.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/PhrasalTemplate/PhrasalTemplate.test.tsx
@@ -1,0 +1,42 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+import { screen } from '@testing-library/react';
+
+// eslint-disable-next-line prettier/prettier
+import {
+  mockedAppletId,
+  mockedActivityId,
+  mockedAppletFormData,
+  mockedPhrasalTemplateActivityItem,
+  mockedParagraphTextActivityItem,
+} from 'shared/mock';
+import { renderWithAppletFormData } from 'shared/utils/renderWithAppletFormData';
+import { page } from 'resources';
+
+import { PhrasalTemplate } from './PhrasalTemplate';
+
+const appletFormData = {
+  ...mockedAppletFormData,
+  activities: [
+    {
+      ...mockedAppletFormData.activities[0],
+      items: [mockedParagraphTextActivityItem, mockedPhrasalTemplateActivityItem],
+    },
+  ],
+};
+const route = `/builder/${mockedAppletId}/activities/${mockedActivityId}/items/c17b7b59-8074-4c69-b787-88ea9ea3df5d`;
+const routePath = page.builderAppletActivityItem;
+const name = 'activities.0.itemws.0';
+
+describe('PhrasalTemplate', () => {
+  test('render PhrasalTemplate with Paragraph', () => {
+    renderWithAppletFormData({
+      children: <PhrasalTemplate name={name} />,
+      appletFormData,
+      options: { route, routePath },
+    });
+
+    const phrasalTemplates = screen.queryAllByDisplayValue('phrasalTemplate');
+    expect(phrasalTemplates.length).toBe(1);
+  });
+});

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/PhrasalTemplate/PhrasalTemplate.utils.ts
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/PhrasalTemplate/PhrasalTemplate.utils.ts
@@ -25,6 +25,7 @@ const PHRASAL_TEMPLATE_COMPATIBLE_RESPONSE_TYPES = [
   ItemResponseType.MultipleSelectionPerRow,
   ItemResponseType.SingleSelectionPerRow,
   ItemResponseType.SliderRows,
+  ItemResponseType.ParagraphText,
 ];
 
 const DEFAULT_PHRASE: PhrasalTemplateResponseValues['phrases'][number] = {

--- a/src/modules/Builder/features/ActivityItemsFlow/ActivityItemsFlow.test.tsx
+++ b/src/modules/Builder/features/ActivityItemsFlow/ActivityItemsFlow.test.tsx
@@ -26,6 +26,7 @@ import {
   mockedNumberSelectActivityItem,
   mockedMultiSelectRowsActivityItem,
   mockedSingleSelectRowsActivityItem,
+  mockedPhrasalTemplateActivityItem,
   mockedParagraphTextActivityItem,
 } from 'shared/mock';
 import { createArray, getEntityKey } from 'shared/utils';
@@ -62,6 +63,7 @@ const mockedAppletWithAllItemTypes = {
         mockedSliderRowsActivityItem,
         mockedAudioPlayerActivityItem,
         mockedNumberSelectActivityItem,
+        mockedPhrasalTemplateActivityItem,
         mockedParagraphTextActivityItem,
         mockedMultiSelectRowsActivityItem,
         mockedSingleSelectRowsActivityItem,
@@ -100,6 +102,7 @@ const mockedOrderedSummaryItemItems = [
   mockedParagraphTextActivityItem,
   mockedMultiSelectRowsActivityItem,
   mockedSingleSelectRowsActivityItem,
+  mockedPhrasalTemplateActivityItem,
 ];
 
 const renderActivityItemsFlow = (formData) => {

--- a/src/modules/Builder/features/ActivitySettings/SubscalesConfiguration/SubscalesConfiguration.test.tsx
+++ b/src/modules/Builder/features/ActivitySettings/SubscalesConfiguration/SubscalesConfiguration.test.tsx
@@ -28,6 +28,8 @@ import {
   mockedNumberSelectActivityItem,
   mockedMultiSelectRowsActivityItem,
   mockedSingleSelectRowsActivityItem,
+  mockedPhrasalTemplateActivityItem,
+  mockedParagraphTextActivityItem,
 } from 'shared/mock';
 import { SettingParam, isSystemItem } from 'shared/utils';
 import { renderWithAppletFormData } from 'shared/utils/renderWithAppletFormData';
@@ -115,6 +117,8 @@ const mockedAppletWithAllItemTypes = {
         mockedSingleActivityItemWithoutScores,
         mockedMultiActivityItemWithoutScores,
         mockedSliderActivityItemWithoutScores,
+        mockedPhrasalTemplateActivityItem,
+        mockedParagraphTextActivityItem,
       ],
     },
   ],

--- a/src/shared/mock.ts
+++ b/src/shared/mock.ts
@@ -1463,12 +1463,6 @@ export const mockedPhrasalTemplateActivityItem = {
   _id: undefined,
 };
 
-export const mockedParagraphAndPhrasalTemplateActivities = [
-  // Directly using the mockedParagraphTextActivityItem
-  mockedParagraphTextActivityItem,
-  mockedPhrasalTemplateActivityItem,
-];
-
 export const mockedVideoActivityItem = {
   question: 'video_text',
   responseType: 'video',

--- a/src/shared/mock.ts
+++ b/src/shared/mock.ts
@@ -1417,6 +1417,58 @@ export const mockedPhotoActivityItem = {
   id: '129a20df-5330-494c-8c4c-eb3c7847fe95',
 };
 
+export const mockedPhrasalTemplateActivityItem = {
+  key: undefined,
+  name: 'Item phrasalTemplate',
+  question: {
+    en: '',
+  },
+  responseType: 'phrasalTemplate',
+  responseValues: {
+    type: 'phrasalTemplate',
+    cardTitle: 'ItemPhraseBuilder',
+    phrases: [
+      {
+        image: null,
+        fields: [
+          {
+            type: 'sentence',
+            text: 'First sentence phrase builder',
+          },
+          {
+            type: 'item_response',
+            itemName: mockedParagraphTextActivityItem.name, // Reference the paragraph item's name
+            displayMode: 'sentence',
+            itemIndex: 0,
+          },
+          {
+            type: 'sentence',
+            text: 'Second sentence phrase builder',
+          },
+        ],
+      },
+    ],
+  },
+  config: {
+    type: 'phrasalTemplate',
+    removeBackButton: false,
+  },
+  conditionalLogic: undefined,
+  alerts: undefined,
+  allowEdit: true,
+  isHidden: false,
+  order: undefined,
+  id: '53b9e37a-ae36-43cd-9f58-d3ce6dc41c72',
+  settings: undefined,
+  _id: undefined,
+};
+
+export const mockedParagraphAndPhrasalTemplateActivities = [
+  // Directly using the mockedParagraphTextActivityItem
+  mockedParagraphTextActivityItem,
+  mockedPhrasalTemplateActivityItem,
+];
+
 export const mockedVideoActivityItem = {
   question: 'video_text',
   responseType: 'video',


### PR DESCRIPTION
- [ ] Create a new activity with one pragraph item and one phrase builder item
- [ ] Paragraph item should be a valid option to select from the PhraseBuilder select options. 

### 📝 Description
As an Admin, I want to choose the paragraph item type as a response phrase field so that I can include its contents in my Action Plan. By adding paragraph option to the PHRASAL_TEMPLATE_COMPATIBLE_RESPONSE_TYPES, now paragraphs can be choosen from PhraseBuilder response the dropdown menu.
 
🔗 [Jira Ticket M2-7762](https://mindlogger.atlassian.net/browse/M2-7762)

Changes include:
- [Allow new item_type (paragraph) to phrase-builder response options]


### 📸 Screenshots

ADMIN PANEL - CONFIGURATION
Creating Activity with paragraph type on Phrase Builder
![image](https://github.com/user-attachments/assets/e159f3cd-29aa-4fbf-ba1f-8c948e6c5dbe)

WEB APPLICATION: 
![image](https://github.com/user-attachments/assets/1f02faf2-7fe7-4483-a3cf-e678a0388161)

ADMIN PANEL -  RESULTS
![image](https://github.com/user-attachments/assets/8b08e601-d337-40b3-9d99-461d51697aff)


### 🪤 Peer Testing
* Create an activity
* Create and item  of type parragraph inside your activity
* In the same activity create a new item of type phrase builder
* Phrase builder should allow you to choose the newly created paragraph item inside the “Select Item (Response)” dropdown menu.
* Complete an activity from the web application and validate that the parragraph can be selected on the Phrase Builder section. 
