### PR TITLE
fix: Allow Report Items to Print Number Selection Activity Items (M2-8147)

### DIFF
--- a/src/modules/Builder/features/ActivitySettings/ScoresAndReports/ScoresAndReports.const.ts
+++ b/src/modules/Builder/features/ActivitySettings/ScoresAndReports/ScoresAndReports.const.ts
@@ -3,6 +3,7 @@ import { ItemResponseType } from 'shared/consts';
 export const ItemTypesToPrint = [
   ItemResponseType.SingleSelection,
   ItemResponseType.MultipleSelection,
+  ItemResponseType.NumberSelection,
   ItemResponseType.Slider,
   ItemResponseType.Text,
   ItemResponseType.ParagraphText,


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-8147](https://mindlogger.atlassian.net/browse/M2-8147)

> [!NOTE]
> - Requires https://github.com/ChildMindInstitute/mindlogger-backend-refactor/pull/1644

This PR updates the list of item types allowed to be printed on a report section or score to include number selection. This is necessary because the `age_screen` system item may now be of type number selection when "Dropdown" is selected.

### 📸 Screenshots

<img width="360" alt="image" src="https://github.com/user-attachments/assets/c6db9c9d-ca3f-400a-afbb-bd56a0899b4a">

<img width="360" alt="image" src="https://github.com/user-attachments/assets/3dbdcdbd-95e0-4c83-ab43-59b738ff57b1">

### 🪤 Peer Testing

Create an activity in an empty applet with:
- A single selection item with scores
- A subscale with a lookup table (make sure the age field type is set to Text)
- A report score with score type set to Raw Score.
- In the report score, check all the items to be printed and confirm the presence of the `age_screen` item.
- Create a score condition in the report score and check all the items to be printed within the score condition. Confirm the presence of the `age_screen` item here as well.
- Save the applet
- Set the subscale age field type to Dropdown
- Reconfirm the presence of the `age_screen` item in both places in the report score and that they are still checked

### ✏️ Notes

N/A
