### PR TITLE
fix: Report Score Average Range Calculation (M2-7738)

### DIFF
--- a/src/modules/Builder/features/ActivitySettings/ScoresAndReports/ScoreContent/ScoreContent.utils.ts
+++ b/src/modules/Builder/features/ActivitySettings/ScoresAndReports/ScoreContent/ScoreContent.utils.ts
@@ -112,22 +112,42 @@ export const getScoreRange = ({
     totalMaxScore += itemMaxScore;
   });
 
-  totalMinScore = isNaN(lookupTableMinScore)
-    ? totalMinScore
-    : Math.min(totalMinScore, lookupTableMinScore);
-
-  totalMaxScore = isNaN(lookupTableMaxScore)
-    ? totalMaxScore
-    : Math.max(totalMaxScore, lookupTableMaxScore);
-
   switch (calculationType) {
-    case CalculationType.Sum:
-      return { minScore: totalMinScore, maxScore: totalMaxScore };
-    case CalculationType.Average:
+    case CalculationType.Sum: {
+      const minScore = isNaN(lookupTableMinScore)
+        ? totalMinScore
+        : Math.min(totalMinScore, lookupTableMinScore);
+
+      const maxScore = isNaN(lookupTableMaxScore)
+        ? totalMaxScore
+        : Math.max(totalMaxScore, lookupTableMaxScore);
+
+      return { minScore, maxScore };
+    }
+    case CalculationType.Average: {
+      if (!count) {
+        return {
+          minScore: 0,
+          maxScore: 0,
+        };
+      }
+
+      const minItemAverage = totalMinScore / count;
+      const maxItemAverage = totalMaxScore / count;
+
+      const minAverageScore = isNaN(lookupTableMinScore)
+        ? minItemAverage
+        : Math.min(minItemAverage, lookupTableMinScore);
+
+      const maxAverageScore = isNaN(lookupTableMaxScore)
+        ? maxItemAverage
+        : Math.max(maxItemAverage, lookupTableMaxScore);
+
       return {
-        minScore: count ? totalMinScore / count : 0,
-        maxScore: count ? totalMaxScore / count : 0,
+        minScore: minAverageScore,
+        maxScore: maxAverageScore,
       };
+    }
     case CalculationType.Percentage:
       return { minScore: totalMaxScore ? (totalMinScore / totalMaxScore) * 100 : 0, maxScore: 100 };
   }


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-7738](https://mindlogger.atlassian.net/browse/M2-7738)

This PR updates the way the report score score range is calculated and displayed for scoring type "Score". When a subscale is linked that uses _Average_ calculation type, the score range now properly excludes the min and max lookup table scores from the division.

The average score range is determined by finding the min and max average scores from each item, and then finding the min/max between those and the min/max scores in the lookup table respectively.

### 📸 Screenshots

N/A

### 🪤 Peer Testing

- Create an activity with three single selection items, each with three option having scores 20, 25, and 30
- Create a subscale with a lookup table that uses Average calculation type and include each of those items in the subscale. Use this lookup table:
```csv
score,rawScore,age,sex,optionalText
10,1,15,M,https://gist.githubusercontent.com/benbalter/3914310/raw/f757a33411082da23f0ad4a124b45fcdacc1b43f/Example--text.txt
20,2,15,M,https://gist.githubusercontent.com/benbalter/3914310/raw/f757a33411082da23f0ad4a124b45fcdacc1b43f/Example--text.txt
30,3,15,M,Markdown Text Here
40,4,15,F,Good
50,5,15,,
```

- Create a report score that uses scoring type "Score" and link the subscale you created.
- Confirm that the score range says 10 - 50 (it previously would have said 3.33 - 30)

### ✏️ Notes

N/A
