### PR TITLE
feat: Add `PreviewPhrasePopup`. (M2-7164)

### DIFF
--- a/src/modules/Builder/components/PreviewPhrasePopup/PreviewPhrasePopup.styles.ts
+++ b/src/modules/Builder/components/PreviewPhrasePopup/PreviewPhrasePopup.styles.ts
@@ -5,10 +5,10 @@ import { theme, variables } from 'shared/styles';
 export const StyledImage = styled('img')({
   borderRadius: variables.borderRadius.md,
   flexShrink: 0,
-  height: 56,
+  height: '5.6rem',
   objectFit: 'cover',
   overflow: 'hidden',
-  width: 56,
+  width: '5.6rem',
 });
 
 export const StyledPreviewContainer = styled('div')({
@@ -16,7 +16,7 @@ export const StyledPreviewContainer = styled('div')({
   borderRadius: variables.borderRadius.lg2,
   display: 'flex',
   gap: theme.spacing(2.4),
-  maxHeight: 400,
+  maxHeight: '40rem',
   overflowY: 'auto',
   padding: theme.spacing(4, 3.2),
   placeItems: 'flex-start',

--- a/src/modules/Builder/components/PreviewPhrasePopup/PreviewPhrasePopup.styles.ts
+++ b/src/modules/Builder/components/PreviewPhrasePopup/PreviewPhrasePopup.styles.ts
@@ -1,0 +1,23 @@
+import { styled } from '@mui/material';
+
+import { theme, variables } from 'shared/styles';
+
+export const StyledImage = styled('img')({
+  borderRadius: variables.borderRadius.md,
+  flexShrink: 0,
+  height: 56,
+  objectFit: 'cover',
+  overflow: 'hidden',
+  width: 56,
+});
+
+export const StyledPreviewContainer = styled('div')({
+  border: `${variables.borderWidth.md} solid ${variables.palette.outline_variant}`,
+  borderRadius: variables.borderRadius.lg2,
+  display: 'flex',
+  gap: theme.spacing(2.4),
+  maxHeight: 400,
+  overflowY: 'auto',
+  padding: theme.spacing(4, 3.2),
+  placeItems: 'flex-start',
+});

--- a/src/modules/Builder/components/PreviewPhrasePopup/PreviewPhrasePopup.tsx
+++ b/src/modules/Builder/components/PreviewPhrasePopup/PreviewPhrasePopup.tsx
@@ -1,0 +1,72 @@
+import { useCallback } from 'react';
+import { Box } from '@mui/material';
+import { FieldArrayWithId } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+
+import { useCustomFormContext } from 'modules/Builder/hooks';
+import { PhrasalTemplateField } from 'redux/modules';
+import { Modal, ModalProps } from 'shared/components';
+import { StyledModalWrapper } from 'shared/styles';
+
+import { StyledImage, StyledPreviewContainer } from './PreviewPhrasePopup.styles';
+
+export const PreviewPhrasePopup = ({
+  fields = [],
+  name = '',
+  imageUrl = '',
+  ...otherProps
+}: Omit<ModalProps, 'children'> & {
+  fields?: FieldArrayWithId<{ values: PhrasalTemplateField[] }, 'values', 'id'>[];
+  name?: string;
+  imageUrl?: string;
+}) => {
+  const { t } = useTranslation('app');
+  const { getValues } = useCustomFormContext();
+
+  const renderField = useCallback(
+    (_: PhrasalTemplateField, index = 0) => {
+      const fieldValue = getValues(`${name}.${index}` as string);
+
+      if (!fieldValue) {
+        return '';
+      }
+
+      const renderedName = ` ${t('phrasalTemplatePreviewPopup.responsePlaceholder', {
+        itemName: fieldValue?.itemName,
+      })} `;
+
+      switch (fieldValue.type) {
+        case 'sentence':
+          return <Box component="span">{fieldValue.text}</Box>;
+        case 'line_break':
+          return <Box component="hr" sx={{ m: 0, height: 32, border: 'none' }} />;
+        case 'item_response':
+          return ['sentence', 'sentence_option_row', 'sentence_row_option'].includes(
+            fieldValue.displayMode,
+          ) ? (
+            <Box component="span" fontWeight="bold">
+              {renderedName}
+            </Box>
+          ) : (
+            <ul>
+              <Box component="li" fontWeight="bold">
+                {renderedName}
+              </Box>
+            </ul>
+          );
+      }
+    },
+    [getValues, name, t],
+  );
+
+  return (
+    <Modal submitBtnColor="error" {...otherProps}>
+      <StyledModalWrapper>
+        <StyledPreviewContainer>
+          {imageUrl && <StyledImage aria-hidden src={imageUrl} />}
+          <div>{fields.map(renderField)}</div>
+        </StyledPreviewContainer>
+      </StyledModalWrapper>
+    </Modal>
+  );
+};

--- a/src/modules/Builder/components/PreviewPhrasePopup/index.ts
+++ b/src/modules/Builder/components/PreviewPhrasePopup/index.ts
@@ -1,0 +1,1 @@
+export * from './PreviewPhrasePopup';

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/PhrasalTemplate/PhrasalTemplatePhrase/PhrasalTemplatePhrase.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/PhrasalTemplate/PhrasalTemplatePhrase/PhrasalTemplatePhrase.tsx
@@ -18,6 +18,7 @@ import {
 } from 'shared/styles';
 import { DndDroppable } from 'modules/Builder/components';
 import { RemovePhrasePopup } from 'modules/Builder/components/RemovePhrasePopup';
+import { PreviewPhrasePopup } from 'modules/Builder/components/PreviewPhrasePopup/PreviewPhrasePopup';
 
 import { PhrasalTemplateField } from '../PhrasalTemplateField';
 import { PhrasalTemplateImageField } from '../PhrasalTemplateImageField';
@@ -39,6 +40,7 @@ export const PhrasalTemplatePhrase = ({
 }: PhrasalTemplatePhraseProps) => {
   const { t } = useTranslation('app');
   const [removePopupOpen, setRemovePopupOpen] = useState(false);
+  const [previewPopupOpen, setPreviewPopupOpen] = useState(false);
   const [addItemMenuAnchorEl, setAddItemMenuAnchorEl] = useState<null | HTMLElement>(null);
 
   const phraseFieldsName = `${name}.fields`;
@@ -88,7 +90,7 @@ export const PhrasalTemplatePhrase = ({
   const handlePreviewPhrase = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     e.stopPropagation();
 
-    console.warn('TODO: M2-7164 — Preview Phrase');
+    setPreviewPopupOpen(true);
   };
 
   const handleDragEnd: DragDropContextProps['onDragEnd'] = ({ destination, source }) => {
@@ -139,7 +141,7 @@ export const PhrasalTemplatePhrase = ({
               onClick={handlePreviewPhrase}
               sx={{ gap: 0.8, width: 'max-content' }}
               variant="text"
-              disabled={formState.isDirty || formState.isSubmitting || !formState.isValid}
+              disabled={formState.isSubmitting || !formState.isValid}
             >
               <Svg aria-hidden height={18} id="notes" width={18} />
               {t('phrasalTemplateItem.btnPreviewPhrase')}
@@ -244,6 +246,15 @@ export const PhrasalTemplatePhrase = ({
         open={removePopupOpen}
         onClose={() => setRemovePopupOpen(false)}
         onRemove={handleRemovePhrase}
+      />
+
+      <PreviewPhrasePopup
+        title={t('phrasalTemplatePreviewPopup.title', { index: index + 1 })}
+        fields={fields}
+        name={phraseFieldsName}
+        imageUrl={imageFieldValue}
+        open={previewPopupOpen}
+        onClose={() => setPreviewPopupOpen(false)}
       />
     </StyledAccordion>
   );

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/PhrasalTemplate/PhrasalTemplatePhrase/PhrasalTemplatePhrase.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/PhrasalTemplate/PhrasalTemplatePhrase/PhrasalTemplatePhrase.tsx
@@ -136,7 +136,15 @@ export const PhrasalTemplatePhrase = ({
             </Tooltip>
           </StyledFlexTopCenter>
 
-          <StyledFlexTopCenter sx={{ gap: 0.8 }}>
+          <StyledFlexTopCenter
+            onClick={(e) => {
+              // This exists in order to prevent clicks on the child Button
+              // from propagating up and triggering the Accordion
+              // expand / collapse behavior when it is `disabled`.
+              e.stopPropagation();
+            }}
+            sx={{ gap: 0.8 }}
+          >
             <Button
               onClick={handlePreviewPhrase}
               sx={{ gap: 0.8, width: 'max-content' }}

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -898,7 +898,7 @@
     "visitsDescription": "Please check if predefined Visit values are correct: ",
     "successMessage": "If any new data has been collected, it has been uploaded successfully.",
     "visitRequired": "Selected rows require visits.",
-    "visitsMinRequired": "Select at least one visit", 
+    "visitsMinRequired": "Select at least one visit",
     "noDataToUpload": "At the moment there is no new data available. Please check back later.",
     "description": "This integration will allow you to decrypt and upload responses from this applet to your LORIS database.",
     "configureReportServerHint": "To connect, you must first configure your server under <1>Report Configuration</1>.",
@@ -1137,6 +1137,10 @@
     "title": "Remove Phrase",
     "areYouSure": "Are you sure you want to delete this phrase? This action cannot be undone.",
     "confirm": "Yes, Remove"
+  },
+  "phrasalTemplatePreviewPopup": {
+    "title": "Preview Phrase {{index}}",
+    "responsePlaceholder": "[{{itemName}} Response]"
   },
   "phrasalTemplateItem": {
     "btnAddField": "Add…",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -926,7 +926,6 @@
       "appletAlreadyTied": "Cet applet est déjà lié à un projet LORIS",
       "saveProjectFailed": "Échec de l'enregistrement du projet"
     }
-
   },
   "lockDescription": "Vous êtes resté inactif pendant 15 minutes.<br/> Connectez-vous pour continuer.",
   "login": "Se Connecter",
@@ -1133,6 +1132,10 @@
   "photoResponseDescription": "Le participant pourra prendre ou uploader une photo.",
   "photoResponseTitle": "Réponse avec Photo",
   "phrasalTemplate": "Constructeur de phrases",
+  "phrasalTemplatePreviewPopup": {
+    "title": "Aperçu de la phrase {{index}}",
+    "responsePlaceholder": "[{{itemName}} réponse]"
+  },
   "phrasalTemplateRemovePopup": {
     "title": "Supprimer la phrase",
     "areYouSure": "Êtes-vous sûr de vouloir supprimer cette phrase? Cette action ne peut pas être annulée.",

--- a/src/shared/state/Applet/Applet.schema.ts
+++ b/src/shared/state/Applet/Applet.schema.ts
@@ -351,9 +351,22 @@ export type DrawingResponseValues = {
   } | null;
 };
 
+export type PhrasalTemplateFieldDisplayMode =
+  | 'bullet_list'
+  | 'bullet_list_option_row'
+  | 'bullet_list_text_row'
+  | 'sentence'
+  | 'sentence_option_row'
+  | 'sentence_row_option';
+
 export type PhrasalTemplateField =
   | { type: 'sentence'; text: string }
-  | { type: 'item_response'; itemName: string; displayMode: string; itemIndex: number }
+  | {
+      type: 'item_response';
+      itemName: string;
+      displayMode: PhrasalTemplateFieldDisplayMode;
+      itemIndex: number;
+    }
   | { type: 'line_break' };
 
 export type PhrasalTemplateFieldType = PhrasalTemplateField['type'];

--- a/src/shared/styles/theme.tsx
+++ b/src/shared/styles/theme.tsx
@@ -290,17 +290,15 @@ export const theme = createTheme({
               color: variables.palette.disabled,
             },
 
-            '&:not(.MuiButton-textError)': {
+            '&:not(.MuiButton-textError):not(.Mui-disabled)': {
               color: variables.palette.primary,
 
-              '&:not(.Mui-disabled)': {
-                '&:hover': {
-                  backgroundColor: variables.palette.primary_alfa8,
-                },
+              '&:hover': {
+                backgroundColor: variables.palette.primary_alfa8,
+              },
 
-                '&:focus, &:active': {
-                  backgroundColor: variables.palette.primary_alfa12,
-                },
+              '&:focus, &:active': {
+                backgroundColor: variables.palette.primary_alfa12,
               },
             },
 


### PR DESCRIPTION
### 📝 Description

🔗 [M2-7164](https://mindlogger.atlassian.net/browse/M2-7164): [R2] [Phrase Builder Item Type] Preview a phrase

This PR adds a new popup — `PreviewPhrasePopup`, which can be used to view an approximation of how a specific phrase within a Phrase Builder item may appear to a user within the web app.

This new popup has been connected to "Preview Phrase" button, which was previously non-functional.

### 📸 Screenshots

![2024-10-24 11 42 11](https://github.com/user-attachments/assets/8f1ffd9d-6a16-49c6-acb2-a848f06eeebe)

### 🪤 Peer Testing

While editing an activity within an applet, that has multiple items compatible with the phrase builder item type…

1. Create a new item, and select the type "Phrase Builder".
2. Edit the new phrase to include variations of possible fields, including each of the compatible item types.
3. Press "Preview Phrase" and observe that the popup displays the preview correctly.

[M2-7164]: https://mindlogger.atlassian.net/browse/M2-7164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ