### PR TITLE
Feature: Add respondent and subject labels to DataViz responses page (M2-7855)

### DIFF
--- a/src/modules/Dashboard/api/api.types.ts
+++ b/src/modules/Dashboard/api/api.types.ts
@@ -602,6 +602,7 @@ export type ActivityAnswer = {
   identifier: string | null;
   createdAt: string;
   endDatetime: string;
+  sourceSubject: RespondentDetails;
 };
 
 export type ActivityHistoryFull = Omit<ExportActivity, 'isPerformanceTask' | 'subscaleSetting'> & {

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.tsx
@@ -261,6 +261,8 @@ export const RespondentDataReview = () => {
     ? activityAnswers?.[0]?.sourceSubject
     : flowAnswers?.[0]?.answers[0].sourceSubject;
 
+  console.log('sourceSubject', activityAnswers);
+
   return (
     <StyledContainer>
       <ReviewMenu

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.tsx
@@ -261,8 +261,6 @@ export const RespondentDataReview = () => {
     ? activityAnswers?.[0]?.sourceSubject
     : flowAnswers?.[0]?.answers[0].sourceSubject;
 
-  console.log('sourceSubject', activityAnswers);
-
   return (
     <StyledContainer>
       <ReviewMenu

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.tsx
@@ -251,6 +251,9 @@ export const RespondentDataReview = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [lastActivityCompleted]);
 
+  const sourceSubject =
+    activityAnswers?.[0]?.sourceSubject || flowAnswers?.[0]?.answers[0].sourceSubject;
+
   return (
     <StyledContainer>
       <ReviewMenu
@@ -296,8 +299,12 @@ export const RespondentDataReview = () => {
           />
           {!isLoading && (
             <>
-              {selectedAnswer && responsesSummary && !error && (
-                <ResponsesSummary {...responsesSummary} data-testid={dataTestid} />
+              {selectedAnswer && responsesSummary && sourceSubject && !error && (
+                <ResponsesSummary
+                  {...responsesSummary}
+                  sourceSubject={sourceSubject}
+                  data-testid={dataTestid}
+                />
               )}
               <EmptyResponses
                 hasAnswers={hasAnswers}

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.tsx
@@ -251,8 +251,9 @@ export const RespondentDataReview = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [lastActivityCompleted]);
 
-  const sourceSubject =
-    activityAnswers?.[0]?.sourceSubject || flowAnswers?.[0]?.answers[0].sourceSubject;
+  const sourceSubject = hasActivityResponses
+    ? activityAnswers?.[0]?.sourceSubject
+    : flowAnswers?.[0]?.answers[0].sourceSubject;
 
   return (
     <StyledContainer>

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.tsx
@@ -23,6 +23,7 @@ import { useAsync } from 'shared/hooks';
 import { StyledContainer, theme } from 'shared/styles';
 import { users } from 'redux/modules';
 import { page } from 'resources';
+import { RespondentDetails } from 'modules/Dashboard/types';
 
 import { Feedback } from './Feedback';
 import { ActivityResponses } from './ActivityResponses';
@@ -305,10 +306,10 @@ export const RespondentDataReview = () => {
           />
           {!isLoading && (
             <>
-              {selectedAnswer && responsesSummary && !!sourceSubject && !error && (
+              {selectedAnswer && responsesSummary && !error && (
                 <ResponsesSummary
                   {...responsesSummary}
-                  sourceSubject={sourceSubject}
+                  sourceSubject={sourceSubject as RespondentDetails}
                   data-testid={dataTestid}
                 />
               )}

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.tsx
@@ -251,6 +251,11 @@ export const RespondentDataReview = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [lastActivityCompleted]);
 
+  /**
+   * Determines the source subject based on the presence of activity responses.
+   * If activity responses are available, it retrieves the source subject from the first activity answer.
+   * Otherwise, it retrieves the source subject from the first flow answer.
+   */
   const sourceSubject = hasActivityResponses
     ? activityAnswers?.[0]?.sourceSubject
     : flowAnswers?.[0]?.answers[0].sourceSubject;

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.tsx
@@ -299,7 +299,7 @@ export const RespondentDataReview = () => {
           />
           {!isLoading && (
             <>
-              {selectedAnswer && responsesSummary && sourceSubject && !error && (
+              {selectedAnswer && responsesSummary && !error && (
                 <ResponsesSummary
                   {...responsesSummary}
                   sourceSubject={sourceSubject}

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.tsx
@@ -305,7 +305,7 @@ export const RespondentDataReview = () => {
           />
           {!isLoading && (
             <>
-              {selectedAnswer && responsesSummary && !error && (
+              {selectedAnswer && responsesSummary && !!sourceSubject && !error && (
                 <ResponsesSummary
                   {...responsesSummary}
                   sourceSubject={sourceSubject}

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.tsx
@@ -23,7 +23,6 @@ import { useAsync } from 'shared/hooks';
 import { StyledContainer, theme } from 'shared/styles';
 import { users } from 'redux/modules';
 import { page } from 'resources';
-import { RespondentDetails } from 'modules/Dashboard/types';
 
 import { Feedback } from './Feedback';
 import { ActivityResponses } from './ActivityResponses';
@@ -309,7 +308,7 @@ export const RespondentDataReview = () => {
               {selectedAnswer && responsesSummary && !error && (
                 <ResponsesSummary
                   {...responsesSummary}
-                  sourceSubject={sourceSubject as RespondentDetails}
+                  sourceSubject={sourceSubject}
                   data-testid={dataTestid}
                 />
               )}

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.hooks.test.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.hooks.test.ts
@@ -1,6 +1,16 @@
+import { renderHook } from '@testing-library/react';
+import * as routerDom from 'react-router-dom';
+
 import { renderHookWithProviders } from 'shared/utils/renderHookWithProviders';
+import { useRespondentLabel } from 'shared/hooks';
+import { users } from 'redux/modules';
 
 import { useResponsesSummary } from './ResponsesSummary.hooks';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: jest.fn(),
+}));
 
 describe('useResponsesSummary', () => {
   const endDatetime = '2024-04-10T10:00:00';
@@ -9,6 +19,17 @@ describe('useResponsesSummary', () => {
   const version = '1.0';
 
   test('should return a correct array with review description objects', () => {
+    jest.spyOn(routerDom, 'useParams').mockReturnValue({ respondentId: '123' });
+    const res = {
+      secretUserId: 'secret123',
+      nickname: '',
+    };
+
+    users.useRespondent = jest.fn().mockReturnValue({ result: res });
+    users.useSubject = jest.fn().mockReturnValue({ details: undefined });
+
+    const { result: respondent } = renderHook(() => useRespondentLabel({ hideLabel: true }));
+
     const { result } = renderHookWithProviders(() =>
       useResponsesSummary({ endDatetime, createdAt, identifier, version }),
     );
@@ -21,11 +42,16 @@ describe('useResponsesSummary', () => {
       },
       {
         id: 'review-desc-2',
+        title: 'Respondent:',
+        content: respondent.current,
+      },
+      {
+        id: 'review-desc-3',
         title: 'Response Identifier:',
         content: identifier,
       },
       {
-        id: 'review-desc-3',
+        id: 'review-desc-4',
         title: 'Version:',
         content: version,
       },

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.hooks.test.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.hooks.test.ts
@@ -1,9 +1,8 @@
-import { renderHook } from '@testing-library/react';
 import * as routerDom from 'react-router-dom';
 
 import { renderHookWithProviders } from 'shared/utils/renderHookWithProviders';
-import { useRespondentLabel } from 'shared/hooks';
 import { users } from 'redux/modules';
+import { getRespondentName } from 'shared/utils';
 
 import { useResponsesSummary } from './ResponsesSummary.hooks';
 
@@ -22,16 +21,21 @@ describe('useResponsesSummary', () => {
     jest.spyOn(routerDom, 'useParams').mockReturnValue({ respondentId: '123' });
     const res = {
       secretUserId: 'secret123',
-      nickname: '',
+      nickname: 'John Doe',
+      firstName: 'John',
+      lastName: 'Doe',
+      id: '123',
+      lastSeen: '2024-04-10T10:00:00',
+      userId: '123',
     };
 
     users.useRespondent = jest.fn().mockReturnValue({ result: res });
     users.useSubject = jest.fn().mockReturnValue({ details: undefined });
 
-    const { result: respondent } = renderHook(() => useRespondentLabel({ hideLabel: true }));
+    const respondent = res?.nickname ? getRespondentName(res.secretUserId, res.nickname) : '';
 
     const { result } = renderHookWithProviders(() =>
-      useResponsesSummary({ endDatetime, createdAt, identifier, version }),
+      useResponsesSummary({ endDatetime, createdAt, identifier, version, sourceSubject: res }),
     );
 
     expect(result.current).toEqual([
@@ -43,7 +47,7 @@ describe('useResponsesSummary', () => {
       {
         id: 'review-desc-2',
         title: 'Respondent:',
-        content: respondent.current,
+        content: respondent,
       },
       {
         id: 'review-desc-3',

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.hooks.test.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.hooks.test.ts
@@ -32,7 +32,9 @@ describe('useResponsesSummary', () => {
     users.useRespondent = jest.fn().mockReturnValue({ result: res });
     users.useSubject = jest.fn().mockReturnValue({ details: undefined });
 
-    const respondent = res?.nickname ? getRespondentName(res.secretUserId, res.nickname) : '';
+    const respondent = res?.nickname
+      ? getRespondentName(res.secretUserId, res.nickname, 'comma')
+      : '';
 
     const { result } = renderHookWithProviders(() =>
       useResponsesSummary({ endDatetime, createdAt, identifier, version, sourceSubject: res }),

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.hooks.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.hooks.ts
@@ -20,7 +20,8 @@ export const useResponsesSummary = ({
     DateFormats.MonthDayYearTimeSeconds,
   );
 
-  const respondent = getRespondentName(sourceSubject?.secretUserId, sourceSubject?.nickname);
+  const respondent =
+    sourceSubject && getRespondentName(sourceSubject.secretUserId, sourceSubject.nickname, 'comma');
 
   return [
     {

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.hooks.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.hooks.ts
@@ -11,6 +11,7 @@ export const useResponsesSummary = ({
   endDatetime,
   createdAt,
   identifier,
+  sourceSubject,
   version,
 }: Omit<ResponsesSummaryProps, 'data-testid'>) => {
   const { t } = useTranslation();
@@ -19,7 +20,7 @@ export const useResponsesSummary = ({
     DateFormats.MonthDayYearTimeSeconds,
   );
 
-  const respondent = useRespondentLabel({ hideLabel: true });
+  const respondent = useRespondentLabel({ hideLabel: true, sourceSubject });
 
   return [
     {

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.hooks.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.hooks.ts
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { format } from 'date-fns';
 
 import { DateFormats } from 'shared/consts';
+import { useRespondentLabel } from 'shared/hooks';
 
 import { ResponsesSummaryProps } from './ResponsesSummary.types';
 import { EMPTY_IDENTIFIER } from './ResponsesSummary.const';
@@ -18,6 +19,8 @@ export const useResponsesSummary = ({
     DateFormats.MonthDayYearTimeSeconds,
   );
 
+  const respondent = useRespondentLabel({ hideLabel: true });
+
   return [
     {
       id: 'review-desc-1',
@@ -26,11 +29,16 @@ export const useResponsesSummary = ({
     },
     {
       id: 'review-desc-2',
+      title: t('respondentIdentifierWithColon'),
+      content: respondent,
+    },
+    {
+      id: 'review-desc-3',
       title: t('responseIdentifierWithColon'),
       content: identifier ?? EMPTY_IDENTIFIER,
     },
     {
-      id: 'review-desc-3',
+      id: 'review-desc-4',
       title: t('versionWithColon'),
       content: version,
     },

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.hooks.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.hooks.ts
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { format } from 'date-fns';
 
 import { DateFormats } from 'shared/consts';
-import { useRespondentLabel } from 'shared/hooks';
+import { getRespondentName } from 'shared/utils';
 
 import { ResponsesSummaryProps } from './ResponsesSummary.types';
 import { EMPTY_IDENTIFIER } from './ResponsesSummary.const';
@@ -20,7 +20,7 @@ export const useResponsesSummary = ({
     DateFormats.MonthDayYearTimeSeconds,
   );
 
-  const respondent = useRespondentLabel({ hideLabel: true, sourceSubject });
+  const respondent = getRespondentName(sourceSubject.secretUserId, sourceSubject.nickname);
 
   return [
     {

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.hooks.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.hooks.ts
@@ -20,7 +20,7 @@ export const useResponsesSummary = ({
     DateFormats.MonthDayYearTimeSeconds,
   );
 
-  const respondent = getRespondentName(sourceSubject.secretUserId, sourceSubject.nickname);
+  const respondent = getRespondentName(sourceSubject?.secretUserId, sourceSubject?.nickname);
 
   return [
     {

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from '@testing-library/react';
 
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
+import { getRespondentName } from 'shared/utils';
 
 import { ResponsesSummary } from './ResponsesSummary';
 import { ResponsesSummaryProps } from './ResponsesSummary.types';
@@ -38,6 +39,12 @@ describe('Responses Summary', () => {
     expect(screen.getByTestId('review-description')).toBeInTheDocument();
     expect(screen.getByText('Viewing responses submitted on:')).toBeInTheDocument();
     expect(screen.getByText('Mar 14, 2024 14:33:48')).toBeInTheDocument();
+    expect(screen.getByText('Respondent:')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        getRespondentName(sourceSubject.secretUserId, sourceSubject.nickname, 'comma'),
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByText('Response Identifier:')).toBeInTheDocument();
     expect(screen.getByText(mockedIdentifier)).toBeInTheDocument();
     expect(screen.queryByText(EMPTY_IDENTIFIER)).not.toBeInTheDocument();

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.test.tsx
@@ -9,6 +9,15 @@ import { EMPTY_IDENTIFIER } from './ResponsesSummary.const';
 const dataTestId = 'review';
 const mockedIdentifier = 'ident-1';
 const mockedVersion = 'version-111.0.25';
+const sourceSubject = {
+  secretUserId: 'secret123',
+  nickname: 'John Doe',
+  firstName: 'John',
+  lastName: 'Doe',
+  id: '123',
+  lastSeen: '2024-04-10T10:00:00',
+  userId: '123',
+};
 const renderComponent = (props?: Partial<ResponsesSummaryProps>) =>
   renderWithProviders(
     <ResponsesSummary
@@ -17,6 +26,7 @@ const renderComponent = (props?: Partial<ResponsesSummaryProps>) =>
       identifier={mockedIdentifier}
       version={mockedVersion}
       data-testid={dataTestId}
+      sourceSubject={sourceSubject}
       {...props}
     />,
   );

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.tsx
@@ -1,6 +1,6 @@
 import { Grid } from '@mui/material';
 
-import { StyledBodyLarge, StyledTitleSmall } from 'shared/styles';
+import { StyledBodyLarge, StyledTitleBoldSmall } from 'shared/styles';
 
 import { ResponsesSummaryProps } from './ResponsesSummary.types';
 import { StyledSummary } from './ResponsesSummary.styles';
@@ -17,7 +17,7 @@ export const ResponsesSummary = ({
       <Grid container columns={4} spacing={2.4}>
         {reviewDescription.map(({ id, title, content }) => (
           <Grid key={id} item xs={1}>
-            <StyledTitleSmall fontWeight="bold">{title}</StyledTitleSmall>
+            <StyledTitleBoldSmall>{title}</StyledTitleBoldSmall>
             <StyledBodyLarge>{content}</StyledBodyLarge>
           </Grid>
         ))}

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.tsx
@@ -14,13 +14,25 @@ export const ResponsesSummary = ({
 
   return (
     <StyledSummary data-testid={`${dataTestid}-description`}>
-      <Grid container columns={3} spacing={2.4}>
+      <Grid container columns={4} spacing={2.4}>
         {reviewDescription.map(({ id, title, content }) => (
           <Grid key={id} item xs={1}>
-            <StyledTitleMedium sx={{ color: variables.palette.on_surface_variant }}>
+            <StyledTitleMedium
+              sx={{
+                color: variables.palette.on_surface_variant,
+                fontWeight: variables.font.weight.bold,
+                fontSize: variables.font.size.sm,
+              }}
+            >
               {title}
             </StyledTitleMedium>
-            <StyledTitleBoldMedium sx={{ color: variables.palette.on_surface_variant }}>
+            <StyledTitleBoldMedium
+              sx={{
+                color: variables.palette.on_surface_variant,
+                fontWeight: variables.font.weight.regular,
+                fontSize: variables.font.size.md,
+              }}
+            >
               {content}
             </StyledTitleBoldMedium>
           </Grid>

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.tsx
@@ -1,6 +1,6 @@
 import { Grid } from '@mui/material';
 
-import { StyledTitleBoldMedium, StyledTitleMedium, variables } from 'shared/styles';
+import { StyledBodyLarge, StyledTitleSmall } from 'shared/styles';
 
 import { ResponsesSummaryProps } from './ResponsesSummary.types';
 import { StyledSummary } from './ResponsesSummary.styles';
@@ -17,24 +17,8 @@ export const ResponsesSummary = ({
       <Grid container columns={4} spacing={2.4}>
         {reviewDescription.map(({ id, title, content }) => (
           <Grid key={id} item xs={1}>
-            <StyledTitleMedium
-              sx={{
-                color: variables.palette.on_surface_variant,
-                fontWeight: variables.font.weight.bold,
-                fontSize: variables.font.size.sm,
-              }}
-            >
-              {title}
-            </StyledTitleMedium>
-            <StyledTitleBoldMedium
-              sx={{
-                color: variables.palette.on_surface_variant,
-                fontWeight: variables.font.weight.regular,
-                fontSize: variables.font.size.md,
-              }}
-            >
-              {content}
-            </StyledTitleBoldMedium>
+            <StyledTitleSmall fontWeight="bold">{title}</StyledTitleSmall>
+            <StyledBodyLarge>{content}</StyledBodyLarge>
           </Grid>
         ))}
       </Grid>

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.types.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.types.ts
@@ -1,5 +1,8 @@
+import { RespondentDetails } from 'modules/Dashboard/types';
+
 import { ResponsesSummary } from '../RespondentDataReview.types';
 
 export type ResponsesSummaryProps = ResponsesSummary & {
   'data-testid': string;
+  sourceSubject?: RespondentDetails;
 };

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.types.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.types.ts
@@ -4,5 +4,5 @@ import { ResponsesSummary } from '../RespondentDataReview.types';
 
 export type ResponsesSummaryProps = ResponsesSummary & {
   'data-testid': string;
-  sourceSubject?: RespondentDetails;
+  sourceSubject: RespondentDetails;
 };

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.types.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.types.ts
@@ -4,5 +4,5 @@ import { ResponsesSummary } from '../RespondentDataReview.types';
 
 export type ResponsesSummaryProps = ResponsesSummary & {
   'data-testid': string;
-  sourceSubject: RespondentDetails;
+  sourceSubject?: RespondentDetails;
 };

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewMenu/ReviewMenu.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewMenu/ReviewMenu.test.tsx
@@ -149,7 +149,7 @@ describe('ReviewMenu', () => {
     expect(screen.getByText('Responses')).toBeInTheDocument();
     expectReviewDateActivity(true);
     expect(
-      screen.getByText('Subject: 3921968c-3903-4872-8f30-a6e6a10cef36 (Mocked Respondent)'),
+      screen.getByText('Subject: 3921968c-3903-4872-8f30-a6e6a10cef36, Mocked Respondent'),
     ).toBeInTheDocument();
 
     const activityLength = screen.queryAllByTestId(/respondents-review-menu-activity-\d+-select$/);

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewMenu/ReviewMenu.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewMenu/ReviewMenu.test.tsx
@@ -149,7 +149,7 @@ describe('ReviewMenu', () => {
     expect(screen.getByText('Responses')).toBeInTheDocument();
     expectReviewDateActivity(true);
     expect(
-      screen.getByText('Respondent: 3921968c-3903-4872-8f30-a6e6a10cef36 (Mocked Respondent)'),
+      screen.getByText('Subject: 3921968c-3903-4872-8f30-a6e6a10cef36 (Mocked Respondent)'),
     ).toBeInTheDocument();
 
     const activityLength = screen.queryAllByTestId(/respondents-review-menu-activity-\d+-select$/);

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewMenu/ReviewMenu.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewMenu/ReviewMenu.tsx
@@ -30,7 +30,7 @@ export const ReviewMenu = ({
 }: ReviewMenuProps) => {
   const { t } = useTranslation();
   const { activityId, activityFlowId } = useParams();
-  const respondentLabel = useRespondentLabel({ isSubject: true });
+  const respondentLabel = useRespondentLabel({ isSubject: true, variant: 'comma' });
 
   const dataTestid = 'respondents-review-menu';
 

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewMenu/ReviewMenu.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewMenu/ReviewMenu.tsx
@@ -4,7 +4,7 @@ import { Box } from '@mui/material';
 
 import { DatePicker, DatePickerUiType, Spinner, SpinnerUiType } from 'shared/components';
 import { useRespondentLabel } from 'shared/hooks';
-import { StyledHeadlineLarge, StyledLabelLarge, theme } from 'shared/styles';
+import { StyledBodyMedium, StyledHeadlineLarge, theme } from 'shared/styles';
 
 import { StyledMenu } from '../../RespondentData.styles';
 import { StyledHeader } from './ReviewMenu.styles';
@@ -38,9 +38,9 @@ export const ReviewMenu = ({
     <StyledMenu data-testid={dataTestid}>
       <StyledHeader>
         <StyledHeadlineLarge>{t('responses')}</StyledHeadlineLarge>
-        <StyledLabelLarge sx={{ marginBottom: theme.spacing(4) }}>
+        <StyledBodyMedium sx={{ marginBottom: theme.spacing(4) }}>
           {respondentLabel}
-        </StyledLabelLarge>
+        </StyledBodyMedium>
         <DatePicker
           name="responseDate"
           control={control}

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/ReportMenu/StickyHeader/StickyHeader.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/ReportMenu/StickyHeader/StickyHeader.test.tsx
@@ -52,7 +52,7 @@ describe('StickyHeader', () => {
     );
 
     const description = getByText(
-      'Respondent: b60a142d-2b7f-4328-841c-dbhjhj4afcf1c7 (Mocked Respondent)',
+      'Subject: b60a142d-2b7f-4328-841c-dbhjhj4afcf1c7 (Mocked Respondent)',
     );
     expect(description).toBeInTheDocument();
     expect(description).toHaveStyle({ position: 'relative', padding: 0 });

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -1023,6 +1023,8 @@
   "noResponseIdentifier": "No response identifier yet.",
   "viewingResponsesSubmitted": "Viewing responses submitted on:",
   "responseIdentifierWithColon": "Response Identifier:",
+  "respondentIdentifierWithColon": "Respondent:",
+  "subjectIdentifierWithColon": "Subject:",
   "versionWithColon": "Version:",
   "noRespondents": "No Respondents yet.",
   "noParticipants": "No Participants yet.",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -1022,6 +1022,8 @@
   "noResponseIdentifier": "Aucun identifiant de réponse pour le moment.",
   "viewingResponsesSubmitted": "Consultation des réponses soumises le :",
   "responseIdentifierWithColon": "Identifiant de réponse :",
+  "respondentIdentifierWithColon": "Intimé :",
+  "subjectIdentifierWithColon": "Sujet :",
   "versionWithColon": "Version :",
   "noRespondents": "Pas encore de participants.",
   "noParticipants": "Aucun participant pour l'instant.",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -1022,7 +1022,7 @@
   "noResponseIdentifier": "Aucun identifiant de réponse pour le moment.",
   "viewingResponsesSubmitted": "Consultation des réponses soumises le :",
   "responseIdentifierWithColon": "Identifiant de réponse :",
-  "respondentIdentifierWithColon": "Intimé :",
+  "respondentIdentifierWithColon": "Répondant :",
   "subjectIdentifierWithColon": "Sujet :",
   "versionWithColon": "Version :",
   "noRespondents": "Pas encore de participants.",

--- a/src/shared/hooks/useRespondentLabel.test.ts
+++ b/src/shared/hooks/useRespondentLabel.test.ts
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react';
 import * as routerDom from 'react-router-dom';
 
 import { users } from 'redux/modules';
+import { getRespondentName } from 'shared/utils';
 
 import { useRespondentLabel } from './useRespondentLabel';
 
@@ -80,12 +81,17 @@ describe('useRespondentLabel', () => {
     const res = {
       secretUserId: 'secret123',
       nickname: 'John Doe',
+      firstName: 'John',
+      lastName: 'Doe',
+      id: '123',
+      lastSeen: '2024-04-10T10:00:00',
+      userId: '123',
     };
 
     users.useRespondent = jest.fn().mockReturnValue({ result: res });
     users.useSubject = jest.fn().mockReturnValue({ details: undefined });
 
-    const { result } = renderHook(() => useRespondentLabel({ hideLabel: true }));
+    const { result } = renderHook(() => getRespondentName(res.secretUserId, res.nickname));
 
     expect(result.current).toBe('secret123 (John Doe)');
   });

--- a/src/shared/hooks/useRespondentLabel.test.ts
+++ b/src/shared/hooks/useRespondentLabel.test.ts
@@ -46,7 +46,7 @@ describe('useRespondentLabel', () => {
     expect(result.current).toBe('Respondent: secret123');
   });
 
-  test('should construct and return the respondent label correctly for subject (User: secret123)', () => {
+  test('should construct and return the subject label correctly for subject (User: secret123)', () => {
     jest.spyOn(routerDom, 'useParams').mockReturnValue({ respondentId: '123' });
     const res = {
       secretUserId: 'subject123',
@@ -58,7 +58,7 @@ describe('useRespondentLabel', () => {
 
     const { result } = renderHook(() => useRespondentLabel({ isSubject: true }));
 
-    expect(result.current).toBe('Respondent: subject123');
+    expect(result.current).toBe('Subject: subject123');
   });
 
   test('should construct and return the respondent label correctly (User: secret123 (John Doe))', () => {
@@ -73,5 +73,20 @@ describe('useRespondentLabel', () => {
     const { result } = renderHook(useRespondentLabel);
 
     expect(result.current).toBe('Respondent: secret123 (John Doe)');
+  });
+
+  test('should construct and return the respondent without the label (secret123 (John Doe))', () => {
+    jest.spyOn(routerDom, 'useParams').mockReturnValue({ respondentId: '123' });
+    const res = {
+      secretUserId: 'secret123',
+      nickname: 'John Doe',
+    };
+
+    users.useRespondent = jest.fn().mockReturnValue({ result: res });
+    users.useSubject = jest.fn().mockReturnValue({ details: undefined });
+
+    const { result } = renderHook(() => useRespondentLabel({ hideLabel: true }));
+
+    expect(result.current).toBe('secret123 (John Doe)');
   });
 });

--- a/src/shared/hooks/useRespondentLabel.ts
+++ b/src/shared/hooks/useRespondentLabel.ts
@@ -25,5 +25,8 @@ export const useRespondentLabel = (
   if (!secretUserId) return '';
   if (parameters.hideNickname) return secretUserId;
 
-  return `${t('respondent')}: ${getRespondentName(secretUserId, nickname)}`;
+  return `${t(parameters.isSubject ? 'Subject' : 'respondent')}: ${getRespondentName(
+    secretUserId,
+    nickname,
+  )}`;
 };

--- a/src/shared/hooks/useRespondentLabel.ts
+++ b/src/shared/hooks/useRespondentLabel.ts
@@ -1,41 +1,34 @@
 import { useTranslation } from 'react-i18next';
 
-import { RespondentDetails } from 'modules/Dashboard/types';
 import { users } from 'redux/modules';
 import { getRespondentName } from 'shared/utils';
 
 type Parameters = {
   isSubject?: boolean;
   hideNickname?: boolean;
-  hideLabel?: boolean;
-  sourceSubject?: RespondentDetails | null;
 };
 
 export const useRespondentLabel = (
   parameters: Parameters = {
     isSubject: false,
     hideNickname: false,
-    hideLabel: false,
-    sourceSubject: null,
   },
 ) => {
   const { t } = useTranslation('app');
   const { useRespondent, useSubject } = users;
   const subjectResult = useSubject();
-  const respondentResult = useRespondent()?.result ?? parameters.sourceSubject;
+  const respondentResult = useRespondent();
 
-  const result = parameters.isSubject ? subjectResult?.result : respondentResult;
+  const result = parameters.isSubject ? subjectResult?.result : respondentResult?.result;
 
   const { secretUserId, nickname } = result || {};
 
   if (!secretUserId) return '';
   if (parameters.hideNickname) return secretUserId;
 
-  const label = !parameters.hideLabel
-    ? `${t(
-        parameters.isSubject ? 'subjectIdentifierWithColon' : 'respondentIdentifierWithColon',
-      )}${' '}`
-    : '';
+  const label = `${t(
+    parameters.isSubject ? 'subjectIdentifierWithColon' : 'respondentIdentifierWithColon',
+  )}${' '}`;
 
   return `${label}${getRespondentName(secretUserId, nickname)}`;
 };

--- a/src/shared/hooks/useRespondentLabel.ts
+++ b/src/shared/hooks/useRespondentLabel.ts
@@ -6,12 +6,14 @@ import { getRespondentName } from 'shared/utils';
 type Parameters = {
   isSubject?: boolean;
   hideNickname?: boolean;
+  hideLabel?: boolean;
 };
 
 export const useRespondentLabel = (
   parameters: Parameters = {
     isSubject: false,
     hideNickname: false,
+    hideLabel: false,
   },
 ) => {
   const { t } = useTranslation('app');
@@ -25,8 +27,11 @@ export const useRespondentLabel = (
   if (!secretUserId) return '';
   if (parameters.hideNickname) return secretUserId;
 
-  return `${t(parameters.isSubject ? 'Subject' : 'respondent')}: ${getRespondentName(
-    secretUserId,
-    nickname,
-  )}`;
+  const label = !parameters.hideLabel
+    ? `${t(
+        parameters.isSubject ? 'subjectIdentifierWithColon' : 'respondentIdentifierWithColon',
+      )}${' '}`
+    : '';
+
+  return `${label}${getRespondentName(secretUserId, nickname)}`;
 };

--- a/src/shared/hooks/useRespondentLabel.ts
+++ b/src/shared/hooks/useRespondentLabel.ts
@@ -6,12 +6,14 @@ import { getRespondentName } from 'shared/utils';
 type Parameters = {
   isSubject?: boolean;
   hideNickname?: boolean;
+  variant?: 'default' | 'comma';
 };
 
 export const useRespondentLabel = (
   parameters: Parameters = {
     isSubject: false,
     hideNickname: false,
+    variant: 'default',
   },
 ) => {
   const { t } = useTranslation('app');
@@ -30,5 +32,5 @@ export const useRespondentLabel = (
     parameters.isSubject ? 'subjectIdentifierWithColon' : 'respondentIdentifierWithColon',
   )}${' '}`;
 
-  return `${label}${getRespondentName(secretUserId, nickname)}`;
+  return `${label}${getRespondentName(secretUserId, nickname, parameters.variant)}`;
 };

--- a/src/shared/hooks/useRespondentLabel.ts
+++ b/src/shared/hooks/useRespondentLabel.ts
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 
+import { RespondentDetails } from 'modules/Dashboard/types';
 import { users } from 'redux/modules';
 import { getRespondentName } from 'shared/utils';
 
@@ -7,6 +8,7 @@ type Parameters = {
   isSubject?: boolean;
   hideNickname?: boolean;
   hideLabel?: boolean;
+  sourceSubject?: RespondentDetails | null;
 };
 
 export const useRespondentLabel = (
@@ -14,14 +16,16 @@ export const useRespondentLabel = (
     isSubject: false,
     hideNickname: false,
     hideLabel: false,
+    sourceSubject: null,
   },
 ) => {
   const { t } = useTranslation('app');
   const { useRespondent, useSubject } = users;
   const subjectResult = useSubject();
-  const respondentResult = useRespondent();
+  const respondentResult = useRespondent()?.result ?? parameters.sourceSubject;
 
-  const result = parameters.isSubject ? subjectResult?.result : respondentResult?.result;
+  const result = parameters.isSubject ? subjectResult?.result : respondentResult;
+
   const { secretUserId, nickname } = result || {};
 
   if (!secretUserId) return '';

--- a/src/shared/styles/styledComponents/Typography.ts
+++ b/src/shared/styles/styledComponents/Typography.ts
@@ -68,7 +68,7 @@ export const StyledTitleMedium = styled(Typography, shouldForwardProp)`
 export const StyledTitleSmall = styled(Typography)`
   font-size: ${variables.font.size.md};
   line-height: ${variables.font.lineHeight.md};
-  font-weight: ${variables.font.weight.regular};
+  font-weight: ${({ fontWeight }: StyledProps) => fontWeight || variables.font.weight.regular};
   color: ${({ color }: StyledProps) => color || variables.palette.on_surface_variant};
   letter-spacing: ${variables.font.letterSpacing.sm};
 `;

--- a/src/shared/utils/getRespondentName.test.ts
+++ b/src/shared/utils/getRespondentName.test.ts
@@ -2,12 +2,16 @@ import { getRespondentName } from './getRespondentName';
 
 describe('getRespondentName', () => {
   test.each`
-    secretId      | nickname      | expected                 | description
-    ${'secretId'} | ${null}       | ${'secretId'}            | ${'should return the secretId when nickname is not provided'}
-    ${'secretId'} | ${'nickname'} | ${'secretId (nickname)'} | ${'should return the secretId with nickname in parentheses when nickname is provided'}
-    ${''}         | ${''}         | ${''}                    | ${'should return an empty string when secretId and nickname are empty strings'}
-    ${''}         | ${'nickname'} | ${'(nickname)'}          | ${'should return the nickname in parentheses when nickname is provided without secretId'}
-  `('$description', ({ secretId, nickname, expected }) => {
-    expect(getRespondentName(secretId, nickname)).toEqual(expected);
+    secretId      | nickname      | variant      | expected                 | description
+    ${'secretId'} | ${null}       | ${'default'} | ${'secretId'}            | ${'using default variant should return the secretId when nickname is not provided'}
+    ${'secretId'} | ${'nickname'} | ${'default'} | ${'secretId (nickname)'} | ${'using default variant should return the secretId with nickname in parentheses when nickname is provided'}
+    ${''}         | ${''}         | ${'default'} | ${''}                    | ${'using default variant should return an empty string when secretId and nickname are empty strings'}
+    ${''}         | ${'nickname'} | ${'default'} | ${'(nickname)'}          | ${'using default variant should return the nickname in parentheses when nickname is provided without secretId'}
+    ${'secretId'} | ${null}       | ${'comma'}   | ${'secretId'}            | ${'using comma variant should return the secretId when nickname is not provided'}
+    ${'secretId'} | ${'nickname'} | ${'comma'}   | ${'secretId, nickname'}  | ${'using comma variant should return the secretId with nickname in parentheses when nickname is provided'}
+    ${''}         | ${''}         | ${'comma'}   | ${''}                    | ${'using comma variant should return an empty string when secretId and nickname are empty strings'}
+    ${''}         | ${'nickname'} | ${'comma'}   | ${'nickname'}            | ${'using comma variant should return the nickname in parentheses when nickname is provided without secretId'}
+  `('$description', ({ secretId, nickname, variant, expected }) => {
+    expect(getRespondentName(secretId, nickname, variant)).toEqual(expected);
   });
 });

--- a/src/shared/utils/getRespondentName.ts
+++ b/src/shared/utils/getRespondentName.ts
@@ -1,2 +1,17 @@
-export const getRespondentName = (secretId: string, nickname?: string | null) =>
-  `${secretId}${nickname ? ` (${nickname})` : ''}`.trim();
+export const getRespondentName = (
+  secretId: string,
+  nickname?: string | null,
+  variant: 'default' | 'comma' = 'default',
+) => {
+  const secretIdString = secretId.trim();
+  let nicknameString = '';
+  if (nickname) {
+    if (variant === 'comma') {
+      nicknameString = secretIdString ? `, ${nickname}` : nickname;
+    } else {
+      nicknameString = ` (${nickname})`;
+    }
+  }
+
+  return `${secretId}${nicknameString}`.trim();
+};


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added
- [ ] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-7855](https://mindlogger.atlassian.net/browse/M2-7855)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Changes include:

- Update to the `useRespondenLabel` hook to add appropriate labels for `subject`, `respondent`, or the users credentials without the label. 
- This also adds additional formatted translations for "subject" and "respondent" both with colons. 
- I've also added a column for displaying the Respondents credential on the DataViz response page. (tbd)

### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
|  <img width="800" alt="Screenshot 2024-11-04 at 13 35 28" src="https://github.com/user-attachments/assets/e44ceb97-1ef4-4153-b27f-022735015692"> | <img width="800" alt="Screenshot 2024-11-04 at 13 36 17" src="https://github.com/user-attachments/assets/7880d669-3443-4f21-a417-350831d06ac3"> |

### 🪤 Peer Testing

<!-- If peer testing is not needed, then delete this section -->
<!-- Uncomment out any of the following as needed:           -->
<!-- **Requires `npm install`**     -->

1. navigate to a users DataViz screen and select the `Responses` tab.
2. confirm that the left Menu displays the Subject with the name and id.
3. confirm that in the activity summary header, there's a "Respondent" column with the respondent for the activity listed below it.
4. do the same for a flow summary.