### PR TITLE
chore: Mixpanel Refactor

### DIFF
--- a/src/modules/Auth/features/Login/LoginForm/LoginForm.tsx
+++ b/src/modules/Auth/features/Login/LoginForm/LoginForm.tsx
@@ -71,7 +71,7 @@ export const LoginForm = () => {
         }
       }
 
-      Mixpanel.track(MixpanelEventType.LoginSuccessful);
+      Mixpanel.track({ action: MixpanelEventType.LoginSuccessful });
 
       clearSoftLock();
     }
@@ -124,11 +124,11 @@ export const LoginForm = () => {
     clearSoftLock();
     navigate(page.signUp);
 
-    Mixpanel.track(MixpanelEventType.CreateAccountOnLoginScreen);
+    Mixpanel.track({ action: MixpanelEventType.CreateAccountOnLoginScreen });
   };
 
   const handleLoginClick = () => {
-    Mixpanel.track(MixpanelEventType.LoginBtnClick);
+    Mixpanel.track({ action: MixpanelEventType.LoginBtnClick });
   };
 
   const handleResetPasswordClick = () => {

--- a/src/modules/Auth/features/Login/LoginForm/LoginForm.tsx
+++ b/src/modules/Auth/features/Login/LoginForm/LoginForm.tsx
@@ -12,7 +12,7 @@ import { auth } from 'modules/Auth/state';
 import { navigateToLibrary } from 'modules/Auth/utils';
 import { InputController } from 'shared/components/FormComponents';
 import { StyledErrorText, StyledHeadline } from 'shared/styles/styledComponents';
-import { Mixpanel } from 'shared/utils';
+import { Mixpanel, MixpanelEventType } from 'shared/utils';
 import { variables } from 'shared/styles';
 import { AUTH_BOX_WIDTH } from 'shared/consts';
 import { LocationStateKeys } from 'shared/types';
@@ -71,7 +71,7 @@ export const LoginForm = () => {
         }
       }
 
-      Mixpanel.track('Login Successful');
+      Mixpanel.track(MixpanelEventType.LoginSuccessful);
 
       clearSoftLock();
     }
@@ -124,11 +124,11 @@ export const LoginForm = () => {
     clearSoftLock();
     navigate(page.signUp);
 
-    Mixpanel.track('Create account button on login screen click');
+    Mixpanel.track(MixpanelEventType.CreateAccountOnLoginScreen);
   };
 
   const handleLoginClick = () => {
-    Mixpanel.track('Login Button click');
+    Mixpanel.track(MixpanelEventType.LoginBtnClick);
   };
 
   const handleResetPasswordClick = () => {

--- a/src/modules/Auth/features/SignUp/SignUpForm/SignUpForm.tsx
+++ b/src/modules/Auth/features/SignUp/SignUpForm/SignUpForm.tsx
@@ -8,7 +8,7 @@ import { useAppDispatch } from 'redux/store';
 import { page } from 'resources';
 import { InputController, CheckboxController } from 'shared/components/FormComponents';
 import { variables, StyledErrorText, StyledLinkBtn } from 'shared/styles';
-import { Mixpanel } from 'shared/utils';
+import { Mixpanel, MixpanelEventType } from 'shared/utils';
 import { auth } from 'modules/Auth/state';
 import { navigateToLibrary } from 'modules/Auth/utils';
 
@@ -55,7 +55,7 @@ export const SignUpForm = () => {
     if (signUp.fulfilled.match(result)) {
       navigateToLibrary(navigate);
 
-      Mixpanel.track('Signup Successful');
+      Mixpanel.track(MixpanelEventType.SignUpSuccessful);
     }
 
     if (signUp.rejected.match(result)) {

--- a/src/modules/Auth/features/SignUp/SignUpForm/SignUpForm.tsx
+++ b/src/modules/Auth/features/SignUp/SignUpForm/SignUpForm.tsx
@@ -55,7 +55,7 @@ export const SignUpForm = () => {
     if (signUp.fulfilled.match(result)) {
       navigateToLibrary(navigate);
 
-      Mixpanel.track(MixpanelEventType.SignUpSuccessful);
+      Mixpanel.track({ action: MixpanelEventType.SignUpSuccessful });
     }
 
     if (signUp.rejected.match(result)) {

--- a/src/modules/Builder/features/Activities/Activities.tsx
+++ b/src/modules/Builder/features/Activities/Activities.tsx
@@ -77,7 +77,8 @@ export const Activities = () => {
     );
   const handleModalClose = () => setActivityToDelete('');
   const handleActivityAdd = (props: ActivityAddProps) => {
-    Mixpanel.track(MixpanelEventType.AddActivityClick, {
+    Mixpanel.track({
+      action: MixpanelEventType.AddActivityClick,
       [MixpanelProps.AppletId]: appletId,
     });
     const {
@@ -142,7 +143,8 @@ export const Activities = () => {
   };
 
   const handleEditActivity = (index: number) => {
-    Mixpanel.track(MixpanelEventType.ActivityEditClick, {
+    Mixpanel.track({
+      action: MixpanelEventType.ActivityEditClick,
       [MixpanelProps.AppletId]: appletId,
     });
     const activityToEdit = activities[index];

--- a/src/modules/Builder/features/Activities/Activities.tsx
+++ b/src/modules/Builder/features/Activities/Activities.tsx
@@ -16,7 +16,7 @@ import {
 } from 'modules/Builder/pages/BuilderApplet/BuilderApplet.utils';
 import { BuilderContainer } from 'shared/features';
 import { PerfTaskType } from 'shared/consts';
-import { pluck, Mixpanel } from 'shared/utils';
+import { pluck, Mixpanel, MixpanelEventType, MixpanelProps } from 'shared/utils';
 import { getUniqueName, getUpdatedActivityFlows } from 'modules/Builder/utils';
 import { useCustomFormContext } from 'modules/Builder/hooks';
 
@@ -77,8 +77,8 @@ export const Activities = () => {
     );
   const handleModalClose = () => setActivityToDelete('');
   const handleActivityAdd = (props: ActivityAddProps) => {
-    Mixpanel.track('Add Activity click', {
-      'Applet ID': appletId,
+    Mixpanel.track(MixpanelEventType.AddActivityClick, {
+      [MixpanelProps.AppletId]: appletId,
     });
     const {
       index,
@@ -142,8 +142,8 @@ export const Activities = () => {
   };
 
   const handleEditActivity = (index: number) => {
-    Mixpanel.track('Activity edit click', {
-      'Applet ID': appletId,
+    Mixpanel.track(MixpanelEventType.ActivityEditClick, {
+      [MixpanelProps.AppletId]: appletId,
     });
     const activityToEdit = activities[index];
     const activityKey = getActivityKey(activityToEdit);

--- a/src/modules/Builder/features/ActivitySettings/ActivitySettings.utils.tsx
+++ b/src/modules/Builder/features/ActivitySettings/ActivitySettings.utils.tsx
@@ -32,7 +32,8 @@ export const getActivitySettings = ({
           hasError: hasActivityReportsErrors,
           'data-testid': `${dataTestid}-scores-and-reports`,
           onClick: () =>
-            Mixpanel.track(MixpanelEventType.ScoresAndReportBtnClick, {
+            Mixpanel.track({
+              action: MixpanelEventType.ScoresAndReportBtnClick,
               [MixpanelProps.AppletId]: appletId,
             }),
         },
@@ -45,7 +46,8 @@ export const getActivitySettings = ({
           tooltip: isNewActivity ? 'saveAndPublishFirst' : undefined,
           'data-testid': `${dataTestid}-report-config`,
           onClick: () =>
-            Mixpanel.track(MixpanelEventType.ActivityReportConfigurationClick, {
+            Mixpanel.track({
+              action: MixpanelEventType.ActivityReportConfigurationClick,
               [MixpanelProps.AppletId]: appletId,
             }),
         },

--- a/src/modules/Builder/features/ActivitySettings/ActivitySettings.utils.tsx
+++ b/src/modules/Builder/features/ActivitySettings/ActivitySettings.utils.tsx
@@ -1,7 +1,7 @@
 import { lazy } from 'react';
 
 import { Svg } from 'shared/components/Svg';
-import { SettingParam } from 'shared/utils';
+import { SettingParam, MixpanelEventType, MixpanelProps } from 'shared/utils';
 import { Item as ItemNavigation } from 'shared/components/NavigationMenu/NavigationMenu.types';
 import { Mixpanel } from 'shared/utils/mixpanel';
 
@@ -32,8 +32,8 @@ export const getActivitySettings = ({
           hasError: hasActivityReportsErrors,
           'data-testid': `${dataTestid}-scores-and-reports`,
           onClick: () =>
-            Mixpanel.track('Scores and Report Button Click', {
-              'Applet ID': appletId,
+            Mixpanel.track(MixpanelEventType.ScoresAndReportBtnClick, {
+              [MixpanelProps.AppletId]: appletId,
             }),
         },
         {
@@ -45,8 +45,8 @@ export const getActivitySettings = ({
           tooltip: isNewActivity ? 'saveAndPublishFirst' : undefined,
           'data-testid': `${dataTestid}-report-config`,
           onClick: () =>
-            Mixpanel.track('Activity - Report Configuration Click', {
-              'Applet ID': appletId,
+            Mixpanel.track(MixpanelEventType.ActivityReportConfigurationClick, {
+              [MixpanelProps.AppletId]: appletId,
             }),
         },
       ],

--- a/src/modules/Builder/features/BuilderAppletSettings/BuilderAppletSettings.utils.tsx
+++ b/src/modules/Builder/features/BuilderAppletSettings/BuilderAppletSettings.utils.tsx
@@ -11,7 +11,14 @@ import {
   VersionHistorySetting,
   LiveResponseStreamingSetting,
 } from 'shared/features/AppletSettings';
-import { Mixpanel, SettingParam, isManagerOrOwner, checkIfCanEdit } from 'shared/utils';
+import {
+  Mixpanel,
+  SettingParam,
+  isManagerOrOwner,
+  checkIfCanEdit,
+  MixpanelEventType,
+  MixpanelProps,
+} from 'shared/utils';
 import { Item as ItemNavigation } from 'shared/components/NavigationMenu/NavigationMenu.types';
 
 import { GetSettings } from './BuilderAppletSettings.types';
@@ -125,8 +132,8 @@ export const getSettings = ({
           tooltip,
           'data-testid': `${dataTestid}-report-config`,
           onClick: () =>
-            Mixpanel.track('Applet - Report Configuration Click', {
-              'Applet ID': appletId,
+            Mixpanel.track(MixpanelEventType.AppletReportConfigurationClick, {
+              [MixpanelProps.AppletId]: appletId,
             }),
         },
       ],

--- a/src/modules/Builder/features/BuilderAppletSettings/BuilderAppletSettings.utils.tsx
+++ b/src/modules/Builder/features/BuilderAppletSettings/BuilderAppletSettings.utils.tsx
@@ -132,7 +132,8 @@ export const getSettings = ({
           tooltip,
           'data-testid': `${dataTestid}-report-config`,
           onClick: () =>
-            Mixpanel.track(MixpanelEventType.AppletReportConfigurationClick, {
+            Mixpanel.track({
+              action: MixpanelEventType.AppletReportConfigurationClick,
               [MixpanelProps.AppletId]: appletId,
             }),
         },

--- a/src/modules/Builder/features/SaveAndPublish/SaveAndPublish.hooks.ts
+++ b/src/modules/Builder/features/SaveAndPublish/SaveAndPublish.hooks.ts
@@ -365,7 +365,8 @@ export const useSaveAndPublishSetup = (): SaveAndPublishSetup => {
     shouldNavigateRef.current = true;
     setPromptVisible(false);
     await handleSaveAndPublishFirstClick();
-    Mixpanel.track(MixpanelEventType.AppletSaveClick, {
+    Mixpanel.track({
+      action: MixpanelEventType.AppletSaveClick,
       [MixpanelProps.AppletId]: appletId,
     });
 
@@ -418,7 +419,8 @@ export const useSaveAndPublishSetup = (): SaveAndPublishSetup => {
 
     setPublishProcessPopupOpened(false);
 
-    Mixpanel.track(MixpanelEventType.AppletSaveClick, {
+    Mixpanel.track({
+      action: MixpanelEventType.AppletSaveClick,
       [MixpanelProps.AppletId]: appletId,
     });
 
@@ -452,7 +454,8 @@ export const useSaveAndPublishSetup = (): SaveAndPublishSetup => {
 
   const handlePasswordSubmit = async (ref?: AppletPasswordRefType) => {
     await handleAppletPasswordSubmit(ref?.current?.password).then(() =>
-      Mixpanel.track(MixpanelEventType.PasswordAddedSuccessfully, {
+      Mixpanel.track({
+        action: MixpanelEventType.PasswordAddedSuccessfully,
         [MixpanelProps.AppletId]: appletId,
       }),
     );
@@ -523,7 +526,8 @@ export const useSaveAndPublishSetup = (): SaveAndPublishSetup => {
     if (!result) return;
 
     if (updateApplet.fulfilled.match(result)) {
-      Mixpanel.track(MixpanelEventType.AppletEditSuccessful, {
+      Mixpanel.track({
+        action: MixpanelEventType.AppletEditSuccessful,
         [MixpanelProps.AppletId]: appletId,
       });
 
@@ -541,7 +545,8 @@ export const useSaveAndPublishSetup = (): SaveAndPublishSetup => {
     }
 
     if (createApplet.fulfilled.match(result)) {
-      Mixpanel.track(MixpanelEventType.AppletCreatedSuccessfully, {
+      Mixpanel.track({
+        action: MixpanelEventType.AppletCreatedSuccessfully,
         [MixpanelProps.AppletId]: appletId,
       });
 

--- a/src/modules/Builder/features/SaveAndPublish/SaveAndPublish.hooks.ts
+++ b/src/modules/Builder/features/SaveAndPublish/SaveAndPublish.hooks.ts
@@ -19,6 +19,8 @@ import {
   getSanitizedContent,
   getUpdatedAppletUrl,
   Mixpanel,
+  MixpanelEventType,
+  MixpanelProps,
   SettingParam,
 } from 'shared/utils';
 import { Activity, ActivityFlow, applet, SingleApplet } from 'shared/state';
@@ -363,8 +365,8 @@ export const useSaveAndPublishSetup = (): SaveAndPublishSetup => {
     shouldNavigateRef.current = true;
     setPromptVisible(false);
     await handleSaveAndPublishFirstClick();
-    Mixpanel.track('Applet Save click', {
-      'Applet ID': appletId,
+    Mixpanel.track(MixpanelEventType.AppletSaveClick, {
+      [MixpanelProps.AppletId]: appletId,
     });
 
     if (isLogoutInProgress && !isNewApplet) {
@@ -416,8 +418,8 @@ export const useSaveAndPublishSetup = (): SaveAndPublishSetup => {
 
     setPublishProcessPopupOpened(false);
 
-    Mixpanel.track('Applet Save click', {
-      'Applet ID': appletId,
+    Mixpanel.track(MixpanelEventType.AppletSaveClick, {
+      [MixpanelProps.AppletId]: appletId,
     });
 
     await sendRequestWithPasswordCheck();
@@ -450,8 +452,8 @@ export const useSaveAndPublishSetup = (): SaveAndPublishSetup => {
 
   const handlePasswordSubmit = async (ref?: AppletPasswordRefType) => {
     await handleAppletPasswordSubmit(ref?.current?.password).then(() =>
-      Mixpanel.track('Password added successfully', {
-        'Applet ID': appletId,
+      Mixpanel.track(MixpanelEventType.PasswordAddedSuccessfully, {
+        [MixpanelProps.AppletId]: appletId,
       }),
     );
     setIsPasswordPopupOpened(false);
@@ -521,8 +523,8 @@ export const useSaveAndPublishSetup = (): SaveAndPublishSetup => {
     if (!result) return;
 
     if (updateApplet.fulfilled.match(result)) {
-      Mixpanel.track('Applet edit successful', {
-        'Applet ID': appletId,
+      Mixpanel.track(MixpanelEventType.AppletEditSuccessful, {
+        [MixpanelProps.AppletId]: appletId,
       });
 
       showSuccessBanner(true);
@@ -539,8 +541,8 @@ export const useSaveAndPublishSetup = (): SaveAndPublishSetup => {
     }
 
     if (createApplet.fulfilled.match(result)) {
-      Mixpanel.track('Applet Created Successfully', {
-        'Applet ID': appletId,
+      Mixpanel.track(MixpanelEventType.AppletCreatedSuccessfully, {
+        [MixpanelProps.AppletId]: appletId,
       });
 
       showSuccessBanner();

--- a/src/modules/Dashboard/api/api.ts
+++ b/src/modules/Dashboard/api/api.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosResponse } from 'axios';
 
 import { AppletId, ActivityId, ActivityFlowId, Response, ResponseWithObject } from 'shared/api';
-import { ExportDataResult } from 'shared/types';
+import { ExportDataResult, Invitation } from 'shared/types';
 import { DEFAULT_ROWS_PER_PAGE as SHARED_DEFAULT_ROWS_PER_PAGE, MAX_LIMIT } from 'shared/consts'; // TODO: replace MAX_LIMIT with infinity scroll
 import { authApiClient } from 'shared/api/apiConfig';
 
@@ -284,7 +284,7 @@ export const postAppletInvitationApi = (
   { url, appletId, options }: AppletInvitationData,
   signal?: AbortSignal,
 ) =>
-  authApiClient.post(
+  authApiClient.post<ResponseWithObject<Invitation>>(
     `/invitations/${appletId}/${url}`,
     { ...options },
     {

--- a/src/modules/Dashboard/api/api.types.ts
+++ b/src/modules/Dashboard/api/api.types.ts
@@ -1,6 +1,6 @@
 import { ActivityId, AppletId } from 'shared/api';
 import { Activity, ActivityFlow, Item, SingleApplet, SubscaleSetting } from 'shared/state';
-import { ParticipantTag, PerfTaskType, Roles, UserSelectableParticipantTag } from 'shared/consts';
+import { ParticipantTag, PerfTaskType, Roles } from 'shared/consts';
 import { RetentionPeriods, EncryptedAnswerSharedProps, ExportActivity } from 'shared/types';
 import { Encryption } from 'shared/utils';
 import { User } from 'modules/Auth/state';
@@ -258,7 +258,7 @@ export type EditSubjectResponse = {
   userId: string | null;
   secretUserId: string;
   nickname: string | null;
-  tag: UserSelectableParticipantTag | null;
+  tag: ParticipantTag | null;
 };
 
 export type DeleteSubject = SubjectId & {

--- a/src/modules/Dashboard/api/api.types.ts
+++ b/src/modules/Dashboard/api/api.types.ts
@@ -1,6 +1,6 @@
 import { ActivityId, AppletId } from 'shared/api';
 import { Activity, ActivityFlow, Item, SingleApplet, SubscaleSetting } from 'shared/state';
-import { ParticipantTag, PerfTaskType, Roles } from 'shared/consts';
+import { ParticipantTag, PerfTaskType, Roles, UserSelectableParticipantTag } from 'shared/consts';
 import { RetentionPeriods, EncryptedAnswerSharedProps, ExportActivity } from 'shared/types';
 import { Encryption } from 'shared/utils';
 import { User } from 'modules/Auth/state';
@@ -258,7 +258,7 @@ export type EditSubjectResponse = {
   userId: string | null;
   secretUserId: string;
   nickname: string | null;
-  tag: string | null;
+  tag: UserSelectableParticipantTag | null;
 };
 
 export type DeleteSubject = SubjectId & {

--- a/src/modules/Dashboard/components/HeaderOptions/HeaderOptions.tsx
+++ b/src/modules/Dashboard/components/HeaderOptions/HeaderOptions.tsx
@@ -7,7 +7,7 @@ import { page } from 'resources';
 import { Svg } from 'shared/components';
 import { ExportDataSetting } from 'shared/features/AppletSettings';
 import { StyledFlexTopCenter, variables } from 'shared/styles';
-import { Mixpanel, checkIfCanAccessData, checkIfCanEdit } from 'shared/utils';
+import { Mixpanel, checkIfCanAccessData, checkIfCanEdit, MixpanelEventType } from 'shared/utils';
 import { workspaces } from 'shared/state';
 
 export const HeaderOptions = () => {
@@ -20,7 +20,7 @@ export const HeaderOptions = () => {
 
   const handleOpenExport = () => {
     setIsExportOpen(true);
-    Mixpanel.track('Export Data click');
+    Mixpanel.track(MixpanelEventType.ExportDataClick);
   };
 
   const handleCloseExport = () => {

--- a/src/modules/Dashboard/components/HeaderOptions/HeaderOptions.tsx
+++ b/src/modules/Dashboard/components/HeaderOptions/HeaderOptions.tsx
@@ -20,7 +20,7 @@ export const HeaderOptions = () => {
 
   const handleOpenExport = () => {
     setIsExportOpen(true);
-    Mixpanel.track(MixpanelEventType.ExportDataClick);
+    Mixpanel.track({ action: MixpanelEventType.ExportDataClick });
   };
 
   const handleCloseExport = () => {

--- a/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.test-utils.ts
+++ b/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.test-utils.ts
@@ -1,9 +1,21 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Dict } from 'mixpanel-browser';
 
 import { mockedAppletData, mockedAppletId } from 'shared/mock';
-import { MixpanelProps, Mixpanel } from 'shared/utils';
+import {
+  MixpanelProps,
+  Mixpanel,
+  TakeNowDialogClosedEvent,
+  MultiInformantStartActivityClickEvent,
+  ProvidingResponsesDropdownOpenedEvent,
+  ProvidingResponsesSelectionChangedEvent,
+  OwnResponsesCheckboxToggledEvent,
+  InputtingResponsesDropdownOpenedEvent,
+  InputtingResponsesSelectionChangedEvent,
+  ResponsesAboutDropdownOpenedEvent,
+  ResponsesAboutSelectionChangedEvent,
+  TakeNowClickEvent,
+} from 'shared/utils';
 
 const spyMixpanelTrack = jest.spyOn(Mixpanel, 'track');
 
@@ -69,15 +81,26 @@ export const toggleSelfReportCheckbox = async (testId: string) => {
   fireEvent.click(checkbox);
 };
 
-export const expectMixpanelTrack = (action: string, payload?: Dict) => {
+export const expectMixpanelTrack = (
+  event:
+    | TakeNowDialogClosedEvent
+    | MultiInformantStartActivityClickEvent
+    | ProvidingResponsesDropdownOpenedEvent
+    | ProvidingResponsesSelectionChangedEvent
+    | OwnResponsesCheckboxToggledEvent
+    | InputtingResponsesDropdownOpenedEvent
+    | InputtingResponsesSelectionChangedEvent
+    | ResponsesAboutDropdownOpenedEvent
+    | ResponsesAboutSelectionChangedEvent
+    | TakeNowClickEvent,
+) => {
   expect(spyMixpanelTrack).toHaveBeenCalledWith(
-    action,
     expect.objectContaining({
       [MixpanelProps.Feature]: 'Multi-informant',
       [MixpanelProps.AppletId]: mockedAppletId,
       [MixpanelProps.MultiInformantAssessmentId]: expect.any(String),
       [MixpanelProps.ActivityId]: mockedAppletData.activities[0].id,
-      ...payload,
+      ...event,
     }),
   );
 };

--- a/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.tsx
+++ b/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.tsx
@@ -25,6 +25,8 @@ import {
   checkIfDashboardAppletParticipantDetailsUrlPassed,
   checkIfFullAccess,
   getErrorMessage,
+  MixpanelAction,
+  MixpanelEventType,
 } from 'shared/utils';
 import { useAsync, useLogout } from 'shared/hooks';
 import { HydratedActivityFlow } from 'modules/Dashboard/types';
@@ -96,7 +98,7 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
 
   const track = useCallback(
     (
-      action: string,
+      action: MixpanelAction,
       payload?: MixpanelPayload,
       newActivityOrFlow?: Activity | HydratedActivityFlow | ParticipantActivityOrFlow,
     ) => {
@@ -122,7 +124,7 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
   const TakeNowModal = ({ onClose }: TakeNowModalProps) => {
     const handleLogout = useLogout();
     const handleClose = () => {
-      track('Take Now dialogue closed');
+      track(MixpanelEventType.TakeNowDialogClosed);
 
       setActivityOrFlow(null);
       setMultiInformantAssessmentId(null);
@@ -245,7 +247,7 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
           respondent = loggedInUser;
         }
 
-        track('Multi-informant Start Activity click', {
+        track(MixpanelEventType.MultiInformantStartActivityClick, {
           [MixpanelProps.SourceAccountType]: getAccountType(sourceSubject),
           [MixpanelProps.TargetAccountType]: getAccountType(targetSubject),
           [MixpanelProps.InputAccountType]: getAccountType(
@@ -364,10 +366,10 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
                   value={sourceSubject}
                   options={participantsAndTeamMembers}
                   onOpen={() => {
-                    track('"Who will be providing responses" dropdown opened');
+                    track(MixpanelEventType.ProvidingResponsesDropdownOpened);
                   }}
                   onChange={(option) => {
-                    track('"Who will be providing responses" selection changed', {
+                    track(MixpanelEventType.ProvidingResponsesSelectionChanged, {
                       [MixpanelProps.SourceAccountType]: getAccountType(option),
                     });
 
@@ -394,7 +396,7 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
                   sx={{ gap: 0.4 }}
                   checked={isSelfReporting}
                   onChange={(_e, checked) => {
-                    track('Own responses checkbox toggled', {
+                    track(MixpanelEventType.OwnResponsesCheckboxToggled, {
                       [MixpanelProps.IsSelfReporting]: checked,
                     });
                     setIsSelfReporting(checked);
@@ -420,10 +422,10 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
                       : teamMembersOnly
                   }
                   onOpen={() => {
-                    track('"Who will be inputting the responses" dropdown opened');
+                    track(MixpanelEventType.InputtingResponsesDropdownOpened);
                   }}
                   onChange={(option) => {
-                    track('"Who will be inputting the responses" selection changed', {
+                    track(MixpanelEventType.InputtingResponsesSelectionChanged, {
                       [MixpanelProps.InputAccountType]: getAccountType(option),
                     });
                     setLoggedInUser(option);
@@ -450,10 +452,10 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
               value={targetSubject}
               options={participantsAndTeamMembers}
               onOpen={() => {
-                track('"Who are the responses about" dropdown opened');
+                track(MixpanelEventType.ResponsesAboutDropdownOpened);
               }}
               onChange={(option) => {
-                track('"Who are the responses about" selection changed', {
+                track(MixpanelEventType.ResponsesAboutSelectionChanged, {
                   [MixpanelProps.TargetAccountType]: getAccountType(option),
                 });
                 setTargetSubject(option);
@@ -498,7 +500,7 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
       analyticsPayload[MixpanelProps.Via] = 'Applet - Participants - Activities';
     }
 
-    track('Take Now click', analyticsPayload, activityOrFlow);
+    track(MixpanelEventType.TakeNowClick, analyticsPayload, activityOrFlow);
   };
 
   return { TakeNowModal, openTakeNowModal };

--- a/src/modules/Dashboard/features/Applet/Activities/Activities.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Activities/Activities.test.tsx
@@ -36,7 +36,7 @@ import {
   takeNowModalTestId,
   toggleSelfReportCheckbox,
 } from 'modules/Dashboard/components/TakeNowModal/TakeNowModal.test-utils';
-import { MixpanelProps } from 'shared/utils';
+import { MixpanelEventType, MixpanelProps } from 'shared/utils';
 
 import { Activities } from './Activities';
 
@@ -356,7 +356,10 @@ describe('Dashboard > Applet > Activities screen', () => {
 
       await openTakeNowModal(testId);
 
-      expectMixpanelTrack('Take Now click', { [MixpanelProps.Via]: 'Applet - Activities' });
+      expectMixpanelTrack({
+        action: MixpanelEventType.TakeNowClick,
+        [MixpanelProps.Via]: 'Applet - Activities',
+      });
 
       const sourceInputElement = screen
         .getByTestId(sourceSubjectDropdownTestId(testId))
@@ -368,8 +371,9 @@ describe('Dashboard > Applet > Activities screen', () => {
 
       selectParticipant(testId, 'target', mockedRespondent.details[0].subjectId);
 
-      expectMixpanelTrack('"Who are the responses about" dropdown opened');
-      expectMixpanelTrack('"Who are the responses about" selection changed', {
+      expectMixpanelTrack({ action: MixpanelEventType.ResponsesAboutDropdownOpened });
+      expectMixpanelTrack({
+        action: MixpanelEventType.ResponsesAboutSelectionChanged,
         [MixpanelProps.TargetAccountType]: 'Full',
       });
 
@@ -379,7 +383,8 @@ describe('Dashboard > Applet > Activities screen', () => {
 
       fireEvent.click(submitButton);
 
-      expectMixpanelTrack('Multi-informant Start Activity click', {
+      expectMixpanelTrack({
+        action: MixpanelEventType.MultiInformantStartActivityClick,
         [MixpanelProps.SourceAccountType]: 'Team',
         [MixpanelProps.TargetAccountType]: 'Full',
         [MixpanelProps.InputAccountType]: 'Team',
@@ -494,8 +499,9 @@ describe('Dashboard > Applet > Activities screen', () => {
 
       selectParticipant(testId, 'source', mockedRespondent.details[0].subjectId);
 
-      expectMixpanelTrack('"Who will be providing responses" dropdown opened');
-      expectMixpanelTrack('"Who will be providing responses" selection changed', {
+      expectMixpanelTrack({ action: MixpanelEventType.ProvidingResponsesDropdownOpened });
+      expectMixpanelTrack({
+        action: MixpanelEventType.ProvidingResponsesSelectionChanged,
         [MixpanelProps.SourceAccountType]: 'Full',
       });
 
@@ -611,14 +617,16 @@ describe('Dashboard > Applet > Activities screen', () => {
 
       await selectParticipant(testId, 'source', mockedOwnerRespondent.details[0].subjectId);
 
-      expectMixpanelTrack('"Who will be providing responses" dropdown opened');
-      expectMixpanelTrack('"Who will be providing responses" selection changed', {
+      expectMixpanelTrack({ action: MixpanelEventType.ProvidingResponsesDropdownOpened });
+      expectMixpanelTrack({
+        action: MixpanelEventType.ProvidingResponsesSelectionChanged,
         [MixpanelProps.SourceAccountType]: 'Team',
       });
 
       await toggleSelfReportCheckbox(testId);
 
-      expectMixpanelTrack('Own responses checkbox toggled', {
+      expectMixpanelTrack({
+        action: MixpanelEventType.OwnResponsesCheckboxToggled,
         [MixpanelProps.IsSelfReporting]: false,
       });
 
@@ -632,7 +640,7 @@ describe('Dashboard > Applet > Activities screen', () => {
 
       fireEvent.mouseDown(inputElement);
 
-      expectMixpanelTrack('"Who will be inputting the responses" dropdown opened');
+      expectMixpanelTrack({ action: MixpanelEventType.InputtingResponsesDropdownOpened });
 
       const options = within(getByRole('listbox')).queryAllByRole('option');
 
@@ -649,7 +657,8 @@ describe('Dashboard > Applet > Activities screen', () => {
 
       selectParticipant(testId, 'loggedin', mockedOwnerRespondent.details[0].subjectId);
 
-      expectMixpanelTrack('"Who will be inputting the responses" selection changed', {
+      expectMixpanelTrack({
+        action: MixpanelEventType.InputtingResponsesSelectionChanged,
         [MixpanelProps.InputAccountType]: 'Team',
       });
     });
@@ -771,8 +780,9 @@ describe('Dashboard > Applet > Activities screen', () => {
 
         await selectParticipant(testId, 'source', mockedOwnerRespondent.details[0].subjectId);
 
-        expectMixpanelTrack('"Who will be providing responses" dropdown opened');
-        expectMixpanelTrack('"Who will be providing responses" selection changed', {
+        expectMixpanelTrack({ action: MixpanelEventType.ProvidingResponsesDropdownOpened });
+        expectMixpanelTrack({
+          action: MixpanelEventType.ProvidingResponsesSelectionChanged,
           [MixpanelProps.SourceAccountType]: 'Team',
         });
 
@@ -888,14 +898,16 @@ describe('Dashboard > Applet > Activities screen', () => {
 
         await selectParticipant(testId, 'source', mockedOwnerRespondent.details[0].subjectId);
 
-        expectMixpanelTrack('"Who will be providing responses" dropdown opened');
-        expectMixpanelTrack('"Who will be providing responses" selection changed', {
+        expectMixpanelTrack({ action: MixpanelEventType.ProvidingResponsesDropdownOpened });
+        expectMixpanelTrack({
+          action: MixpanelEventType.ProvidingResponsesSelectionChanged,
           [MixpanelProps.SourceAccountType]: 'Team',
         });
 
         await toggleSelfReportCheckbox(testId);
 
-        expectMixpanelTrack('Own responses checkbox toggled', {
+        expectMixpanelTrack({
+          action: MixpanelEventType.OwnResponsesCheckboxToggled,
           [MixpanelProps.IsSelfReporting]: false,
         });
 
@@ -909,7 +921,7 @@ describe('Dashboard > Applet > Activities screen', () => {
 
         fireEvent.mouseDown(inputElement);
 
-        expectMixpanelTrack('"Who will be inputting the responses" dropdown opened');
+        expectMixpanelTrack({ action: MixpanelEventType.InputtingResponsesDropdownOpened });
 
         const options = within(getByRole('listbox')).queryAllByRole('option');
 

--- a/src/modules/Dashboard/features/Applet/DashboardAppletSettings/DashboardAppletSettings.utils.tsx
+++ b/src/modules/Dashboard/features/Applet/DashboardAppletSettings/DashboardAppletSettings.utils.tsx
@@ -10,7 +10,14 @@ import {
   VersionHistorySetting,
   ShareAppletSetting,
 } from 'shared/features/AppletSettings';
-import { Mixpanel, SettingParam, isManagerOrOwner, checkIfCanEdit } from 'shared/utils';
+import {
+  Mixpanel,
+  SettingParam,
+  isManagerOrOwner,
+  checkIfCanEdit,
+  MixpanelEventType,
+  MixpanelProps,
+} from 'shared/utils';
 import { Item as ItemNavigation } from 'shared/components/NavigationMenu';
 
 import { GetSettings } from './DashboardAppletSettings.types';
@@ -50,8 +57,8 @@ export const getSettings = ({
           param: SettingParam.EditApplet,
           'data-testid': `${dataTestid}-edit-applet`,
           onClick: () =>
-            Mixpanel.track('Applet edit click', {
-              'Applet ID': appletId,
+            Mixpanel.track(MixpanelEventType.AppletEditClick, {
+              [MixpanelProps.AppletId]: appletId,
             }),
         },
         // Description: "Download Schema" logic is hidden until it will be used in future features

--- a/src/modules/Dashboard/features/Applet/DashboardAppletSettings/DashboardAppletSettings.utils.tsx
+++ b/src/modules/Dashboard/features/Applet/DashboardAppletSettings/DashboardAppletSettings.utils.tsx
@@ -57,7 +57,8 @@ export const getSettings = ({
           param: SettingParam.EditApplet,
           'data-testid': `${dataTestid}-edit-applet`,
           onClick: () =>
-            Mixpanel.track(MixpanelEventType.AppletEditClick, {
+            Mixpanel.track({
+              action: MixpanelEventType.AppletEditClick,
               [MixpanelProps.AppletId]: appletId,
             }),
         },

--- a/src/modules/Dashboard/features/Applet/Overview/Overview.tsx
+++ b/src/modules/Dashboard/features/Applet/Overview/Overview.tsx
@@ -10,7 +10,7 @@ import { Spinner } from 'shared/components';
 import { StyledFlexColumn, StyledTitleLarge } from 'shared/styles';
 import { workspaces } from 'redux/modules';
 import { useAsync, useEncryptionStorage, usePermissions } from 'shared/hooks';
-import { MixpanelProps, Mixpanel, checkIfCanAccessData } from 'shared/utils';
+import { MixpanelProps, Mixpanel, checkIfCanAccessData, MixpanelEventType } from 'shared/utils';
 
 import { mapResponseToQuickStatProps, mapResponseToSubmissionsTableProps } from './Overview.utils';
 import { StyledRoot } from './Overview.styles';
@@ -83,7 +83,7 @@ export const Overview = () => {
           <QuickStats
             {...mapResponseToQuickStatProps(data, {
               onPressAddParticipant: () => {
-                Mixpanel.track('Add Participant button clicked', {
+                Mixpanel.track(MixpanelEventType.AddParticipantBtnClicked, {
                   [MixpanelProps.AppletId]: appletId,
                   [MixpanelProps.Via]: 'Applet - Overview',
                 });

--- a/src/modules/Dashboard/features/Applet/Overview/Overview.tsx
+++ b/src/modules/Dashboard/features/Applet/Overview/Overview.tsx
@@ -83,7 +83,8 @@ export const Overview = () => {
           <QuickStats
             {...mapResponseToQuickStatProps(data, {
               onPressAddParticipant: () => {
-                Mixpanel.track(MixpanelEventType.AddParticipantBtnClicked, {
+                Mixpanel.track({
+                  action: MixpanelEventType.AddParticipantBtnClicked,
                   [MixpanelProps.AppletId]: appletId,
                   [MixpanelProps.Via]: 'Applet - Overview',
                 });

--- a/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.test.tsx
@@ -4,7 +4,7 @@ import mockAxios from 'jest-mock-axios';
 
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
 import { mockedAppletId } from 'shared/mock';
-import { expectBanner } from 'shared/utils';
+import { expectBanner, MixpanelEventType } from 'shared/utils';
 import { MixpanelProps, Mixpanel } from 'shared/utils/mixpanel';
 import { ParticipantTag } from 'shared/consts';
 
@@ -92,7 +92,8 @@ describe('AddParticipantPopup component', () => {
 
     await userEvent.click(getByText('Send Invitation'));
 
-    expect(mixpanelTrack).toBeCalledWith('Full Account invitation form submitted', {
+    expect(mixpanelTrack).toBeCalledWith({
+      action: MixpanelEventType.FullAccountInvitationFormSubmitted,
       [MixpanelProps.AppletId]: mockedAppletId,
       [MixpanelProps.Tag]: 'Child',
     });
@@ -101,7 +102,8 @@ describe('AddParticipantPopup component', () => {
       expectBanner(store, 'AddParticipantSuccessBanner');
     });
 
-    expect(mixpanelTrack).toBeCalledWith('Full Account invitation created successfully', {
+    expect(mixpanelTrack).toBeCalledWith({
+      action: MixpanelEventType.FullAccountInvitationCreated,
       [MixpanelProps.AppletId]: mockedAppletId,
       [MixpanelProps.Tag]: 'Child',
     });
@@ -134,7 +136,8 @@ describe('AddParticipantPopup component', () => {
 
     await userEvent.click(getByText('Create'));
 
-    expect(mixpanelTrack).toBeCalledWith('Add Limited Account form submitted', {
+    expect(mixpanelTrack).toBeCalledWith({
+      action: MixpanelEventType.AddLimitedAccountFormSubmitted,
       [MixpanelProps.AppletId]: mockedAppletId,
       [MixpanelProps.Tag]: 'Child',
     });
@@ -143,7 +146,8 @@ describe('AddParticipantPopup component', () => {
       expectBanner(store, 'AddParticipantSuccessBanner');
     });
 
-    expect(mixpanelTrack).toBeCalledWith('Limited Account created successfully', {
+    expect(mixpanelTrack).toBeCalledWith({
+      action: MixpanelEventType.LimitedAccountCreated,
       [MixpanelProps.AppletId]: mockedAppletId,
       [MixpanelProps.Tag]: 'Child',
     });

--- a/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.tsx
@@ -8,7 +8,7 @@ import { Modal, Spinner, ToggleButtonGroup, ToggleButtonVariants } from 'shared/
 import { StyledErrorText, StyledFlexEnd, StyledModalWrapper } from 'shared/styles';
 import { useFormError } from 'modules/Dashboard/hooks';
 import { NON_UNIQUE_VALUE_MESSAGE, Roles } from 'shared/consts';
-import { MixpanelProps, Mixpanel, getErrorMessage } from 'shared/utils';
+import { MixpanelProps, Mixpanel, getErrorMessage, MixpanelEventType } from 'shared/utils';
 import { ApiLanguages, postAppletInvitationApi, postAppletShellAccountApi } from 'api';
 import { useAppDispatch } from 'redux/store';
 import { useAsync } from 'shared/hooks';
@@ -85,7 +85,7 @@ export const AddParticipantPopup = ({
       }),
     );
 
-    Mixpanel.track('Full Account invitation created successfully', {
+    Mixpanel.track(MixpanelEventType.FullAccountInvitationCreated, {
       [MixpanelProps.AppletId]: appletId,
       [MixpanelProps.Tag]: data?.result?.tag || null, // Normalize empty string tag to null
     });
@@ -107,7 +107,7 @@ export const AddParticipantPopup = ({
       }),
     );
 
-    Mixpanel.track('Limited Account created successfully', {
+    Mixpanel.track(MixpanelEventType.LimitedAccountCreated, {
       [MixpanelProps.AppletId]: appletId,
       [MixpanelProps.Tag]: data?.result?.tag || null, // Normalize empty string tag to null
     });
@@ -127,7 +127,7 @@ export const AddParticipantPopup = ({
     const { email, nickname, tag, ...rest } = values;
 
     if (isFullAccount) {
-      Mixpanel.track('Full Account invitation form submitted', {
+      Mixpanel.track(MixpanelEventType.FullAccountInvitationFormSubmitted, {
         [MixpanelProps.AppletId]: appletId,
         [MixpanelProps.Tag]: tag || null, // Normalize empty string tag to null
       });
@@ -146,7 +146,7 @@ export const AddParticipantPopup = ({
         },
       });
     } else {
-      Mixpanel.track('Add Limited Account form submitted', {
+      Mixpanel.track(MixpanelEventType.AddLimitedAccountFormSubmitted, {
         [MixpanelProps.AppletId]: appletId,
         [MixpanelProps.Tag]: tag || null, // Normalize empty string tag to null
       });

--- a/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.tsx
@@ -85,7 +85,8 @@ export const AddParticipantPopup = ({
       }),
     );
 
-    Mixpanel.track(MixpanelEventType.FullAccountInvitationCreated, {
+    Mixpanel.track({
+      action: MixpanelEventType.FullAccountInvitationCreated,
       [MixpanelProps.AppletId]: appletId,
       [MixpanelProps.Tag]: data?.result?.tag || null, // Normalize empty string tag to null
     });
@@ -107,7 +108,8 @@ export const AddParticipantPopup = ({
       }),
     );
 
-    Mixpanel.track(MixpanelEventType.LimitedAccountCreated, {
+    Mixpanel.track({
+      action: MixpanelEventType.LimitedAccountCreated,
       [MixpanelProps.AppletId]: appletId,
       [MixpanelProps.Tag]: data?.result?.tag || null, // Normalize empty string tag to null
     });
@@ -127,7 +129,8 @@ export const AddParticipantPopup = ({
     const { email, nickname, tag, ...rest } = values;
 
     if (isFullAccount) {
-      Mixpanel.track(MixpanelEventType.FullAccountInvitationFormSubmitted, {
+      Mixpanel.track({
+        action: MixpanelEventType.FullAccountInvitationFormSubmitted,
         [MixpanelProps.AppletId]: appletId,
         [MixpanelProps.Tag]: tag || null, // Normalize empty string tag to null
       });
@@ -146,7 +149,8 @@ export const AddParticipantPopup = ({
         },
       });
     } else {
-      Mixpanel.track(MixpanelEventType.AddLimitedAccountFormSubmitted, {
+      Mixpanel.track({
+        action: MixpanelEventType.AddLimitedAccountFormSubmitted,
         [MixpanelProps.AppletId]: appletId,
         [MixpanelProps.Tag]: tag || null, // Normalize empty string tag to null
       });

--- a/src/modules/Dashboard/features/Applet/Popups/DuplicatePopups/DuplicatePopups.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/DuplicatePopups/DuplicatePopups.tsx
@@ -161,7 +161,8 @@ export const DuplicatePopups = ({ onCloseCallback }: { onCloseCallback?: () => v
     duplicatePopupsClose();
     resetEncryptionData();
 
-    Mixpanel.track(MixpanelEventType.AppletCreatedSuccessfully, {
+    Mixpanel.track({
+      action: MixpanelEventType.AppletCreatedSuccessfully,
       [MixpanelProps.AppletId]: currentAppletId,
     });
 

--- a/src/modules/Dashboard/features/Applet/Popups/DuplicatePopups/DuplicatePopups.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/DuplicatePopups/DuplicatePopups.tsx
@@ -12,6 +12,8 @@ import {
   getPrivateKey,
   Mixpanel,
   publicEncrypt,
+  MixpanelEventType,
+  MixpanelProps,
 } from 'shared/utils';
 import { Modal, Spinner, SpinnerUiType } from 'shared/components';
 import { CheckboxController, InputController } from 'shared/components/FormComponents';
@@ -159,8 +161,8 @@ export const DuplicatePopups = ({ onCloseCallback }: { onCloseCallback?: () => v
     duplicatePopupsClose();
     resetEncryptionData();
 
-    Mixpanel.track('Applet Created Successfully', {
-      'Applet ID': currentAppletId,
+    Mixpanel.track(MixpanelEventType.AppletCreatedSuccessfully, {
+      [MixpanelProps.AppletId]: currentAppletId,
     });
 
     dispatch(

--- a/src/modules/Dashboard/features/Applet/Popups/UpgradeAccountPopup/UpgradeAccountPopup.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/UpgradeAccountPopup/UpgradeAccountPopup.test.tsx
@@ -4,7 +4,7 @@ import mockAxios from 'jest-mock-axios';
 
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
 import { mockedAppletId, mockedSubjectId1 } from 'shared/mock';
-import { Mixpanel, MixpanelProps, expectBanner } from 'shared/utils';
+import { Mixpanel, MixpanelProps, expectBanner, MixpanelEventType } from 'shared/utils';
 import { ParticipantTag } from 'shared/consts';
 
 import { UpgradeAccountPopup } from './UpgradeAccountPopup';
@@ -50,7 +50,8 @@ describe('UpgradeAccountPopup component', () => {
 
     await userEvent.click(getByText('Send Invitation'));
 
-    expect(mixpanelTrack).toBeCalledWith('Upgrade to Full Account invitation form submitted', {
+    expect(mixpanelTrack).toBeCalledWith({
+      action: MixpanelEventType.UpgradeToFullAccountFormSubmitted,
       [MixpanelProps.AppletId]: mockedAppletId,
     });
 
@@ -58,9 +59,9 @@ describe('UpgradeAccountPopup component', () => {
       expectBanner(store, 'AddParticipantSuccessBanner');
     });
 
-    expect(mixpanelTrack).toBeCalledWith(
-      'Upgrade to Full Account invitation created successfully',
-      { [MixpanelProps.AppletId]: mockedAppletId },
-    );
+    expect(mixpanelTrack).toBeCalledWith({
+      action: MixpanelEventType.UpgradeToFullAccountInviteCreated,
+      [MixpanelProps.AppletId]: mockedAppletId,
+    });
   });
 });

--- a/src/modules/Dashboard/features/Applet/Popups/UpgradeAccountPopup/UpgradeAccountPopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/UpgradeAccountPopup/UpgradeAccountPopup.tsx
@@ -11,7 +11,7 @@ import {
   StyledModalWrapper,
 } from 'shared/styles';
 import { useFormError } from 'modules/Dashboard/hooks';
-import { Mixpanel, MixpanelProps, getErrorMessage } from 'shared/utils';
+import { Mixpanel, MixpanelProps, getErrorMessage, MixpanelEventType } from 'shared/utils';
 import { ApiLanguages, postSubjectInvitationApi } from 'api';
 import { useAppDispatch } from 'redux/store';
 import { useAsync } from 'shared/hooks';
@@ -80,7 +80,7 @@ export const UpgradeAccountPopup = ({
       }),
     );
 
-    Mixpanel.track('Upgrade to Full Account invitation created successfully', {
+    Mixpanel.track(MixpanelEventType.UpgradeToFullAccountInviteCreated, {
       [MixpanelProps.AppletId]: appletId,
     });
 
@@ -90,7 +90,7 @@ export const UpgradeAccountPopup = ({
   const handleSubmitForm = (values: UpgradeAccountFormValues) => {
     if (!appletId || !subjectId) return;
 
-    Mixpanel.track('Upgrade to Full Account invitation form submitted', {
+    Mixpanel.track(MixpanelEventType.UpgradeToFullAccountFormSubmitted, {
       [MixpanelProps.AppletId]: appletId,
     });
 

--- a/src/modules/Dashboard/features/Applet/Popups/UpgradeAccountPopup/UpgradeAccountPopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/UpgradeAccountPopup/UpgradeAccountPopup.tsx
@@ -80,7 +80,8 @@ export const UpgradeAccountPopup = ({
       }),
     );
 
-    Mixpanel.track(MixpanelEventType.UpgradeToFullAccountInviteCreated, {
+    Mixpanel.track({
+      action: MixpanelEventType.UpgradeToFullAccountInviteCreated,
       [MixpanelProps.AppletId]: appletId,
     });
 
@@ -90,7 +91,8 @@ export const UpgradeAccountPopup = ({
   const handleSubmitForm = (values: UpgradeAccountFormValues) => {
     if (!appletId || !subjectId) return;
 
-    Mixpanel.track(MixpanelEventType.UpgradeToFullAccountFormSubmitted, {
+    Mixpanel.track({
+      action: MixpanelEventType.UpgradeToFullAccountFormSubmitted,
       [MixpanelProps.AppletId]: appletId,
     });
 

--- a/src/modules/Dashboard/features/Applet/Schedule/CreateEventPopup/CreateEventPopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/CreateEventPopup/CreateEventPopup.tsx
@@ -37,7 +37,8 @@ export const CreateEventPopup = ({
       eventFormRef.current.submitForm();
     }
 
-    Mixpanel.track(MixpanelCalendarEvent[analyticsPrefix].ScheduleSaveClick, {
+    Mixpanel.track({
+      action: MixpanelCalendarEvent[analyticsPrefix].ScheduleSaveClick,
       [MixpanelProps.AppletId]: appletId,
     });
   };

--- a/src/modules/Dashboard/features/Applet/Schedule/CreateEventPopup/CreateEventPopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/CreateEventPopup/CreateEventPopup.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 
 import { Modal, Spinner, SpinnerUiType } from 'shared/components';
-import { Mixpanel } from 'shared/utils/mixpanel';
+import { Mixpanel, MixpanelCalendarEvent, MixpanelProps } from 'shared/utils/mixpanel';
 import { AnalyticsCalendarPrefix } from 'shared/consts';
 
 import { EventForm, EventFormRef } from '../EventForm';
@@ -37,8 +37,8 @@ export const CreateEventPopup = ({
       eventFormRef.current.submitForm();
     }
 
-    Mixpanel.track(`${analyticsPrefix} Schedule save click`, {
-      'Applet ID': appletId,
+    Mixpanel.track(MixpanelCalendarEvent[analyticsPrefix].ScheduleSaveClick, {
+      [MixpanelProps.AppletId]: appletId,
     });
   };
 

--- a/src/modules/Dashboard/features/Applet/Schedule/EditEventPopup/EditEventPopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/EditEventPopup/EditEventPopup.tsx
@@ -8,7 +8,7 @@ import { useAsync } from 'shared/hooks/useAsync';
 import { deleteEventApi } from 'api';
 import { applets } from 'modules/Dashboard/state';
 import { useAppDispatch } from 'redux/store';
-import { Mixpanel } from 'shared/utils/mixpanel';
+import { Mixpanel, MixpanelCalendarEvent } from 'shared/utils/mixpanel';
 import { AnalyticsCalendarPrefix } from 'shared/consts';
 import { StyledFlexSpaceBetween } from 'shared/styles';
 
@@ -61,7 +61,7 @@ export const EditEventPopup = ({
       eventFormRef.current.submitForm();
     }
 
-    Mixpanel.track(`${analyticsPrefix} Schedule save click`);
+    Mixpanel.track(MixpanelCalendarEvent[analyticsPrefix].ScheduleSaveClick);
   };
 
   const handleRemoveEvent = async () => {

--- a/src/modules/Dashboard/features/Applet/Schedule/EditEventPopup/EditEventPopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/EditEventPopup/EditEventPopup.tsx
@@ -61,7 +61,7 @@ export const EditEventPopup = ({
       eventFormRef.current.submitForm();
     }
 
-    Mixpanel.track(MixpanelCalendarEvent[analyticsPrefix].ScheduleSaveClick);
+    Mixpanel.track({ action: MixpanelCalendarEvent[analyticsPrefix].ScheduleSaveClick });
   };
 
   const handleRemoveEvent = async () => {

--- a/src/modules/Dashboard/features/Applet/Schedule/EventForm/EventForm.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/EventForm/EventForm.tsx
@@ -158,7 +158,8 @@ export const EventForm = forwardRef<EventFormRef, EventFormProps>(
         await createEvent({ appletId, body });
       }
 
-      Mixpanel.track(MixpanelCalendarEvent[analyticsPrefix].ScheduleSuccessful, {
+      Mixpanel.track({
+        action: MixpanelCalendarEvent[analyticsPrefix].ScheduleSuccessful,
         [MixpanelProps.AppletId]: appletId,
       });
     };

--- a/src/modules/Dashboard/features/Applet/Schedule/EventForm/EventForm.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/EventForm/EventForm.tsx
@@ -7,7 +7,7 @@ import { ObjectSchema } from 'yup';
 import { Option, SelectController } from 'shared/components/FormComponents';
 import { DefaultTabs as Tabs } from 'shared/components';
 import { StyledBodyLarge, StyledModalWrapper, theme, variables } from 'shared/styles';
-import { getErrorMessage, Mixpanel } from 'shared/utils';
+import { getErrorMessage, Mixpanel, MixpanelCalendarEvent, MixpanelProps } from 'shared/utils';
 import { UiType } from 'shared/components/Tabs/Tabs.types';
 import { applets } from 'modules/Dashboard/state';
 import { applet, workspaces } from 'shared/state';
@@ -158,8 +158,8 @@ export const EventForm = forwardRef<EventFormRef, EventFormProps>(
         await createEvent({ appletId, body });
       }
 
-      Mixpanel.track(`${analyticsPrefix} Schedule successful`, {
-        'Applet ID': appletId,
+      Mixpanel.track(MixpanelCalendarEvent[analyticsPrefix].ScheduleSuccessful, {
+        [MixpanelProps.AppletId]: appletId,
       });
     };
 

--- a/src/modules/Dashboard/features/Applet/Schedule/ImportSchedulePopup/ImportSchedulePopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/ImportSchedulePopup/ImportSchedulePopup.tsx
@@ -14,7 +14,7 @@ import { StyledBodyLarge, StyledModalWrapper, theme } from 'shared/styles';
 import { useAppDispatch } from 'redux/store';
 import { useAsync } from 'shared/hooks';
 import { applet } from 'shared/state';
-import { Mixpanel } from 'shared/utils/mixpanel';
+import { Mixpanel, MixpanelCalendarEvent, MixpanelProps } from 'shared/utils/mixpanel';
 import { AnalyticsCalendarPrefix } from 'shared/consts';
 import {
   deleteIndividualEventsApi,
@@ -155,8 +155,8 @@ export const ImportSchedulePopup = ({
       await importSchedule({ appletId, body });
       onClose();
 
-      Mixpanel.track(`${analyticsPrefix} Schedule import successful`, {
-        'Applet ID': appletId,
+      Mixpanel.track(MixpanelCalendarEvent[analyticsPrefix].ScheduleImportSuccessful, {
+        [MixpanelProps.AppletId]: appletId,
       });
     }
 

--- a/src/modules/Dashboard/features/Applet/Schedule/ImportSchedulePopup/ImportSchedulePopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/ImportSchedulePopup/ImportSchedulePopup.tsx
@@ -155,7 +155,8 @@ export const ImportSchedulePopup = ({
       await importSchedule({ appletId, body });
       onClose();
 
-      Mixpanel.track(MixpanelCalendarEvent[analyticsPrefix].ScheduleImportSuccessful, {
+      Mixpanel.track({
+        action: MixpanelCalendarEvent[analyticsPrefix].ScheduleImportSuccessful,
         [MixpanelProps.AppletId]: appletId,
       });
     }

--- a/src/modules/Dashboard/features/Applet/Schedule/Legend/Legend.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/Legend/Legend.tsx
@@ -65,7 +65,8 @@ export const Legend = ({
   const handleImportClick = () => {
     setImportSchedulePopupVisible(true);
 
-    Mixpanel.track(MixpanelCalendarEvent[analyticsPrefix].ScheduleImportClick, {
+    Mixpanel.track({
+      action: MixpanelCalendarEvent[analyticsPrefix].ScheduleImportClick,
       [MixpanelProps.AppletId]: appletId,
     });
   };

--- a/src/modules/Dashboard/features/Applet/Schedule/Legend/Legend.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/Legend/Legend.tsx
@@ -3,7 +3,7 @@ import { Box, Button } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 
 import { Svg } from 'shared/components';
-import { exportTemplate, Mixpanel } from 'shared/utils';
+import { exportTemplate, Mixpanel, MixpanelCalendarEvent, MixpanelProps } from 'shared/utils';
 import { AnalyticsCalendarPrefix } from 'shared/consts';
 import { StyledFlexColumn, StyledFlexTopCenter, variables } from 'shared/styles';
 
@@ -65,8 +65,8 @@ export const Legend = ({
   const handleImportClick = () => {
     setImportSchedulePopupVisible(true);
 
-    Mixpanel.track(`${analyticsPrefix} Schedule Import click`, {
-      'Applet ID': appletId,
+    Mixpanel.track(MixpanelCalendarEvent[analyticsPrefix].ScheduleImportClick, {
+      [MixpanelProps.AppletId]: appletId,
     });
   };
 

--- a/src/modules/Dashboard/features/Applets/Applets.const.tsx
+++ b/src/modules/Dashboard/features/Applets/Applets.const.tsx
@@ -3,7 +3,7 @@ import { NavigateFunction } from 'react-router-dom';
 
 import { Svg } from 'shared/components/Svg';
 import { HeadCell } from 'shared/types/table';
-import { getBuilderAppletUrl, Mixpanel, Path } from 'shared/utils';
+import { getBuilderAppletUrl, Mixpanel, Path, MixpanelEventType } from 'shared/utils';
 import { page } from 'resources';
 
 export enum AppletsColumnsWidth {
@@ -38,7 +38,7 @@ export const getMenuItems = (handleMenuClose: () => void, navigate: NavigateFunc
     action: () => {
       handleMenuClose();
       navigate(getBuilderAppletUrl(Path.NewApplet));
-      Mixpanel.track('Build Applet click');
+      Mixpanel.track(MixpanelEventType.BuildAppletClick);
     },
     'data-testid': 'dashboard-applets-add-applet-new',
   },
@@ -48,7 +48,7 @@ export const getMenuItems = (handleMenuClose: () => void, navigate: NavigateFunc
     action: () => {
       handleMenuClose();
       navigate(page.library);
-      Mixpanel.track('Browse applet library click');
+      Mixpanel.track(MixpanelEventType.BrowseAppletLibraryClick);
     },
     'data-testid': 'dashboard-applets-add-applet-from-library',
   },

--- a/src/modules/Dashboard/features/Applets/Applets.const.tsx
+++ b/src/modules/Dashboard/features/Applets/Applets.const.tsx
@@ -38,7 +38,7 @@ export const getMenuItems = (handleMenuClose: () => void, navigate: NavigateFunc
     action: () => {
       handleMenuClose();
       navigate(getBuilderAppletUrl(Path.NewApplet));
-      Mixpanel.track(MixpanelEventType.BuildAppletClick);
+      Mixpanel.track({ action: MixpanelEventType.BuildAppletClick });
     },
     'data-testid': 'dashboard-applets-add-applet-new',
   },
@@ -48,7 +48,7 @@ export const getMenuItems = (handleMenuClose: () => void, navigate: NavigateFunc
     action: () => {
       handleMenuClose();
       navigate(page.library);
-      Mixpanel.track(MixpanelEventType.BrowseAppletLibraryClick);
+      Mixpanel.track({ action: MixpanelEventType.BrowseAppletLibraryClick });
     },
     'data-testid': 'dashboard-applets-add-applet-from-library',
   },

--- a/src/modules/Dashboard/features/Applets/AppletsTable/AppletItem/AppletItem.tsx
+++ b/src/modules/Dashboard/features/Applets/AppletsTable/AppletItem/AppletItem.tsx
@@ -114,7 +114,8 @@ export const AppletItem = ({ item, onPublish, enableShareToLibrary }: AppletItem
     });
     await fetchData();
     setPasswordPopupVisible(false);
-    Mixpanel.track(MixpanelEventType.AppletCreatedSuccessfully, {
+    Mixpanel.track({
+      action: MixpanelEventType.AppletCreatedSuccessfully,
       [MixpanelProps.AppletId]: appletId,
     });
   };
@@ -134,7 +135,8 @@ export const AppletItem = ({ item, onPublish, enableShareToLibrary }: AppletItem
     viewCalendar: () =>
       checkAppletEncryption(() => {
         navigate(APPLET_SCHEDULE);
-        Mixpanel.track(MixpanelEventType.ViewGeneralCalendarClick, {
+        Mixpanel.track({
+          action: MixpanelEventType.ViewGeneralCalendarClick,
           [MixpanelProps.AppletId]: appletId,
         });
       }),
@@ -188,7 +190,8 @@ export const AppletItem = ({ item, onPublish, enableShareToLibrary }: AppletItem
         if (item.isFolder) return;
 
         navigate(getBuilderAppletUrl(appletId));
-        Mixpanel.track(MixpanelEventType.AppletEditClick, {
+        Mixpanel.track({
+          action: MixpanelEventType.AppletEditClick,
           [MixpanelProps.AppletId]: appletId,
         });
       }),

--- a/src/modules/Dashboard/features/Applets/AppletsTable/AppletItem/AppletItem.tsx
+++ b/src/modules/Dashboard/features/Applets/AppletsTable/AppletItem/AppletItem.tsx
@@ -21,6 +21,8 @@ import {
   getDateInUserTimezone,
   getEncryptionToServer,
   Mixpanel,
+  MixpanelEventType,
+  MixpanelProps,
 } from 'shared/utils';
 import { useAppletsDnd } from 'modules/Dashboard/features/Applets/AppletsTable/AppletsTable.hooks';
 import { ShareAppletPopup } from 'modules/Dashboard/features/Applets/Popups';
@@ -112,15 +114,16 @@ export const AppletItem = ({ item, onPublish, enableShareToLibrary }: AppletItem
     });
     await fetchData();
     setPasswordPopupVisible(false);
-    Mixpanel.track('Applet Created Successfully', {
-      'Applet ID': appletId,
+    Mixpanel.track(MixpanelEventType.AppletCreatedSuccessfully, {
+      [MixpanelProps.AppletId]: appletId,
     });
   };
 
-  const checkAppletEncryption = (callback: () => void) =>
-    hasOwnerRole(workspaceRoles?.data?.[appletId]?.[0]) && !item.encryption
-      ? setPasswordPopupVisible(true)
-      : callback();
+  const checkAppletEncryption = (callback: () => void) => {
+    const itHasOwnerRole = hasOwnerRole(workspaceRoles?.data?.[appletId]?.[0]);
+
+    return itHasOwnerRole && !item.encryption ? setPasswordPopupVisible(true) : callback();
+  };
 
   const actions = {
     removeFromFolder: async () => {
@@ -131,8 +134,8 @@ export const AppletItem = ({ item, onPublish, enableShareToLibrary }: AppletItem
     viewCalendar: () =>
       checkAppletEncryption(() => {
         navigate(APPLET_SCHEDULE);
-        Mixpanel.track('View General calendar click', {
-          'Applet ID': appletId,
+        Mixpanel.track(MixpanelEventType.ViewGeneralCalendarClick, {
+          [MixpanelProps.AppletId]: appletId,
         });
       }),
     deleteAction: () =>
@@ -185,8 +188,8 @@ export const AppletItem = ({ item, onPublish, enableShareToLibrary }: AppletItem
         if (item.isFolder) return;
 
         navigate(getBuilderAppletUrl(appletId));
-        Mixpanel.track('Applet edit click', {
-          'Applet ID': appletId,
+        Mixpanel.track(MixpanelEventType.AppletEditClick, {
+          [MixpanelProps.AppletId]: appletId,
         });
       }),
   };

--- a/src/modules/Dashboard/features/Managers/Managers.tsx
+++ b/src/modules/Dashboard/features/Managers/Managers.tsx
@@ -26,6 +26,7 @@ import {
   checkIfFullAccess,
   isManagerOrOwner,
   joinWihComma,
+  MixpanelEventType,
 } from 'shared/utils';
 import { Roles, DEFAULT_ROWS_PER_PAGE } from 'shared/consts';
 import { StyledBody, StyledFlexWrap, variables } from 'shared/styles';
@@ -127,7 +128,7 @@ export const Managers = () => {
       if (appletId) {
         analyticsPayload[MixpanelProps.AppletId] = appletId;
       }
-      Mixpanel.track('Edit Team Member clicked', analyticsPayload);
+      Mixpanel.track(MixpanelEventType.EditTeamMemberClicked, analyticsPayload);
 
       setSelectedManager(user || null);
       setEditAccessPopupVisible(true);
@@ -154,7 +155,7 @@ export const Managers = () => {
     if (appletId) {
       analyticsPayload[MixpanelProps.AppletId] = appletId;
     }
-    Mixpanel.track('Add Team Member button clicked', analyticsPayload);
+    Mixpanel.track(MixpanelEventType.AddTeamMemberBtnClicked, analyticsPayload);
 
     setAddManagerPopupVisible(true);
   };

--- a/src/modules/Dashboard/features/Managers/Managers.tsx
+++ b/src/modules/Dashboard/features/Managers/Managers.tsx
@@ -20,7 +20,6 @@ import { DashboardTable, DashboardTableProps } from 'modules/Dashboard/component
 import { Manager, WorkspaceInfo } from 'modules/Dashboard/types';
 import {
   Mixpanel,
-  MixpanelPayload,
   MixpanelProps,
   checkIfCanManageParticipants,
   checkIfFullAccess,
@@ -122,13 +121,11 @@ export const Managers = () => {
       setRemoveAccessPopupVisible(true);
     },
     editTeamMemberAction: ({ context: user }: MenuActionProps<Manager>) => {
-      const analyticsPayload: MixpanelPayload = {
+      Mixpanel.track({
+        action: MixpanelEventType.EditTeamMemberClicked,
         [MixpanelProps.Via]: appletId ? 'Applet - Team' : 'Team',
-      };
-      if (appletId) {
-        analyticsPayload[MixpanelProps.AppletId] = appletId;
-      }
-      Mixpanel.track(MixpanelEventType.EditTeamMemberClicked, analyticsPayload);
+        [MixpanelProps.AppletId]: appletId,
+      });
 
       setSelectedManager(user || null);
       setEditAccessPopupVisible(true);
@@ -149,13 +146,11 @@ export const Managers = () => {
   };
 
   const handleAddManagerClick = () => {
-    const analyticsPayload: MixpanelPayload = {
+    Mixpanel.track({
+      action: MixpanelEventType.AddTeamMemberBtnClicked,
+      [MixpanelProps.AppletId]: appletId,
       [MixpanelProps.Via]: appletId ? 'Applet - Team' : 'Team',
-    };
-    if (appletId) {
-      analyticsPayload[MixpanelProps.AppletId] = appletId;
-    }
-    Mixpanel.track(MixpanelEventType.AddTeamMemberBtnClicked, analyticsPayload);
+    });
 
     setAddManagerPopupVisible(true);
   };

--- a/src/modules/Dashboard/features/Managers/Popups/AddManagerPopup/AddManagerPopup.test.tsx
+++ b/src/modules/Dashboard/features/Managers/Popups/AddManagerPopup/AddManagerPopup.test.tsx
@@ -4,7 +4,7 @@ import mockAxios from 'jest-mock-axios';
 
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
 import { mockedAppletId, mockedCurrentWorkspace } from 'shared/mock';
-import { Mixpanel, MixpanelProps, expectBanner } from 'shared/utils';
+import { Mixpanel, MixpanelProps, expectBanner, MixpanelEventType } from 'shared/utils';
 import { initialStateData } from 'redux/modules';
 import { Roles } from 'shared/consts';
 
@@ -92,7 +92,8 @@ describe('AddManagerPopup component', () => {
 
     await userEvent.click(getByText('Send Invitation'));
 
-    expect(mixpanelTrack).toBeCalledWith('Team Member account invitation form submitted', {
+    expect(mixpanelTrack).toBeCalledWith({
+      action: MixpanelEventType.TeamMemberInvitationFormSubmitted,
       [MixpanelProps.AppletId]: mockedAppletId,
       [MixpanelProps.Roles]: [mockSubmitValues.role],
     });
@@ -101,7 +102,8 @@ describe('AddManagerPopup component', () => {
       expectBanner(store, 'AddParticipantSuccessBanner');
     });
 
-    expect(mixpanelTrack).toBeCalledWith('Team Member account invitation created successfully', {
+    expect(mixpanelTrack).toBeCalledWith({
+      action: MixpanelEventType.TeamMemberInvitedSuccessfully,
       [MixpanelProps.AppletId]: mockedAppletId,
       [MixpanelProps.Roles]: [mockSubmitValues.role],
     });

--- a/src/modules/Dashboard/features/Managers/Popups/AddManagerPopup/AddManagerPopup.tsx
+++ b/src/modules/Dashboard/features/Managers/Popups/AddManagerPopup/AddManagerPopup.tsx
@@ -106,7 +106,8 @@ export const AddManagerPopup = ({
       }),
     );
 
-    Mixpanel.track(MixpanelEventType.TeamMemberInvitedSuccessfully, {
+    Mixpanel.track({
+      action: MixpanelEventType.TeamMemberInvitedSuccessfully,
       [MixpanelProps.AppletId]: appletId,
       [MixpanelProps.Roles]: [role],
     });
@@ -119,7 +120,8 @@ export const AddManagerPopup = ({
 
     const { role, participants = [], workspaceName: workspacePrefix, ...rest } = values;
 
-    Mixpanel.track(MixpanelEventType.TeamMemberInvitationFormSubmitted, {
+    Mixpanel.track({
+      action: MixpanelEventType.TeamMemberInvitationFormSubmitted,
       [MixpanelProps.AppletId]: appletId,
       [MixpanelProps.Roles]: [role],
     });

--- a/src/modules/Dashboard/features/Managers/Popups/AddManagerPopup/AddManagerPopup.tsx
+++ b/src/modules/Dashboard/features/Managers/Popups/AddManagerPopup/AddManagerPopup.tsx
@@ -7,7 +7,13 @@ import { EmptyState, Modal, Spinner } from 'shared/components';
 import { StyledErrorText, StyledModalWrapper } from 'shared/styles';
 import { useFormError } from 'modules/Dashboard/hooks';
 import { Roles } from 'shared/consts';
-import { Mixpanel, MixpanelProps, getErrorMessage, isManagerOrOwner } from 'shared/utils';
+import {
+  Mixpanel,
+  MixpanelProps,
+  getErrorMessage,
+  isManagerOrOwner,
+  MixpanelEventType,
+} from 'shared/utils';
 import { ApiLanguages, postAppletInvitationApi } from 'api';
 import { useAppDispatch } from 'redux/store';
 import { useAsync } from 'shared/hooks';
@@ -100,7 +106,7 @@ export const AddManagerPopup = ({
       }),
     );
 
-    Mixpanel.track('Team Member account invitation created successfully', {
+    Mixpanel.track(MixpanelEventType.TeamMemberInvitedSuccessfully, {
       [MixpanelProps.AppletId]: appletId,
       [MixpanelProps.Roles]: [role],
     });
@@ -113,7 +119,7 @@ export const AddManagerPopup = ({
 
     const { role, participants = [], workspaceName: workspacePrefix, ...rest } = values;
 
-    Mixpanel.track('Team Member account invitation form submitted', {
+    Mixpanel.track(MixpanelEventType.TeamMemberInvitationFormSubmitted, {
       [MixpanelProps.AppletId]: appletId,
       [MixpanelProps.Roles]: [role],
     });

--- a/src/modules/Dashboard/features/Managers/Popups/ManagersEditAccessPopup/ManagersEditAccessPopup.test.tsx
+++ b/src/modules/Dashboard/features/Managers/Popups/ManagersEditAccessPopup/ManagersEditAccessPopup.test.tsx
@@ -16,7 +16,7 @@ import {
 import { Roles } from 'shared/consts';
 import { initialStateData } from 'shared/state';
 import { page } from 'resources';
-import { Mixpanel, MixpanelProps, expectBanner } from 'shared/utils';
+import { Mixpanel, MixpanelProps, expectBanner, MixpanelEventType } from 'shared/utils';
 
 import { EditAccessPopup } from './ManagersEditAccessPopup';
 
@@ -146,7 +146,8 @@ describe('EditAccessPopup component', () => {
     const saveButton = screen.getByTestId(`${dataTestid}-access-popup-submit-button`);
     await userEvent.click(saveButton);
 
-    expect(mixpanelTrack).toBeCalledWith('Edit Team Member form submitted', {
+    expect(mixpanelTrack).toBeCalledWith({
+      action: MixpanelEventType.EditTeamMemberFormSubmitted,
       [MixpanelProps.AppletId]: mockedAppletId,
       [MixpanelProps.Roles]: user.roles,
     });
@@ -175,7 +176,8 @@ describe('EditAccessPopup component', () => {
 
     await waitFor(() => expectBanner(store, 'SaveSuccessBanner'));
 
-    expect(mixpanelTrack).toBeCalledWith('Team Member edited successfully', {
+    expect(mixpanelTrack).toBeCalledWith({
+      action: MixpanelEventType.TeamMemberEditSuccessful,
       [MixpanelProps.AppletId]: mockedAppletId,
       [MixpanelProps.Roles]: user.roles,
     });
@@ -242,7 +244,8 @@ describe('EditAccessPopup component', () => {
 
     await userEvent.click(saveButton);
 
-    expect(mixpanelTrack).toBeCalledWith('Edit Team Member form submitted', {
+    expect(mixpanelTrack).toBeCalledWith({
+      action: MixpanelEventType.EditTeamMemberFormSubmitted,
       [MixpanelProps.AppletId]: mockedAppletId,
       [MixpanelProps.Roles]: [Roles.Reviewer],
     });
@@ -271,7 +274,8 @@ describe('EditAccessPopup component', () => {
 
     await waitFor(() => expectBanner(store, 'SaveSuccessBanner'));
 
-    expect(mixpanelTrack).toBeCalledWith('Team Member edited successfully', {
+    expect(mixpanelTrack).toBeCalledWith({
+      action: MixpanelEventType.TeamMemberEditSuccessful,
       [MixpanelProps.AppletId]: mockedAppletId,
       [MixpanelProps.Roles]: [Roles.Reviewer],
     });

--- a/src/modules/Dashboard/features/Managers/Popups/ManagersEditAccessPopup/ManagersEditAccessPopup.tsx
+++ b/src/modules/Dashboard/features/Managers/Popups/ManagersEditAccessPopup/ManagersEditAccessPopup.tsx
@@ -8,7 +8,7 @@ import { Roles } from 'shared/consts';
 import { banners, workspaces } from 'redux/modules';
 import { useAsync } from 'shared/hooks/useAsync';
 import { editManagerAccessApi, removeManagerAccessApi } from 'api';
-import { Mixpanel, MixpanelProps, getErrorMessage, pluck } from 'shared/utils';
+import { Mixpanel, MixpanelProps, getErrorMessage, pluck, MixpanelEventType } from 'shared/utils';
 import { useAppDispatch } from 'redux/store';
 
 import { Applet } from './Applet';
@@ -33,7 +33,7 @@ export const EditAccessPopup = ({ onClose, popupVisible, user }: EditAccessPopup
     isLoading: isEditAccessLoading,
   } = useAsync(editManagerAccessApi, () => {
     for (const { appletId, roles } of submittedAccessesRef.current) {
-      Mixpanel.track('Team Member edited successfully', {
+      Mixpanel.track(MixpanelEventType.TeamMemberEditSuccessful, {
         [MixpanelProps.AppletId]: appletId,
         [MixpanelProps.Roles]: roles,
       });
@@ -106,7 +106,7 @@ export const EditAccessPopup = ({ onClose, popupVisible, user }: EditAccessPopup
 
       submittedAccessesRef.current = accesses;
       for (const { appletId, roles } of accesses) {
-        Mixpanel.track('Edit Team Member form submitted', {
+        Mixpanel.track(MixpanelEventType.EditTeamMemberFormSubmitted, {
           [MixpanelProps.AppletId]: appletId,
           [MixpanelProps.Roles]: roles,
         });

--- a/src/modules/Dashboard/features/Managers/Popups/ManagersEditAccessPopup/ManagersEditAccessPopup.tsx
+++ b/src/modules/Dashboard/features/Managers/Popups/ManagersEditAccessPopup/ManagersEditAccessPopup.tsx
@@ -33,7 +33,8 @@ export const EditAccessPopup = ({ onClose, popupVisible, user }: EditAccessPopup
     isLoading: isEditAccessLoading,
   } = useAsync(editManagerAccessApi, () => {
     for (const { appletId, roles } of submittedAccessesRef.current) {
-      Mixpanel.track(MixpanelEventType.TeamMemberEditSuccessful, {
+      Mixpanel.track({
+        action: MixpanelEventType.TeamMemberEditSuccessful,
         [MixpanelProps.AppletId]: appletId,
         [MixpanelProps.Roles]: roles,
       });
@@ -106,7 +107,8 @@ export const EditAccessPopup = ({ onClose, popupVisible, user }: EditAccessPopup
 
       submittedAccessesRef.current = accesses;
       for (const { appletId, roles } of accesses) {
-        Mixpanel.track(MixpanelEventType.EditTeamMemberFormSubmitted, {
+        Mixpanel.track({
+          action: MixpanelEventType.EditTeamMemberFormSubmitted,
           [MixpanelProps.AppletId]: appletId,
           [MixpanelProps.Roles]: roles,
         });

--- a/src/modules/Dashboard/features/Participant/Activities/Activities.test.tsx
+++ b/src/modules/Dashboard/features/Participant/Activities/Activities.test.tsx
@@ -40,7 +40,7 @@ import {
   targetSubjectDropdownTestId,
   toggleSelfReportCheckbox,
 } from 'modules/Dashboard/components/TakeNowModal/TakeNowModal.test-utils';
-import { MixpanelProps } from 'shared/utils';
+import { MixpanelEventType, MixpanelProps } from 'shared/utils';
 
 import { Activities } from './Activities';
 
@@ -545,20 +545,23 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
 
       await openTakeNowModal(testId);
 
-      expectMixpanelTrack('Take Now click', {
+      expectMixpanelTrack({
+        action: MixpanelEventType.TakeNowClick,
         [MixpanelProps.Via]: 'Applet - Participants - Activities',
       });
 
       await selectParticipant(testId, 'source', mockedOwnerRespondent.details[0].subjectId);
 
-      expectMixpanelTrack('"Who will be providing responses" dropdown opened');
-      expectMixpanelTrack('"Who will be providing responses" selection changed', {
+      expectMixpanelTrack({ action: MixpanelEventType.ProvidingResponsesDropdownOpened });
+      expectMixpanelTrack({
+        action: MixpanelEventType.ProvidingResponsesSelectionChanged,
         [MixpanelProps.SourceAccountType]: 'Team',
       });
 
       await toggleSelfReportCheckbox(testId);
 
-      expectMixpanelTrack('Own responses checkbox toggled', {
+      expectMixpanelTrack({
+        action: MixpanelEventType.OwnResponsesCheckboxToggled,
         [MixpanelProps.IsSelfReporting]: false,
       });
 
@@ -572,7 +575,7 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
 
       fireEvent.mouseDown(inputElement);
 
-      expectMixpanelTrack('"Who will be inputting the responses" dropdown opened');
+      expectMixpanelTrack({ action: MixpanelEventType.InputtingResponsesDropdownOpened });
 
       const options = within(getByRole('listbox')).queryAllByRole('option');
 
@@ -764,8 +767,9 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
 
         selectParticipant(testId, 'source', mockedRespondent.details[0].subjectId);
 
-        expectMixpanelTrack('"Who will be providing responses" dropdown opened');
-        expectMixpanelTrack('"Who will be providing responses" selection changed', {
+        expectMixpanelTrack({ action: MixpanelEventType.ProvidingResponsesDropdownOpened });
+        expectMixpanelTrack({
+          action: MixpanelEventType.ProvidingResponsesSelectionChanged,
           [MixpanelProps.SourceAccountType]: 'Full',
         });
 
@@ -850,14 +854,16 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
 
         await selectParticipant(testId, 'source', mockedOwnerRespondent.details[0].subjectId);
 
-        expectMixpanelTrack('"Who will be providing responses" dropdown opened');
-        expectMixpanelTrack('"Who will be providing responses" selection changed', {
+        expectMixpanelTrack({ action: MixpanelEventType.ProvidingResponsesDropdownOpened });
+        expectMixpanelTrack({
+          action: MixpanelEventType.ProvidingResponsesSelectionChanged,
           [MixpanelProps.SourceAccountType]: 'Team',
         });
 
         await toggleSelfReportCheckbox(testId);
 
-        expectMixpanelTrack('Own responses checkbox toggled', {
+        expectMixpanelTrack({
+          action: MixpanelEventType.OwnResponsesCheckboxToggled,
           [MixpanelProps.IsSelfReporting]: false,
         });
 
@@ -871,7 +877,7 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
 
         fireEvent.mouseDown(inputElement);
 
-        expectMixpanelTrack('"Who will be inputting the responses" dropdown opened');
+        expectMixpanelTrack({ action: MixpanelEventType.InputtingResponsesDropdownOpened });
 
         const options = within(getByRole('listbox')).queryAllByRole('option');
 

--- a/src/modules/Dashboard/features/Participants/Participants.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.tsx
@@ -86,7 +86,8 @@ export const Participants = () => {
           return params;
         }
 
-        Mixpanel.track(MixpanelEventType.AddParticipantBtnClicked, {
+        Mixpanel.track({
+          action: MixpanelEventType.AddParticipantBtnClicked,
           [MixpanelProps.AppletId]: appletId,
           [MixpanelProps.Via]: 'Applet - Participants',
         });
@@ -180,7 +181,8 @@ export const Participants = () => {
     nickname,
     tag,
   }: HandleUpgradeAccount) => {
-    Mixpanel.track(MixpanelEventType.UpgradeToFullAccountClicked, {
+    Mixpanel.track({
+      action: MixpanelEventType.UpgradeToFullAccountClicked,
       [MixpanelProps.AppletId]: appletId,
       [MixpanelProps.Via]: 'Applet - Participants',
     });
@@ -199,10 +201,10 @@ export const Participants = () => {
       const { respondentId, respondentOrSubjectId } = context || {};
       if (!respondentOrSubjectId) return;
 
-      const event = respondentId
-        ? MixpanelEventType.EditFullAccountClicked
-        : MixpanelEventType.EditLimitedAccountClicked;
-      Mixpanel.track(event, {
+      Mixpanel.track({
+        action: respondentId
+          ? MixpanelEventType.EditFullAccountClicked
+          : MixpanelEventType.EditLimitedAccountClicked,
         [MixpanelProps.AppletId]: appletId,
         [MixpanelProps.Via]: 'Applet - Participants',
       });
@@ -228,7 +230,7 @@ export const Participants = () => {
       setRespondentKey(respondentOrSubjectId);
       handleSetDataForAppletPage({ respondentOrSubjectId, key: FilteredAppletsKey.Viewable });
       setDataExportPopupVisible(true);
-      Mixpanel.track(MixpanelEventType.ExportDataClick);
+      Mixpanel.track({ action: MixpanelEventType.ExportDataClick });
     },
     removeParticipant: ({ context }: MenuActionProps<ParticipantActionProps>) => {
       const { respondentOrSubjectId } = context || {};

--- a/src/modules/Dashboard/features/Participants/Participants.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.tsx
@@ -21,6 +21,7 @@ import {
   joinWihComma,
   Mixpanel,
   MixpanelProps,
+  MixpanelEventType,
 } from 'shared/utils';
 import { DEFAULT_ROWS_PER_PAGE, Roles } from 'shared/consts';
 import { StyledBody, StyledFlexWrap } from 'shared/styles';
@@ -85,7 +86,7 @@ export const Participants = () => {
           return params;
         }
 
-        Mixpanel.track('Add Participant button clicked', {
+        Mixpanel.track(MixpanelEventType.AddParticipantBtnClicked, {
           [MixpanelProps.AppletId]: appletId,
           [MixpanelProps.Via]: 'Applet - Participants',
         });
@@ -179,7 +180,7 @@ export const Participants = () => {
     nickname,
     tag,
   }: HandleUpgradeAccount) => {
-    Mixpanel.track('Upgrade to Full Account clicked', {
+    Mixpanel.track(MixpanelEventType.UpgradeToFullAccountClicked, {
       [MixpanelProps.AppletId]: appletId,
       [MixpanelProps.Via]: 'Applet - Participants',
     });
@@ -198,7 +199,9 @@ export const Participants = () => {
       const { respondentId, respondentOrSubjectId } = context || {};
       if (!respondentOrSubjectId) return;
 
-      const event = respondentId ? 'Edit Full Account clicked' : 'Edit Limited Account clicked';
+      const event = respondentId
+        ? MixpanelEventType.EditFullAccountClicked
+        : MixpanelEventType.EditLimitedAccountClicked;
       Mixpanel.track(event, {
         [MixpanelProps.AppletId]: appletId,
         [MixpanelProps.Via]: 'Applet - Participants',
@@ -225,7 +228,7 @@ export const Participants = () => {
       setRespondentKey(respondentOrSubjectId);
       handleSetDataForAppletPage({ respondentOrSubjectId, key: FilteredAppletsKey.Viewable });
       setDataExportPopupVisible(true);
-      Mixpanel.track('Export Data click');
+      Mixpanel.track(MixpanelEventType.ExportDataClick);
     },
     removeParticipant: ({ context }: MenuActionProps<ParticipantActionProps>) => {
       const { respondentOrSubjectId } = context || {};

--- a/src/modules/Dashboard/features/Participants/Participants.utils.test.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.utils.test.tsx
@@ -212,7 +212,7 @@ describe('Participants utils tests', () => {
         meta: {
           subject_id: 'ba1f11c8-df12-43f2-bc01-2c3df232fb48',
         },
-        tag: `${commonGetActionsProps.tag}`,
+        tag: commonGetActionsProps.tag as ParticipantTag,
         title: null,
       };
       const actions = getParticipantActions({
@@ -289,7 +289,7 @@ describe('Participants utils tests', () => {
         meta: {
           subject_id: 'ba1f11c8-df12-43f2-bc01-2c3df232fb48',
         },
-        tag: `${commonGetActionsProps.tag}`,
+        tag: commonGetActionsProps.tag as ParticipantTag,
         title: null,
       };
       const actions = getParticipantActions({

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataHeader/RespondentDataHeader.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataHeader/RespondentDataHeader.tsx
@@ -15,7 +15,7 @@ import {
   theme,
   variables,
 } from 'shared/styles';
-import { Mixpanel, checkIfFullAccess, getIsWebSupported } from 'shared/utils';
+import { Mixpanel, checkIfFullAccess, getIsWebSupported, MixpanelEventType } from 'shared/utils';
 import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 import { useTakeNowModal } from 'modules/Dashboard/components/TakeNowModal/TakeNowModal';
 import { workspaces } from 'redux/modules';
@@ -90,7 +90,7 @@ export const RespondentDataHeader = ({
 
   const handleOpenExport = () => {
     setIsExportOpen(true);
-    Mixpanel.track('Export Data click');
+    Mixpanel.track(MixpanelEventType.ExportDataClick);
   };
 
   const handleCloseExport = () => {

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataHeader/RespondentDataHeader.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataHeader/RespondentDataHeader.tsx
@@ -90,7 +90,7 @@ export const RespondentDataHeader = ({
 
   const handleOpenExport = () => {
     setIsExportOpen(true);
-    Mixpanel.track(MixpanelEventType.ExportDataClick);
+    Mixpanel.track({ action: MixpanelEventType.ExportDataClick });
   };
 
   const handleCloseExport = () => {

--- a/src/modules/Dashboard/features/Respondents/Popups/DataExportPopup/DataExportPopup_old.tsx
+++ b/src/modules/Dashboard/features/Respondents/Popups/DataExportPopup/DataExportPopup_old.tsx
@@ -123,7 +123,8 @@ export const DataExportPopup = ({
         }
 
         handlePopupClose();
-        Mixpanel.track(MixpanelEventType.ExportDataSuccessful, {
+        Mixpanel.track({
+          action: MixpanelEventType.ExportDataSuccessful,
           [MixpanelProps.AppletId]: appletId,
         });
       } catch (e) {

--- a/src/modules/Dashboard/features/Respondents/Popups/DataExportPopup/DataExportPopup_old.tsx
+++ b/src/modules/Dashboard/features/Respondents/Popups/DataExportPopup/DataExportPopup_old.tsx
@@ -13,7 +13,13 @@ import {
   theme,
   variables,
 } from 'shared/styles';
-import { exportEncryptedDataSucceed, Mixpanel, sendLogFile } from 'shared/utils';
+import {
+  exportEncryptedDataSucceed,
+  Mixpanel,
+  sendLogFile,
+  MixpanelEventType,
+  MixpanelProps,
+} from 'shared/utils';
 import { useSetupEnterAppletPassword } from 'shared/hooks';
 import { getExportDataApi } from 'api';
 import { useDecryptedActivityData } from 'modules/Dashboard/hooks';
@@ -117,8 +123,8 @@ export const DataExportPopup = ({
         }
 
         handlePopupClose();
-        Mixpanel.track('Export Data Successful', {
-          'Applet ID': appletId,
+        Mixpanel.track(MixpanelEventType.ExportDataSuccessful, {
+          [MixpanelProps.AppletId]: appletId,
         });
       } catch (e) {
         const error = e as TypeError;

--- a/src/modules/Dashboard/features/Respondents/Popups/DataExportPopup/DataExportWorkersManager/DataExportWorkersManager.ts
+++ b/src/modules/Dashboard/features/Respondents/Popups/DataExportPopup/DataExportWorkersManager/DataExportWorkersManager.ts
@@ -52,7 +52,8 @@ export class DataExportWorkersManager {
     if (allPagesProcessed && allWorkersIdle) {
       this.setDataIsExporting(false);
       this.handleExportPopupClose();
-      Mixpanel.track(MixpanelEventType.ExportDataSuccessful, {
+      Mixpanel.track({
+        action: MixpanelEventType.ExportDataSuccessful,
         [MixpanelProps.AppletId]: this.appletId,
       });
     }

--- a/src/modules/Dashboard/features/Respondents/Popups/DataExportPopup/DataExportWorkersManager/DataExportWorkersManager.ts
+++ b/src/modules/Dashboard/features/Respondents/Popups/DataExportPopup/DataExportWorkersManager/DataExportWorkersManager.ts
@@ -5,6 +5,7 @@ import { EncryptionParsed } from 'shared/utils/encryption';
 import { ExportDataFilters, exportDecryptedDataSucceed } from 'shared/utils/exportData';
 import { ItemResponseType } from 'shared/consts';
 import { Mixpanel } from 'shared/utils/mixpanel/mixpanel';
+import { MixpanelEventType, MixpanelProps } from 'shared/utils/mixpanel/mixpanel.types';
 
 import DecryptionWorker from '../DataExportWorker/DataExportWorker.worker';
 import { IdleWorker } from '../DataExportPopup.types';
@@ -51,7 +52,9 @@ export class DataExportWorkersManager {
     if (allPagesProcessed && allWorkersIdle) {
       this.setDataIsExporting(false);
       this.handleExportPopupClose();
-      Mixpanel.track('Export Data Successful', { 'Applet ID': this.appletId });
+      Mixpanel.track(MixpanelEventType.ExportDataSuccessful, {
+        [MixpanelProps.AppletId]: this.appletId,
+      });
     }
   };
 

--- a/src/modules/Dashboard/features/Respondents/Popups/EditRespondentPopup/EditRespondentPopup.test.tsx
+++ b/src/modules/Dashboard/features/Respondents/Popups/EditRespondentPopup/EditRespondentPopup.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import mockAxios from 'jest-mock-axios';
 
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
-import { Mixpanel, MixpanelProps } from 'shared/utils/mixpanel';
+import { Mixpanel, MixpanelEventType, MixpanelProps } from 'shared/utils/mixpanel';
 import { mockedAppletId } from 'shared/mock';
 import { expectBanner } from 'shared/utils';
 import { EditSubjectResponse } from 'api';
@@ -73,14 +73,16 @@ describe('EditRespondentPopup component tests', () => {
     const submitButton = screen.getByTestId('dashboard-respondents-edit-popup-submit-button');
     await userEvent.click(submitButton);
 
-    expect(mixpanelTrack).toBeCalledWith('Edit Limited Account form submitted', {
+    expect(mixpanelTrack).toBeCalledWith({
+      action: MixpanelEventType.EditLimitedAccountFormSubmitted,
       [MixpanelProps.AppletId]: mockedAppletId,
       [MixpanelProps.Tag]: 'Child',
     });
 
     await waitFor(() => expectBanner(store, 'SaveSuccessBanner'));
 
-    expect(mixpanelTrack).toBeCalledWith('Limited Account edited successfully', {
+    expect(mixpanelTrack).toBeCalledWith({
+      action: MixpanelEventType.LimitedAccountEditedSuccessfully,
       [MixpanelProps.AppletId]: mockedAppletId,
       [MixpanelProps.Tag]: 'Child',
     });
@@ -114,14 +116,16 @@ describe('EditRespondentPopup component tests', () => {
     const submitButton = screen.getByTestId('dashboard-respondents-edit-popup-submit-button');
     await userEvent.click(submitButton);
 
-    expect(mixpanelTrack).toBeCalledWith('Edit Full Account form submitted', {
+    expect(mixpanelTrack).toBeCalledWith({
+      action: MixpanelEventType.EditFullAccountFormSubmitted,
       [MixpanelProps.AppletId]: mockedAppletId,
       [MixpanelProps.Tag]: 'Child',
     });
 
     await waitFor(() => expectBanner(store, 'SaveSuccessBanner'));
 
-    expect(mixpanelTrack).toBeCalledWith('Full Account edited successfully', {
+    expect(mixpanelTrack).toBeCalledWith({
+      action: MixpanelEventType.FullAccountEditedSuccessfully,
       [MixpanelProps.AppletId]: mockedAppletId,
       [MixpanelProps.Tag]: 'Child',
     });

--- a/src/modules/Dashboard/features/Respondents/Popups/EditRespondentPopup/EditRespondentPopup.tsx
+++ b/src/modules/Dashboard/features/Respondents/Popups/EditRespondentPopup/EditRespondentPopup.tsx
@@ -55,10 +55,10 @@ export const EditRespondentPopup = ({
     editSubjectApi,
     ({ data }) => {
       const { userId, appletId, tag } = data?.result ?? {};
-      const event = userId
-        ? MixpanelEventType.FullAccountEditedSuccessfully
-        : MixpanelEventType.LimitedAccountEditedSuccessfully;
-      Mixpanel.track(event, {
+      Mixpanel.track({
+        action: userId
+          ? MixpanelEventType.FullAccountEditedSuccessfully
+          : MixpanelEventType.LimitedAccountEditedSuccessfully,
         [MixpanelProps.AppletId]: appletId,
         [MixpanelProps.Tag]: tag || null, // Normalize empty string tag to null
       });
@@ -78,10 +78,10 @@ export const EditRespondentPopup = ({
     const { secretUserId, nickname, tag } = getValues();
     const { appletId, respondentId, subjectId } = chosenAppletData;
 
-    const event = respondentId
-      ? MixpanelEventType.EditFullAccountFormSubmitted
-      : MixpanelEventType.EditLimitedAccountFormSubmitted;
-    Mixpanel.track(event, {
+    Mixpanel.track({
+      action: respondentId
+        ? MixpanelEventType.EditFullAccountFormSubmitted
+        : MixpanelEventType.EditLimitedAccountFormSubmitted,
       [MixpanelProps.AppletId]: appletId,
       [MixpanelProps.Tag]: tag || null, // Normalize empty string tag to null
     });

--- a/src/modules/Dashboard/features/Respondents/Popups/EditRespondentPopup/EditRespondentPopup.tsx
+++ b/src/modules/Dashboard/features/Respondents/Popups/EditRespondentPopup/EditRespondentPopup.tsx
@@ -10,7 +10,13 @@ import { StyledErrorText, StyledModalWrapper } from 'shared/styles';
 import { InputController, SelectController } from 'shared/components/FormComponents';
 import { useAsync } from 'shared/hooks/useAsync';
 import { editSubjectApi } from 'api';
-import { MixpanelProps, Mixpanel, falseReturnFunc, getErrorMessage } from 'shared/utils';
+import {
+  MixpanelProps,
+  Mixpanel,
+  falseReturnFunc,
+  getErrorMessage,
+  MixpanelEventType,
+} from 'shared/utils';
 import { useAppDispatch } from 'redux/store';
 import { banners } from 'redux/modules';
 
@@ -50,8 +56,8 @@ export const EditRespondentPopup = ({
     ({ data }) => {
       const { userId, appletId, tag } = data?.result ?? {};
       const event = userId
-        ? 'Full Account edited successfully'
-        : 'Limited Account edited successfully';
+        ? MixpanelEventType.FullAccountEditedSuccessfully
+        : MixpanelEventType.LimitedAccountEditedSuccessfully;
       Mixpanel.track(event, {
         [MixpanelProps.AppletId]: appletId,
         [MixpanelProps.Tag]: tag || null, // Normalize empty string tag to null
@@ -73,8 +79,8 @@ export const EditRespondentPopup = ({
     const { appletId, respondentId, subjectId } = chosenAppletData;
 
     const event = respondentId
-      ? 'Edit Full Account form submitted'
-      : 'Edit Limited Account form submitted';
+      ? MixpanelEventType.EditFullAccountFormSubmitted
+      : MixpanelEventType.EditLimitedAccountFormSubmitted;
     Mixpanel.track(event, {
       [MixpanelProps.AppletId]: appletId,
       [MixpanelProps.Tag]: tag || null, // Normalize empty string tag to null

--- a/src/modules/Dashboard/features/Respondents/Popups/ScheduleSetupPopup/ScheduleSetupPopup.tsx
+++ b/src/modules/Dashboard/features/Respondents/Popups/ScheduleSetupPopup/ScheduleSetupPopup.tsx
@@ -49,7 +49,8 @@ export const ScheduleSetupPopup = ({
 
     setPopupVisible(false);
     navigate(generatePath(page.appletParticipantSchedule, { appletId: chosenAppletId, subjectId }));
-    Mixpanel.track(MixpanelEventType.ViewIndividualCalendarClick, {
+    Mixpanel.track({
+      action: MixpanelEventType.ViewIndividualCalendarClick,
       [MixpanelProps.AppletId]: appletId,
     });
   }, [

--- a/src/modules/Dashboard/features/Respondents/Popups/ScheduleSetupPopup/ScheduleSetupPopup.tsx
+++ b/src/modules/Dashboard/features/Respondents/Popups/ScheduleSetupPopup/ScheduleSetupPopup.tsx
@@ -1,12 +1,11 @@
 import { useCallback, useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { generatePath, useNavigate, useParams } from 'react-router-dom';
-import { Trans } from 'react-i18next';
 
 import { Modal } from 'shared/components';
 import { theme, StyledModalWrapper, StyledBodyLarge, variables } from 'shared/styles';
 import { page } from 'resources';
-import { Mixpanel, getErrorMessage } from 'shared/utils';
+import { Mixpanel, getErrorMessage, MixpanelEventType, MixpanelProps } from 'shared/utils';
 import { useAsync } from 'shared/hooks/useAsync';
 import { createIndividualEventsApi } from 'api';
 
@@ -50,8 +49,8 @@ export const ScheduleSetupPopup = ({
 
     setPopupVisible(false);
     navigate(generatePath(page.appletParticipantSchedule, { appletId: chosenAppletId, subjectId }));
-    Mixpanel.track('View Individual calendar click', {
-      'Applet ID': appletId,
+    Mixpanel.track(MixpanelEventType.ViewIndividualCalendarClick, {
+      [MixpanelProps.AppletId]: appletId,
     });
   }, [
     chosenAppletId,

--- a/src/modules/Dashboard/features/Respondents/Popups/SendInvitationPopup/SendInvitationPopup.tsx
+++ b/src/modules/Dashboard/features/Respondents/Popups/SendInvitationPopup/SendInvitationPopup.tsx
@@ -5,7 +5,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 
 import { Modal, Spinner, SpinnerUiType } from 'shared/components';
 import { StyledBodyLarge, StyledModalWrapper, theme, variables } from 'shared/styles';
-import { getErrorMessage, Mixpanel } from 'shared/utils';
+import { getErrorMessage, Mixpanel, MixpanelEventType } from 'shared/utils';
 import { useAsync } from 'shared/hooks/useAsync';
 import { postSubjectInvitationApi } from 'api';
 import { InputController } from 'shared/components/FormComponents';
@@ -45,7 +45,7 @@ export const SendInvitationPopup = ({
 
   const submitForm = () => {
     if (!appletId || !subjectId) return;
-    Mixpanel.track('Subject Invitation click');
+    Mixpanel.track(MixpanelEventType.SubjectInvitationClick);
     setHasCommonError(false);
     execute({ appletId, subjectId, email: getValues('email') });
   };

--- a/src/modules/Dashboard/features/Respondents/Popups/SendInvitationPopup/SendInvitationPopup.tsx
+++ b/src/modules/Dashboard/features/Respondents/Popups/SendInvitationPopup/SendInvitationPopup.tsx
@@ -45,7 +45,7 @@ export const SendInvitationPopup = ({
 
   const submitForm = () => {
     if (!appletId || !subjectId) return;
-    Mixpanel.track(MixpanelEventType.SubjectInvitationClick);
+    Mixpanel.track({ action: MixpanelEventType.SubjectInvitationClick });
     setHasCommonError(false);
     execute({ appletId, subjectId, email: getValues('email') });
   };

--- a/src/modules/Dashboard/features/Respondents/Respondents.tsx
+++ b/src/modules/Dashboard/features/Respondents/Respondents.tsx
@@ -191,7 +191,8 @@ export const Respondents = () => {
       setRespondentKey(respondentOrSubjectId);
       handleSetDataForAppletPage({ respondentOrSubjectId, key: FilteredAppletsKey.Viewable });
       setDataExportPopupVisible(true);
-      Mixpanel.track(MixpanelEventType.ExportDataClick, {
+      Mixpanel.track({
+        action: MixpanelEventType.ExportDataClick,
         [MixpanelProps.AppletId]: appletId,
       });
     },

--- a/src/modules/Dashboard/features/Respondents/Respondents.tsx
+++ b/src/modules/Dashboard/features/Respondents/Respondents.tsx
@@ -30,6 +30,8 @@ import {
   isManagerOrOwner,
   joinWihComma,
   Mixpanel,
+  MixpanelEventType,
+  MixpanelProps,
 } from 'shared/utils';
 import { DEFAULT_ROWS_PER_PAGE, Roles } from 'shared/consts';
 import { StyledBody } from 'shared/styles';
@@ -189,8 +191,8 @@ export const Respondents = () => {
       setRespondentKey(respondentOrSubjectId);
       handleSetDataForAppletPage({ respondentOrSubjectId, key: FilteredAppletsKey.Viewable });
       setDataExportPopupVisible(true);
-      Mixpanel.track('Export Data click', {
-        'Applet ID': appletId,
+      Mixpanel.track(MixpanelEventType.ExportDataClick, {
+        [MixpanelProps.AppletId]: appletId,
       });
     },
     viewDataAction: ({ context }: MenuActionProps<RespondentActionProps>) => {

--- a/src/modules/Dashboard/pages/Applet/Applet.hooks.tsx
+++ b/src/modules/Dashboard/pages/Applet/Applet.hooks.tsx
@@ -43,7 +43,7 @@ export const useMultiInformantAppletTabs = () => {
       id: 'applet-schedule',
       icon: <Svg id="schedule-outlined" />,
       activeIcon: <Svg id="schedule-outlined" />,
-      onClick: () => Mixpanel.track(MixpanelEventType.ViewGeneralCalendarClick),
+      onClick: () => Mixpanel.track({ action: MixpanelEventType.ViewGeneralCalendarClick }),
       path: generatePath(page.appletSchedule, {
         appletId,
       }),

--- a/src/modules/Dashboard/pages/Applet/Applet.hooks.tsx
+++ b/src/modules/Dashboard/pages/Applet/Applet.hooks.tsx
@@ -2,7 +2,7 @@ import { generatePath, useParams } from 'react-router-dom';
 
 import { Svg } from 'shared/components/Svg';
 import { page } from 'resources';
-import { Mixpanel } from 'shared/utils';
+import { Mixpanel, MixpanelEventType } from 'shared/utils';
 
 export const useMultiInformantAppletTabs = () => {
   const { appletId } = useParams();
@@ -43,7 +43,7 @@ export const useMultiInformantAppletTabs = () => {
       id: 'applet-schedule',
       icon: <Svg id="schedule-outlined" />,
       activeIcon: <Svg id="schedule-outlined" />,
-      onClick: () => Mixpanel.track('View General calendar click'),
+      onClick: () => Mixpanel.track(MixpanelEventType.ViewGeneralCalendarClick),
       path: generatePath(page.appletSchedule, {
         appletId,
       }),

--- a/src/modules/Library/features/Applet/Applet.tsx
+++ b/src/modules/Library/features/Applet/Applet.tsx
@@ -92,7 +92,8 @@ export const Applet = ({
       dispatch(library.actions.setAppletsFromStorage(updatedAppletsData));
     }
 
-    Mixpanel.track(MixpanelEventType.AddToBasketClick, {
+    Mixpanel.track({
+      action: MixpanelEventType.AddToBasketClick,
       [MixpanelProps.AppletId]: id,
     });
   };

--- a/src/modules/Library/features/Applet/Applet.tsx
+++ b/src/modules/Library/features/Applet/Applet.tsx
@@ -22,6 +22,8 @@ import {
   getHighlightedText,
   Mixpanel,
   toggleBooleanState,
+  MixpanelEventType,
+  MixpanelProps,
 } from 'shared/utils';
 import { page } from 'resources';
 import { useAppDispatch } from 'redux/store';
@@ -90,8 +92,8 @@ export const Applet = ({
       dispatch(library.actions.setAppletsFromStorage(updatedAppletsData));
     }
 
-    Mixpanel.track('Add to Basket click', {
-      'Applet ID': id,
+    Mixpanel.track(MixpanelEventType.AddToBasketClick, {
+      [MixpanelProps.AppletId]: id,
     });
   };
 

--- a/src/modules/Library/features/AppletDetails/AppletDetails.tsx
+++ b/src/modules/Library/features/AppletDetails/AppletDetails.tsx
@@ -9,7 +9,7 @@ import { getPublishedAppletApi } from 'modules/Library/api';
 import { Header, RightButtonType } from 'modules/Library/components';
 import { useAppletsFromCart, useReturnToLibraryPath } from 'modules/Library/hooks';
 import { library } from 'modules/Library/state';
-import { Mixpanel } from 'shared/utils/mixpanel';
+import { Mixpanel, MixpanelEventType, MixpanelProps } from 'shared/utils/mixpanel';
 
 import { Applet, AppletUiType } from '../Applet';
 
@@ -30,8 +30,8 @@ export const AppletDetails = () => {
 
   const handleNavigateToLibraryCart = () => {
     navigate(page.libraryCart);
-    Mixpanel.track('Go to Basket click', {
-      'Applet ID': appletId,
+    Mixpanel.track(MixpanelEventType.GoToBasketClick, {
+      [MixpanelProps.AppletId]: appletId,
     });
   };
 

--- a/src/modules/Library/features/AppletDetails/AppletDetails.tsx
+++ b/src/modules/Library/features/AppletDetails/AppletDetails.tsx
@@ -30,7 +30,8 @@ export const AppletDetails = () => {
 
   const handleNavigateToLibraryCart = () => {
     navigate(page.libraryCart);
-    Mixpanel.track(MixpanelEventType.GoToBasketClick, {
+    Mixpanel.track({
+      action: MixpanelEventType.GoToBasketClick,
       [MixpanelProps.AppletId]: appletId,
     });
   };

--- a/src/modules/Library/features/AppletsCatalog/AppletsCatalog.tsx
+++ b/src/modules/Library/features/AppletsCatalog/AppletsCatalog.tsx
@@ -61,7 +61,7 @@ export const AppletsCatalog = () => {
 
   const handleNavigateToLibraryCart = () => {
     navigate(page.libraryCart);
-    Mixpanel.track(MixpanelEventType.GoToBasketClick);
+    Mixpanel.track({ action: MixpanelEventType.GoToBasketClick });
   };
 
   useEffect(() => {

--- a/src/modules/Library/features/AppletsCatalog/AppletsCatalog.tsx
+++ b/src/modules/Library/features/AppletsCatalog/AppletsCatalog.tsx
@@ -14,7 +14,7 @@ import {
   StyledAppletContainer,
   StyledAppletList,
 } from 'shared/styles';
-import { Mixpanel } from 'shared/utils/mixpanel';
+import { Mixpanel, MixpanelEventType } from 'shared/utils/mixpanel';
 import { Header, RightButtonType } from 'modules/Library/components';
 import { useAppletsFromCart, useReturnToLibraryPath } from 'modules/Library/hooks';
 
@@ -61,7 +61,7 @@ export const AppletsCatalog = () => {
 
   const handleNavigateToLibraryCart = () => {
     navigate(page.libraryCart);
-    Mixpanel.track('Go to Basket click');
+    Mixpanel.track(MixpanelEventType.GoToBasketClick);
   };
 
   useEffect(() => {

--- a/src/modules/Library/features/Cart/Cart.tsx
+++ b/src/modules/Library/features/Cart/Cart.tsx
@@ -45,7 +45,7 @@ export const Cart = () => {
   const dataTestid = 'library-cart';
 
   const handleAddToBuilder = async () => {
-    Mixpanel.track(MixpanelEventType.AddToAppletBuilderClick);
+    Mixpanel.track({ action: MixpanelEventType.AddToAppletBuilderClick });
     if (!isAuthorized) {
       return setAuthPopupVisible(true);
     }

--- a/src/modules/Library/features/Cart/Cart.tsx
+++ b/src/modules/Library/features/Cart/Cart.tsx
@@ -19,7 +19,7 @@ import {
   useReturnToLibraryPath,
   useWorkspaceList,
 } from 'modules/Library/hooks';
-import { getDictionaryText, Mixpanel, Path } from 'shared/utils';
+import { getDictionaryText, Mixpanel, Path, MixpanelEventType } from 'shared/utils';
 
 import { Applet, AppletUiType } from '../Applet';
 import { AddToBuilderPopup, AuthPopup } from '../Popups';
@@ -45,7 +45,7 @@ export const Cart = () => {
   const dataTestid = 'library-cart';
 
   const handleAddToBuilder = async () => {
-    Mixpanel.track('Add to applet builder click');
+    Mixpanel.track(MixpanelEventType.AddToAppletBuilderClick);
     if (!isAuthorized) {
       return setAuthPopupVisible(true);
     }

--- a/src/shared/components/NavigationMenu/Actions/Actions.tsx
+++ b/src/shared/components/NavigationMenu/Actions/Actions.tsx
@@ -6,7 +6,7 @@ import { Svg } from 'shared/components/Svg';
 import { ExportDataSetting } from 'shared/features/AppletSettings/ExportDataSetting';
 import { useCheckIfNewApplet } from 'shared/hooks';
 import { StyledFlexAllCenter } from 'shared/styles/styledComponents/Flex';
-import { Mixpanel, isManagerOrOwner } from 'shared/utils';
+import { Mixpanel, isManagerOrOwner, MixpanelEventType, MixpanelProps } from 'shared/utils';
 import { workspaces, applet } from 'redux/modules';
 
 import { StyledSettingsGroup, StyledSettings, StyledSetting, StyledTitle } from './Actions.styles';
@@ -32,8 +32,8 @@ export const Actions = ({ isCompact }: ActionsProps) => {
           <StyledSetting
             onClick={() => {
               setIsExportOpen(true);
-              Mixpanel.track('Export Data click', {
-                'Applet ID': appletData?.id ?? appletId,
+              Mixpanel.track(MixpanelEventType.ExportDataClick, {
+                [MixpanelProps.AppletId]: appletData?.id ?? appletId,
               });
             }}
             isCompact={isCompact}

--- a/src/shared/components/NavigationMenu/Actions/Actions.tsx
+++ b/src/shared/components/NavigationMenu/Actions/Actions.tsx
@@ -32,7 +32,8 @@ export const Actions = ({ isCompact }: ActionsProps) => {
           <StyledSetting
             onClick={() => {
               setIsExportOpen(true);
-              Mixpanel.track(MixpanelEventType.ExportDataClick, {
+              Mixpanel.track({
+                action: MixpanelEventType.ExportDataClick,
                 [MixpanelProps.AppletId]: appletData?.id ?? appletId,
               });
             }}

--- a/src/shared/components/Password/EnterAppletPassword/EnterAppletPassword.tsx
+++ b/src/shared/components/Password/EnterAppletPassword/EnterAppletPassword.tsx
@@ -47,7 +47,8 @@ export const EnterAppletPassword = forwardRef<AppletPasswordRef, EnterAppletPass
           setAppletPrivateKey(appletId, Array.from(encryptionInfoGenerated.getPrivateKey()));
         submitCallback();
 
-        Mixpanel.track(MixpanelEventType.PasswordAddedSuccessfully, {
+        Mixpanel.track({
+          action: MixpanelEventType.PasswordAddedSuccessfully,
           [MixpanelProps.AppletId]: appletId,
         });
       } else {

--- a/src/shared/components/Password/EnterAppletPassword/EnterAppletPassword.tsx
+++ b/src/shared/components/Password/EnterAppletPassword/EnterAppletPassword.tsx
@@ -10,7 +10,7 @@ import { getAppletEncryptionInfo, getParsedEncryptionFromServer } from 'shared/u
 import { toggleBooleanState } from 'shared/utils/toggleBooleanState';
 import { Svg } from 'shared/components/Svg';
 import { useEncryptionStorage } from 'shared/hooks/useEncryptionStorage';
-import { Mixpanel } from 'shared/utils/mixpanel';
+import { Mixpanel, MixpanelEventType, MixpanelProps } from 'shared/utils/mixpanel';
 
 import { StyledController } from '../Password.styles';
 import { AppletPasswordRef } from '../Password.types';
@@ -47,8 +47,8 @@ export const EnterAppletPassword = forwardRef<AppletPasswordRef, EnterAppletPass
           setAppletPrivateKey(appletId, Array.from(encryptionInfoGenerated.getPrivateKey()));
         submitCallback();
 
-        Mixpanel.track('Password added successfully', {
-          'Applet ID': appletId,
+        Mixpanel.track(MixpanelEventType.PasswordAddedSuccessfully, {
+          [MixpanelProps.AppletId]: appletId,
         });
       } else {
         setError('appletPassword', { message: t('incorrectAppletPassword') });

--- a/src/shared/features/AppletSettings/EditAppletSetting/EditAppletSetting.tsx
+++ b/src/shared/features/AppletSettings/EditAppletSetting/EditAppletSetting.tsx
@@ -17,7 +17,8 @@ export const EditAppletSetting = () => {
 
   const handleClick = () => {
     navigate(getBuilderAppletUrl(appletId || ''));
-    Mixpanel.track(MixpanelEventType.AppletEditClick, {
+    Mixpanel.track({
+      action: MixpanelEventType.AppletEditClick,
       [MixpanelProps.AppletId]: appletId,
     });
   };

--- a/src/shared/features/AppletSettings/EditAppletSetting/EditAppletSetting.tsx
+++ b/src/shared/features/AppletSettings/EditAppletSetting/EditAppletSetting.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 
 import { Svg } from 'shared/components/Svg';
 import { getBuilderAppletUrl } from 'shared/utils/urlGenerator';
-import { Mixpanel } from 'shared/utils/mixpanel';
+import { Mixpanel, MixpanelEventType, MixpanelProps } from 'shared/utils/mixpanel';
 
 import {
   StyledAppletSettingsButton,
@@ -17,8 +17,8 @@ export const EditAppletSetting = () => {
 
   const handleClick = () => {
     navigate(getBuilderAppletUrl(appletId || ''));
-    Mixpanel.track('Applet edit click', {
-      'Applet ID': appletId,
+    Mixpanel.track(MixpanelEventType.AppletEditClick, {
+      [MixpanelProps.AppletId]: appletId,
     });
   };
 

--- a/src/shared/hooks/useFeatureFlags.ts
+++ b/src/shared/hooks/useFeatureFlags.ts
@@ -24,8 +24,6 @@ export const useFeatureFlags = () => {
     const features: FeatureFlags = {};
     keys.forEach((key) => (features[key] = flags[FeatureFlagsKeys[key]]));
 
-    features.enableCahmiSubscaleScoring = true;
-
     return features;
   };
 

--- a/src/shared/hooks/useFeatureFlags.ts
+++ b/src/shared/hooks/useFeatureFlags.ts
@@ -24,6 +24,8 @@ export const useFeatureFlags = () => {
     const features: FeatureFlags = {};
     keys.forEach((key) => (features[key] = flags[FeatureFlagsKeys[key]]));
 
+    features.enableCahmiSubscaleScoring = true;
+
     return features;
   };
 

--- a/src/shared/hooks/useLogout.ts
+++ b/src/shared/hooks/useLogout.ts
@@ -6,7 +6,7 @@ import { ApiResponseCodes } from 'api';
 import { useAppDispatch } from 'redux/store';
 import { alerts, auth, workspaces } from 'redux/modules';
 import { deleteAccessTokenApi, deleteRefreshTokenApi } from 'modules/Auth/api';
-import { Mixpanel } from 'shared/utils/mixpanel';
+import { Mixpanel, MixpanelEventType } from 'shared/utils/mixpanel';
 import { FeatureFlags } from 'shared/utils/featureFlags';
 import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 
@@ -46,7 +46,7 @@ export const useLogout = () => {
       dispatch(alerts.actions.resetAlerts());
       dispatch(auth.actions.resetAuthorization());
 
-      Mixpanel.track('Logout');
+      Mixpanel.track(MixpanelEventType.Logout);
       Mixpanel.logout();
       await FeatureFlags.logout();
 

--- a/src/shared/hooks/useLogout.ts
+++ b/src/shared/hooks/useLogout.ts
@@ -46,7 +46,7 @@ export const useLogout = () => {
       dispatch(alerts.actions.resetAlerts());
       dispatch(auth.actions.resetAuthorization());
 
-      Mixpanel.track(MixpanelEventType.Logout);
+      Mixpanel.track({ action: MixpanelEventType.Logout });
       Mixpanel.logout();
       await FeatureFlags.logout();
 

--- a/src/shared/hooks/useTransferOwnership.test.ts
+++ b/src/shared/hooks/useTransferOwnership.test.ts
@@ -7,6 +7,7 @@ import { PreloadedState } from '@reduxjs/toolkit';
 import * as MixpanelFunc from 'shared/utils/mixpanel';
 import { RootState } from 'redux/store';
 import { renderHookWithProviders } from 'shared/utils/renderHookWithProviders';
+import { MixpanelEventType, MixpanelProps } from 'shared/utils/mixpanel';
 
 import { useTransferOwnership } from './useTransferOwnership';
 
@@ -78,8 +79,9 @@ describe('useTransferOwnership', () => {
 
     expect(store.getState().banners).toEqual(populatedState.banners);
     expect(mockedCallback).toBeCalled();
-    expect(mixpanelTrack).toBeCalledWith('Invitation sent successfully', {
-      'Applet ID': 'appletId',
+    expect(mixpanelTrack).toBeCalledWith({
+      action: MixpanelEventType.InvitationSent,
+      [MixpanelProps.AppletId]: 'appletId',
     });
   });
 });

--- a/src/shared/hooks/useTransferOwnership.ts
+++ b/src/shared/hooks/useTransferOwnership.ts
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { banners } from 'redux/modules';
 import { useAppDispatch } from 'redux/store';
-import { Mixpanel } from 'shared/utils/mixpanel';
+import { Mixpanel, MixpanelEventType, MixpanelProps } from 'shared/utils/mixpanel';
 
 export const useTransferOwnership = (appletId?: string) => {
   const [isSubmitted, setIsSubmitted] = useState(false);
@@ -22,8 +22,8 @@ export const useTransferOwnership = (appletId?: string) => {
       }),
     );
 
-    Mixpanel.track('Invitation sent successfully', {
-      'Applet ID': appletId,
+    Mixpanel.track(MixpanelEventType.InvitationSent, {
+      [MixpanelProps.AppletId]: appletId,
     });
   };
 

--- a/src/shared/hooks/useTransferOwnership.ts
+++ b/src/shared/hooks/useTransferOwnership.ts
@@ -22,7 +22,8 @@ export const useTransferOwnership = (appletId?: string) => {
       }),
     );
 
-    Mixpanel.track(MixpanelEventType.InvitationSent, {
+    Mixpanel.track({
+      action: MixpanelEventType.InvitationSent,
       [MixpanelProps.AppletId]: appletId,
     });
   };

--- a/src/shared/layouts/BaseLayout/components/LeftBar/LeftBar.tsx
+++ b/src/shared/layouts/BaseLayout/components/LeftBar/LeftBar.tsx
@@ -36,7 +36,7 @@ export const LeftBar = () => {
 
   const handleLinkClick = (key: string) => {
     if (key === 'library') {
-      Mixpanel.track(MixpanelEventType.BrowseAppletLibraryClick);
+      Mixpanel.track({ action: MixpanelEventType.BrowseAppletLibraryClick });
     }
   };
 

--- a/src/shared/layouts/BaseLayout/components/LeftBar/LeftBar.tsx
+++ b/src/shared/layouts/BaseLayout/components/LeftBar/LeftBar.tsx
@@ -10,7 +10,7 @@ import { SwitchWorkspace, WorkspaceImage } from 'shared/features/SwitchWorkspace
 import { workspaces, auth, Workspace } from 'redux/modules';
 import { authStorage } from 'shared/utils/authStorage';
 import { toggleBooleanState } from 'shared/utils/toggleBooleanState';
-import { Mixpanel } from 'shared/utils/mixpanel';
+import { Mixpanel, MixpanelEventType } from 'shared/utils/mixpanel';
 import { useAppDispatch } from 'redux/store';
 import { LocationStateKeys } from 'shared/types';
 import { FeatureFlags } from 'shared/utils/featureFlags';
@@ -36,7 +36,7 @@ export const LeftBar = () => {
 
   const handleLinkClick = (key: string) => {
     if (key === 'library') {
-      Mixpanel.track('Browse applet library click');
+      Mixpanel.track(MixpanelEventType.BrowseAppletLibraryClick);
     }
   };
 

--- a/src/shared/types/invitation.ts
+++ b/src/shared/types/invitation.ts
@@ -1,3 +1,5 @@
+import { ParticipantTag } from 'shared/consts';
+
 export type Invitation = {
   appletId: string;
   appletName: string;
@@ -14,7 +16,7 @@ export type Invitation = {
     subject_id?: string;
     secret_user_id?: string | null;
   };
-  tag: string | null;
+  tag: ParticipantTag | null;
   title: string | null;
 };
 

--- a/src/shared/utils/mixpanel/mixpanel.ts
+++ b/src/shared/utils/mixpanel/mixpanel.ts
@@ -1,4 +1,4 @@
-import { MixpanelPayload, MixpanelAction } from 'shared/utils/mixpanel/mixpanel.types';
+import { MixpanelEvent } from 'shared/utils/mixpanel/mixpanel.types';
 
 import { isProduction, isStaging, isUat, isDev } from '../env';
 
@@ -24,10 +24,11 @@ export const Mixpanel = {
       });
     }
   },
-  track(action: MixpanelAction, payload?: MixpanelPayload) {
+  track(event: MixpanelEvent) {
     if (shouldEnableMixpanel) {
       import('mixpanel-browser').then(({ default: mixpanel }) => {
-        mixpanel.track(`[Admin] ${action}`, payload);
+        const { action, ...properties } = event;
+        mixpanel.track(`[Admin] ${action}`, properties);
       });
     }
   },

--- a/src/shared/utils/mixpanel/mixpanel.ts
+++ b/src/shared/utils/mixpanel/mixpanel.ts
@@ -1,4 +1,4 @@
-import { MixpanelPayload } from 'shared/utils/mixpanel/mixpanel.types';
+import { MixpanelPayload, MixpanelAction } from 'shared/utils/mixpanel/mixpanel.types';
 
 import { isProduction, isStaging, isUat, isDev } from '../env';
 
@@ -24,7 +24,7 @@ export const Mixpanel = {
       });
     }
   },
-  track(action: string, payload?: MixpanelPayload) {
+  track(action: MixpanelAction, payload?: MixpanelPayload) {
     if (shouldEnableMixpanel) {
       import('mixpanel-browser').then(({ default: mixpanel }) => {
         mixpanel.track(`[Admin] ${action}`, payload);

--- a/src/shared/utils/mixpanel/mixpanel.ts
+++ b/src/shared/utils/mixpanel/mixpanel.ts
@@ -36,10 +36,10 @@ export const Mixpanel = {
     if (shouldEnableMixpanel) {
       import('mixpanel-browser').then(({ default: mixpanel }) => {
         mixpanel.identify(userId);
-      });
-      mixpanel.people.set({
-        'User ID': userId,
-        'App Build Number': process.env.REACT_APP_DEVELOP_BUILD_VERSION,
+        mixpanel.people.set({
+          'User ID': userId,
+          'App Build Number': process.env.REACT_APP_DEVELOP_BUILD_VERSION,
+        });
       });
     }
   },

--- a/src/shared/utils/mixpanel/mixpanel.ts
+++ b/src/shared/utils/mixpanel/mixpanel.ts
@@ -10,38 +10,43 @@ const shouldEnableMixpanel =
   (isProduction || isStaging || isUat || process.env.REACT_APP_MIXPANEL_FORCE_ENABLE === 'true');
 
 export const Mixpanel = {
-  async init() {
+  init() {
     if (shouldEnableMixpanel) {
-      const { default: mixpanel } = await import('mixpanel-browser');
-      mixpanel.init(PROJECT_TOKEN, { ignore_dnt: isDev });
+      import('mixpanel-browser').then(({ default: mixpanel }) => {
+        mixpanel.init(PROJECT_TOKEN, { ignore_dnt: isDev });
+      });
     }
   },
-  async trackPageView(pageName: string) {
+  trackPageView(pageName: string) {
     if (shouldEnableMixpanel) {
-      const { default: mixpanel } = await import('mixpanel-browser');
-      mixpanel.track_pageview({ page: `[Admin] ${pageName}` });
+      import('mixpanel-browser').then(({ default: mixpanel }) => {
+        mixpanel.track_pageview({ page: `[Admin] ${pageName}` });
+      });
     }
   },
-  async track(action: string, payload?: MixpanelPayload) {
+  track(action: string, payload?: MixpanelPayload) {
     if (shouldEnableMixpanel) {
-      const { default: mixpanel } = await import('mixpanel-browser');
-      mixpanel.track(`[Admin] ${action}`, payload);
+      import('mixpanel-browser').then(({ default: mixpanel }) => {
+        mixpanel.track(`[Admin] ${action}`, payload);
+      });
     }
   },
-  async login(userId: string) {
+  login(userId: string) {
     if (shouldEnableMixpanel) {
-      const { default: mixpanel } = await import('mixpanel-browser');
-      mixpanel.identify(userId);
+      import('mixpanel-browser').then(({ default: mixpanel }) => {
+        mixpanel.identify(userId);
+      });
       mixpanel.people.set({
         'User ID': userId,
         'App Build Number': process.env.REACT_APP_DEVELOP_BUILD_VERSION,
       });
     }
   },
-  async logout() {
+  logout() {
     if (shouldEnableMixpanel) {
-      const { default: mixpanel } = await import('mixpanel-browser');
-      mixpanel.reset();
+      import('mixpanel-browser').then(({ default: mixpanel }) => {
+        mixpanel.reset();
+      });
     }
   },
 };

--- a/src/shared/utils/mixpanel/mixpanel.types.ts
+++ b/src/shared/utils/mixpanel/mixpanel.types.ts
@@ -88,10 +88,6 @@ export enum MixpanelGeneralCalendarEvent {
   ScheduleImportClick = 'GC Schedule Import click',
 }
 
-export type MixpanelAction =
-  | MixpanelEventType
-  | MixpanelIndividualCalendarEvent
-  | MixpanelGeneralCalendarEvent;
 export const MixpanelCalendarEvent = {
   [AnalyticsCalendarPrefix.IndividualCalendar]: MixpanelIndividualCalendarEvent,
   [AnalyticsCalendarPrefix.GeneralCalendar]: MixpanelGeneralCalendarEvent,

--- a/src/shared/utils/mixpanel/mixpanel.types.ts
+++ b/src/shared/utils/mixpanel/mixpanel.types.ts
@@ -1,4 +1,4 @@
-import { AnalyticsCalendarPrefix } from 'shared/consts';
+import { AnalyticsCalendarPrefix, ParticipantTag } from 'shared/consts';
 
 export enum MixpanelProps {
   Feature = 'Feature',
@@ -14,8 +14,6 @@ export enum MixpanelProps {
   Tag = 'Tag',
   Via = 'Via',
 }
-
-export type MixpanelPayload = Partial<Record<MixpanelProps, unknown>>;
 
 export enum MixpanelEventType {
   InvitationSent = 'Invitation sent successfully',
@@ -98,3 +96,351 @@ export const MixpanelCalendarEvent = {
   [AnalyticsCalendarPrefix.IndividualCalendar]: MixpanelIndividualCalendarEvent,
   [AnalyticsCalendarPrefix.GeneralCalendar]: MixpanelGeneralCalendarEvent,
 } as const;
+
+type WithAppletId<T> = T & { [MixpanelProps.AppletId]?: string | null };
+
+export type MixpanelInvitationSentEvent = WithAppletId<{
+  action: MixpanelEventType.InvitationSent;
+}>;
+
+export type LoginSuccessfulEvent = {
+  action: MixpanelEventType.LoginSuccessful;
+};
+
+export type LoginBtnClickEvent = {
+  action: MixpanelEventType.LoginBtnClick;
+};
+
+export type LogoutEvent = {
+  action: MixpanelEventType.Logout;
+};
+
+export type CreateAccountOnLoginScreenEvent = {
+  action: MixpanelEventType.CreateAccountOnLoginScreen;
+};
+
+export type SignUpSuccessfulEvent = {
+  action: MixpanelEventType.SignUpSuccessful;
+};
+
+export type AddActivityClickEvent = WithAppletId<{
+  action: MixpanelEventType.AddActivityClick;
+}>;
+
+export type ActivityEditClickEvent = WithAppletId<{
+  action: MixpanelEventType.ActivityEditClick;
+}>;
+
+export type AppletEditClickEvent = WithAppletId<{
+  action: MixpanelEventType.AppletEditClick;
+}>;
+
+export type ScoresAndReportBtnClickEvent = WithAppletId<{
+  action: MixpanelEventType.ScoresAndReportBtnClick;
+}>;
+
+export type ActivityReportConfigurationClickEvent = WithAppletId<{
+  action: MixpanelEventType.ActivityReportConfigurationClick;
+}>;
+
+export type AppletReportConfigurationClickEvent = WithAppletId<{
+  action: MixpanelEventType.AppletReportConfigurationClick;
+}>;
+
+export type AppletSaveClickEvent = WithAppletId<{
+  action: MixpanelEventType.AppletSaveClick;
+}>;
+
+export type PasswordAddedSuccessfullyEvent = WithAppletId<{
+  action: MixpanelEventType.PasswordAddedSuccessfully;
+}>;
+
+export type AppletEditSuccessfulEvent = WithAppletId<{
+  action: MixpanelEventType.AppletEditSuccessful;
+}>;
+
+export type AppletCreatedSuccessfullyEvent = WithAppletId<{
+  action: MixpanelEventType.AppletCreatedSuccessfully;
+}>;
+
+export type ExportDataClickEvent = WithAppletId<{
+  action: MixpanelEventType.ExportDataClick;
+}>;
+
+type TakeNowEvent = WithAppletId<{
+  [MixpanelProps.Feature]?: 'Multi-informant';
+  [MixpanelProps.MultiInformantAssessmentId]?: string | null;
+  [MixpanelProps.ActivityId]?: string;
+  [MixpanelProps.ActivityFlowId]?: string;
+}>;
+
+export type TakeNowDialogClosedEvent = TakeNowEvent & {
+  action: MixpanelEventType.TakeNowDialogClosed;
+};
+
+export type MultiInformantStartActivityClickEvent = TakeNowEvent & {
+  action: MixpanelEventType.MultiInformantStartActivityClick;
+  [MixpanelProps.SourceAccountType]?: string | null;
+  [MixpanelProps.TargetAccountType]?: string | null;
+  [MixpanelProps.InputAccountType]?: string | null;
+  [MixpanelProps.IsSelfReporting]: boolean;
+};
+
+export type ProvidingResponsesDropdownOpenedEvent = TakeNowEvent & {
+  action: MixpanelEventType.ProvidingResponsesDropdownOpened;
+};
+
+export type ProvidingResponsesSelectionChangedEvent = TakeNowEvent & {
+  action: MixpanelEventType.ProvidingResponsesSelectionChanged;
+  [MixpanelProps.SourceAccountType]?: string | null;
+};
+
+export type OwnResponsesCheckboxToggledEvent = TakeNowEvent & {
+  action: MixpanelEventType.OwnResponsesCheckboxToggled;
+  [MixpanelProps.IsSelfReporting]: boolean;
+};
+
+export type InputtingResponsesDropdownOpenedEvent = TakeNowEvent & {
+  action: MixpanelEventType.InputtingResponsesDropdownOpened;
+};
+
+export type InputtingResponsesSelectionChangedEvent = TakeNowEvent & {
+  action: MixpanelEventType.InputtingResponsesSelectionChanged;
+  [MixpanelProps.InputAccountType]?: string | null;
+};
+
+export type ResponsesAboutDropdownOpenedEvent = TakeNowEvent & {
+  action: MixpanelEventType.ResponsesAboutDropdownOpened;
+};
+
+export type ResponsesAboutSelectionChangedEvent = TakeNowEvent & {
+  action: MixpanelEventType.ResponsesAboutSelectionChanged;
+  [MixpanelProps.TargetAccountType]?: string | null;
+};
+
+export type TakeNowClickEvent = TakeNowEvent & {
+  action: MixpanelEventType.TakeNowClick;
+  [MixpanelProps.TargetAccountType]?: string | null;
+  [MixpanelProps.SourceAccountType]?: string | null;
+  [MixpanelProps.Via]?: 'Applet - Activities' | 'Applet - Participants - Activities';
+};
+
+export type AddParticipantBtnClickedEvent = WithAppletId<{
+  action: MixpanelEventType.AddParticipantBtnClicked;
+  [MixpanelProps.Via]: 'Applet - Overview' | 'Applet - Participants';
+}>;
+
+export type FullAccountInvitationCreatedEvent = WithAppletId<{
+  action: MixpanelEventType.FullAccountInvitationCreated;
+  [MixpanelProps.Tag]?: Exclude<ParticipantTag, ''> | null;
+}>;
+
+export type LimitedAccountCreatedEvent = WithAppletId<{
+  action: MixpanelEventType.LimitedAccountCreated;
+  [MixpanelProps.Tag]?: Exclude<ParticipantTag, ''> | null;
+}>;
+
+export type FullAccountInvitationFormSubmittedEvent = WithAppletId<{
+  action: MixpanelEventType.FullAccountInvitationFormSubmitted;
+  [MixpanelProps.Tag]?: Exclude<ParticipantTag, ''> | null;
+}>;
+
+export type AddLimitedAccountFormSubmittedEvent = WithAppletId<{
+  action: MixpanelEventType.AddLimitedAccountFormSubmitted;
+  [MixpanelProps.Tag]?: Exclude<ParticipantTag, ''> | null;
+}>;
+
+export type UpgradeToFullAccountInviteCreatedEvent = WithAppletId<{
+  action: MixpanelEventType.UpgradeToFullAccountInviteCreated;
+}>;
+
+export type UpgradeToFullAccountFormSubmittedEvent = WithAppletId<{
+  action: MixpanelEventType.UpgradeToFullAccountFormSubmitted;
+}>;
+
+export type UpgradeToFullAccountClickedEvent = WithAppletId<{
+  action: MixpanelEventType.UpgradeToFullAccountClicked;
+  [MixpanelProps.Via]: 'Applet - Participants';
+}>;
+
+export type BuildAppletClickEvent = {
+  action: MixpanelEventType.BuildAppletClick;
+};
+
+export type BrowseAppletLibraryClickEvent = {
+  action: MixpanelEventType.BrowseAppletLibraryClick;
+};
+
+export type EditTeamMemberClickedEvent = WithAppletId<{
+  action: MixpanelEventType.EditTeamMemberClicked;
+  [MixpanelProps.Via]: 'Applet - Team' | 'Team';
+}>;
+
+export type AddTeamMemberBtnClickedEvent = WithAppletId<{
+  action: MixpanelEventType.AddTeamMemberBtnClicked;
+  [MixpanelProps.Via]: 'Applet - Team' | 'Team';
+}>;
+
+export type TeamMemberInvitedSuccessfullyEvent = WithAppletId<{
+  action: MixpanelEventType.TeamMemberInvitedSuccessfully;
+  [MixpanelProps.Roles]: string[];
+}>;
+
+export type TeamMemberInvitationFormSubmittedEvent = WithAppletId<{
+  action: MixpanelEventType.TeamMemberInvitationFormSubmitted;
+  [MixpanelProps.Roles]: string[];
+}>;
+
+export type TeamMemberEditSuccessfulEvent = WithAppletId<{
+  action: MixpanelEventType.TeamMemberEditSuccessful;
+  [MixpanelProps.Roles]: string[];
+}>;
+
+export type EditTeamMemberFormSubmittedEvent = WithAppletId<{
+  action: MixpanelEventType.EditTeamMemberFormSubmitted;
+  [MixpanelProps.Roles]: string[];
+}>;
+
+export type EditFullAccountClickedEvent = WithAppletId<{
+  action: MixpanelEventType.EditFullAccountClicked;
+  [MixpanelProps.Via]: 'Applet - Participants';
+}>;
+
+export type EditLimitedAccountClickedEvent = WithAppletId<{
+  action: MixpanelEventType.EditLimitedAccountClicked;
+  [MixpanelProps.Via]: 'Applet - Participants';
+}>;
+
+export type ExportDataSuccessfulEvent = WithAppletId<{
+  action: MixpanelEventType.ExportDataSuccessful;
+}>;
+
+export type FullAccountEditedSuccessfullyEvent = WithAppletId<{
+  action: MixpanelEventType.FullAccountEditedSuccessfully;
+  [MixpanelProps.Tag]?: Exclude<ParticipantTag, ''> | null;
+}>;
+
+export type LimitedAccountEditedSuccessfullyEvent = WithAppletId<{
+  action: MixpanelEventType.LimitedAccountEditedSuccessfully;
+  [MixpanelProps.Tag]?: Exclude<ParticipantTag, ''> | null;
+}>;
+
+export type EditFullAccountFormSubmittedEvent = WithAppletId<{
+  action: MixpanelEventType.EditFullAccountFormSubmitted;
+  [MixpanelProps.Tag]?: Exclude<ParticipantTag, ''> | null;
+}>;
+
+export type EditLimitedAccountFormSubmittedEvent = WithAppletId<{
+  action: MixpanelEventType.EditLimitedAccountFormSubmitted;
+  [MixpanelProps.Tag]?: Exclude<ParticipantTag, ''> | null;
+}>;
+
+export type ViewGeneralCalendarClickEvent = WithAppletId<{
+  action: MixpanelEventType.ViewGeneralCalendarClick;
+}>;
+
+export type ViewIndividualCalendarClickEvent = WithAppletId<{
+  action: MixpanelEventType.ViewIndividualCalendarClick;
+}>;
+
+export type SubjectInvitationClickEvent = {
+  action: MixpanelEventType.SubjectInvitationClick;
+};
+
+export type AddToBasketClickEvent = WithAppletId<{
+  action: MixpanelEventType.AddToBasketClick;
+}>;
+
+export type GoToBasketClickEvent = WithAppletId<{
+  action: MixpanelEventType.GoToBasketClick;
+}>;
+
+export type AddToAppletBuilderClickEvent = {
+  action: MixpanelEventType.AddToAppletBuilderClick;
+};
+
+export type ScheduleSaveClickEvent = WithAppletId<{
+  action:
+    | MixpanelIndividualCalendarEvent.ScheduleSaveClick
+    | MixpanelGeneralCalendarEvent.ScheduleSaveClick;
+}>;
+
+export type ScheduleSuccessfulEvent = WithAppletId<{
+  action:
+    | MixpanelIndividualCalendarEvent.ScheduleSuccessful
+    | MixpanelGeneralCalendarEvent.ScheduleSuccessful;
+}>;
+
+export type ScheduleImportSuccessfulEvent = WithAppletId<{
+  action:
+    | MixpanelIndividualCalendarEvent.ScheduleImportSuccessful
+    | MixpanelGeneralCalendarEvent.ScheduleImportSuccessful;
+}>;
+
+export type ScheduleImportClickEvent = WithAppletId<{
+  action:
+    | MixpanelIndividualCalendarEvent.ScheduleImportClick
+    | MixpanelGeneralCalendarEvent.ScheduleImportClick;
+}>;
+
+export type MixpanelEvent =
+  | MixpanelInvitationSentEvent
+  | LoginSuccessfulEvent
+  | LoginBtnClickEvent
+  | LogoutEvent
+  | CreateAccountOnLoginScreenEvent
+  | SignUpSuccessfulEvent
+  | AddActivityClickEvent
+  | ActivityEditClickEvent
+  | AppletEditClickEvent
+  | ScoresAndReportBtnClickEvent
+  | ActivityReportConfigurationClickEvent
+  | AppletReportConfigurationClickEvent
+  | AppletSaveClickEvent
+  | PasswordAddedSuccessfullyEvent
+  | AppletEditSuccessfulEvent
+  | AppletCreatedSuccessfullyEvent
+  | ExportDataClickEvent
+  | TakeNowDialogClosedEvent
+  | MultiInformantStartActivityClickEvent
+  | ProvidingResponsesDropdownOpenedEvent
+  | ProvidingResponsesSelectionChangedEvent
+  | OwnResponsesCheckboxToggledEvent
+  | InputtingResponsesDropdownOpenedEvent
+  | InputtingResponsesSelectionChangedEvent
+  | ResponsesAboutDropdownOpenedEvent
+  | ResponsesAboutSelectionChangedEvent
+  | TakeNowClickEvent
+  | AddParticipantBtnClickedEvent
+  | FullAccountInvitationCreatedEvent
+  | LimitedAccountCreatedEvent
+  | FullAccountInvitationFormSubmittedEvent
+  | AddLimitedAccountFormSubmittedEvent
+  | UpgradeToFullAccountInviteCreatedEvent
+  | UpgradeToFullAccountFormSubmittedEvent
+  | UpgradeToFullAccountClickedEvent
+  | BuildAppletClickEvent
+  | BrowseAppletLibraryClickEvent
+  | EditTeamMemberClickedEvent
+  | AddTeamMemberBtnClickedEvent
+  | TeamMemberInvitedSuccessfullyEvent
+  | TeamMemberInvitationFormSubmittedEvent
+  | TeamMemberEditSuccessfulEvent
+  | EditTeamMemberFormSubmittedEvent
+  | EditFullAccountClickedEvent
+  | EditLimitedAccountClickedEvent
+  | ExportDataSuccessfulEvent
+  | FullAccountEditedSuccessfullyEvent
+  | LimitedAccountEditedSuccessfullyEvent
+  | EditFullAccountFormSubmittedEvent
+  | EditLimitedAccountFormSubmittedEvent
+  | ViewGeneralCalendarClickEvent
+  | ViewIndividualCalendarClickEvent
+  | SubjectInvitationClickEvent
+  | AddToBasketClickEvent
+  | GoToBasketClickEvent
+  | AddToAppletBuilderClickEvent
+  | ScheduleSaveClickEvent
+  | ScheduleSuccessfulEvent
+  | ScheduleImportSuccessfulEvent
+  | ScheduleImportClickEvent;

--- a/src/shared/utils/mixpanel/mixpanel.types.ts
+++ b/src/shared/utils/mixpanel/mixpanel.types.ts
@@ -1,3 +1,5 @@
+import { AnalyticsCalendarPrefix } from 'shared/consts';
+
 export enum MixpanelProps {
   Feature = 'Feature',
   AppletId = 'Applet ID',
@@ -14,3 +16,85 @@ export enum MixpanelProps {
 }
 
 export type MixpanelPayload = Partial<Record<MixpanelProps, unknown>>;
+
+export enum MixpanelEventType {
+  InvitationSent = 'Invitation sent successfully',
+  LoginSuccessful = 'Login Successful',
+  LoginBtnClick = 'Login Button click',
+  Logout = 'Logout',
+  CreateAccountOnLoginScreen = 'Create account button on login screen click',
+  SignUpSuccessful = 'Signup Successful',
+  AddActivityClick = 'Add Activity click',
+  AppletEditClick = 'Applet edit click',
+  ActivityEditClick = 'Activity edit click',
+  ScoresAndReportBtnClick = 'Scores and Report Button Click',
+  ActivityReportConfigurationClick = 'Activity - Report Configuration Click',
+  AppletReportConfigurationClick = 'Applet - Report Configuration Click',
+  AppletSaveClick = 'Applet Save click',
+  PasswordAddedSuccessfully = 'Password added successfully',
+  AppletEditSuccessful = 'Applet edit successful',
+  AppletCreatedSuccessfully = 'Applet Created Successfully',
+  ExportDataClick = 'Export Data click',
+  TakeNowDialogClosed = 'Take Now dialogue closed',
+  MultiInformantStartActivityClick = 'Multi-informant Start Activity click',
+  ProvidingResponsesDropdownOpened = '"Who will be providing responses" dropdown opened',
+  ProvidingResponsesSelectionChanged = '"Who will be providing responses" selection changed',
+  OwnResponsesCheckboxToggled = 'Own responses checkbox toggled',
+  InputtingResponsesDropdownOpened = '"Who will be inputting the responses" dropdown opened',
+  InputtingResponsesSelectionChanged = '"Who will be inputting the responses" selection changed',
+  ResponsesAboutDropdownOpened = '"Who are the responses about" dropdown opened',
+  ResponsesAboutSelectionChanged = '"Who are the responses about" selection changed',
+  TakeNowClick = 'Take Now click',
+  AddParticipantBtnClicked = 'Add Participant button clicked',
+  FullAccountInvitationCreated = 'Full Account invitation created successfully',
+  LimitedAccountCreated = 'Limited Account created successfully',
+  FullAccountInvitationFormSubmitted = 'Full Account invitation form submitted',
+  AddLimitedAccountFormSubmitted = 'Add Limited Account form submitted',
+  UpgradeToFullAccountInviteCreated = 'Upgrade to Full Account invitation created successfully',
+  UpgradeToFullAccountFormSubmitted = 'Upgrade to Full Account invitation form submitted',
+  UpgradeToFullAccountClicked = 'Upgrade to Full Account clicked',
+  BuildAppletClick = 'Build Applet click',
+  BrowseAppletLibraryClick = 'Browse applet library click',
+  EditTeamMemberClicked = 'Edit Team Member clicked',
+  AddTeamMemberBtnClicked = 'Add Team Member button clicked',
+  TeamMemberInvitedSuccessfully = 'Team Member account invitation created successfully',
+  TeamMemberInvitationFormSubmitted = 'Team Member account invitation form submitted',
+  TeamMemberEditSuccessful = 'Team Member edited successfully',
+  EditTeamMemberFormSubmitted = 'Edit Team Member form submitted',
+  EditFullAccountClicked = 'Edit Full Account clicked',
+  EditLimitedAccountClicked = 'Edit Limited Account clicked',
+  ExportDataSuccessful = 'Export Data Successful',
+  FullAccountEditedSuccessfully = 'Full Account edited successfully',
+  LimitedAccountEditedSuccessfully = 'Limited Account edited successfully',
+  EditFullAccountFormSubmitted = 'Edit Full Account form submitted',
+  EditLimitedAccountFormSubmitted = 'Edit Limited Account form submitted',
+  ViewGeneralCalendarClick = 'View General calendar click',
+  ViewIndividualCalendarClick = 'View Individual calendar click',
+  SubjectInvitationClick = 'Subject Invitation click',
+  AddToBasketClick = 'Add to Basket click',
+  GoToBasketClick = 'Go to Basket click',
+  AddToAppletBuilderClick = 'Add to applet builder click',
+}
+
+export enum MixpanelIndividualCalendarEvent {
+  ScheduleSaveClick = 'IC Schedule save click',
+  ScheduleSuccessful = 'IC Schedule successful',
+  ScheduleImportSuccessful = 'IC Schedule import successful',
+  ScheduleImportClick = 'IC Schedule Import click',
+}
+
+export enum MixpanelGeneralCalendarEvent {
+  ScheduleSaveClick = 'GC Schedule save click',
+  ScheduleSuccessful = 'GC Schedule successful',
+  ScheduleImportSuccessful = 'GC Schedule import successful',
+  ScheduleImportClick = 'GC Schedule Import click',
+}
+
+export type MixpanelAction =
+  | MixpanelEventType
+  | MixpanelIndividualCalendarEvent
+  | MixpanelGeneralCalendarEvent;
+export const MixpanelCalendarEvent = {
+  [AnalyticsCalendarPrefix.IndividualCalendar]: MixpanelIndividualCalendarEvent,
+  [AnalyticsCalendarPrefix.GeneralCalendar]: MixpanelGeneralCalendarEvent,
+} as const;


### PR DESCRIPTION
### 📝 Description

This PR modifies the way events are tracked with Mixpanel in the following ways:

- The methods in the `Mixpanel` object are no longer async. This is because they don't return anything and are never awaited
- There is now a central place to define events and their properties so that we can conveniently see which properties are included in each event, and where they are used.

Now in order to track a new event, you first define it in the event type in the `MixpanelEventType` enum

```typescript
export enum MixpanelEventType {
  UpgradeToFullAccountClicked = 'Upgrade to Full Account clicked',
}
```

Then define any extra properties it will need in the `MixpanelProps` enum

```typescript
export enum MixpanelProps {
  Via = 'Via',
}
```

Then finally define the event type and add it to the `MixpanelEvent` type union

```typescript
export type UpgradeToFullAccountClickedEvent = WithAppletId<{
  action: MixpanelEventType.UpgradeToFullAccountClicked;
  [MixpanelProps.Via]: 'Applet - Participants';
}>;

export type MixpanelEvent =
  | MixpanelInvitationSentEvent
  | LoginSuccessfulEvent
  | LoginBtnClickEvent
  // ...
  UpgradeToFullAccountClickedEvent;
```

> [!TIP]
> Wrapping the type in `WithAppletId` adds an optional `Applet ID` property to the event

### 📸 Screenshots

N/A

### 🪤 Peer Testing

Read the code I guess 🤷

### ✏️ Notes

N/A