### PR TITLE
fix: Cascade system item changes to report scores (M2-8146)

### DIFF
--- a/src/modules/Builder/features/ActivitySettings/ScoresAndReports/ScoresAndReports.utils.ts
+++ b/src/modules/Builder/features/ActivitySettings/ScoresAndReports/ScoresAndReports.utils.ts
@@ -59,3 +59,9 @@ export const getTableScoreItems = (items?: ItemFormValues[]) =>
       },
     ];
   }, []);
+
+export const reportIsScore = (report: ScoreOrSection): report is ScoreReport =>
+  report.type === ScoreReportType.Score;
+
+export const reportIsSection = (report: ScoreOrSection): report is SectionReport =>
+  report.type === ScoreReportType.Section;

--- a/src/modules/Builder/features/ActivitySettings/SubscalesConfiguration/SubscalesConfiguration.hooks.ts
+++ b/src/modules/Builder/features/ActivitySettings/SubscalesConfiguration/SubscalesConfiguration.hooks.ts
@@ -216,17 +216,19 @@ export const useLinkedScoreReports = (): UseLinkedScoreReportsReturn => {
    */
   const removeReportScoreLink = useCallback(
     (subscale: ActivitySettingsSubscale<string>) => {
-      linkedScores.forEach((scoreReport, index) => {
-        if (scoreReport.subscaleName === subscale.name) {
+      scoreOrSectionArray.forEach((report, index) => {
+        if (!reportIsScore(report) || !linkedScores.includes(report)) return;
+
+        if (report.subscaleName === subscale.name) {
           const updatedReport: ScoreReport = {
-            ...scoreReport,
+            ...report,
             subscaleName: '',
           };
           updateReport(index, updatedReport);
         }
       });
     },
-    [linkedScores, updateReport],
+    [linkedScores, updateReport, scoreOrSectionArray],
   );
 
   const updateSubscaleNameInReports = useCallback(
@@ -236,17 +238,19 @@ export const useLinkedScoreReports = (): UseLinkedScoreReportsReturn => {
       );
       if (!isEligibleSubscale) return;
 
-      linkedScores.forEach((scoreReport, index) => {
-        if (scoreReport.subscaleName === oldSubscaleName) {
+      scoreOrSectionArray.forEach((report, index) => {
+        if (!reportIsScore(report) || !linkedScores.includes(report)) return;
+
+        if (report.subscaleName === oldSubscaleName) {
           const updatedReport: ScoreReport = {
-            ...scoreReport,
+            ...report,
             subscaleName: newSubscaleName,
           };
           updateReport(index, updatedReport);
         }
       });
     },
-    [eligibleSubscales, linkedScores, updateReport],
+    [eligibleSubscales, linkedScores, updateReport, scoreOrSectionArray],
   );
 
   useEffect(() => {
@@ -254,16 +258,18 @@ export const useLinkedScoreReports = (): UseLinkedScoreReportsReturn => {
       // If there are no more eligible subscales, then these linked scores should be reset to
       // 'raw_score' instead of 'score'. Otherwise, the admin will see an error reported in the UI
       // but there will be nothing to fix when they go back to the reports screen
-      linkedScores.forEach((scoreReport, index) => {
+      scoreOrSectionArray.forEach((report, index) => {
+        if (!reportIsScore(report) || !linkedScores.includes(report)) return;
+
         const updatedReport: ScoreReport = {
-          ...scoreReport,
+          ...report,
           subscaleName: '',
           scoringType: 'raw_score',
         };
         updateReport(index, updatedReport);
       });
     }
-  }, [eligibleSubscales, linkedScores, updateReport]);
+  }, [eligibleSubscales, linkedScores, updateReport, scoreOrSectionArray]);
 
   return { removeReportScoreLink, updateSubscaleNameInReports, hasNonSubscaleItems };
 };


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-8146](https://mindlogger.atlassian.net/browse/M2-8146)

This PR creates logic that cascades changes to activity system items between the subscales configuration and the report configuration.

Whenever a subscale with a lookup table is added to an activity, two non-editable system items are added to the activity (`gender_screen` and `age_screen`). These items then become available for printing in reports. Whenever the subscale lookup table is removed/replaced, these items also get removed and re-added to the activity. Previously if these items were selected for printing, and then subsequently removed/replaced, report items would retain a reference to the older versions of these system items and subsequently throw an error when it fails to find them.

### 📸 Screenshots

N/A

### 🪤 Peer Testing

Create an activity in an empty applet with:
- A single selection item with scores
- A subscale with a lookup table (make sure the age field type is set to Text)
- A report score with score type set to Raw Score, and check all the items to be printed
- Save the applet
- Set the subscale age field type to Dropdown
- Save the applet
- Confirm there are no console errors

### ✏️ Notes

N/A