### PR TITLE
fix: Exclude pending accounts from Take Now & Assign (M2-8035)

### DIFF
--- a/src/modules/Dashboard/components/ParticipantDropdown/ParticipantDropdown.hooks.ts
+++ b/src/modules/Dashboard/components/ParticipantDropdown/ParticipantDropdown.hooks.ts
@@ -4,7 +4,7 @@ import { DEFAULT_ROWS_PER_PAGE, Roles } from 'shared/consts';
 import { ParticipantsData } from 'modules/Dashboard/features/Participants';
 import { getWorkspaceManagersApi, getWorkspaceRespondentsApi } from 'api';
 import { useAsync } from 'shared/hooks';
-import { Manager, Respondent } from 'modules/Dashboard/types';
+import { Manager, Respondent, RespondentStatus } from 'modules/Dashboard/types';
 import { auth, workspaces } from 'redux/modules';
 
 import {
@@ -23,6 +23,7 @@ const ALLOWED_TEAM_MEMBER_ROLES: readonly Roles[] = [
 
 export const useParticipantDropdown = ({
   appletId,
+  includePendingAccounts = false,
   skip = false,
   successCallback,
   errorCallback,
@@ -41,7 +42,11 @@ export const useParticipantDropdown = ({
     (response) => {
       if (response?.data) {
         const options = (response.data as ParticipantsData).result
-          .filter((r) => !r.isAnonymousRespondent)
+          .filter(
+            (r) =>
+              !r.isAnonymousRespondent &&
+              (includePendingAccounts || r.status !== RespondentStatus.Pending),
+          )
           .map(participantToOption);
 
         setAllParticipants(options);

--- a/src/modules/Dashboard/components/ParticipantDropdown/ParticipantDropdown.types.ts
+++ b/src/modules/Dashboard/components/ParticipantDropdown/ParticipantDropdown.types.ts
@@ -41,6 +41,7 @@ export type FullTeamSearchType = 'team' | 'full-participant';
 
 export type UseParticipantDropdownProps = {
   appletId?: string;
+  includePendingAccounts?: boolean;
   skip?: boolean;
   successCallback?: (data: AxiosResponse) => void;
   errorCallback?: (data?: AxiosError<ApiErrorResponse> | null) => void;

--- a/src/modules/Dashboard/features/Applet/Overview/Overview.utils.tsx
+++ b/src/modules/Dashboard/features/Applet/Overview/Overview.utils.tsx
@@ -100,6 +100,7 @@ export function mapResponseToSubmissionsTableProps(
               };
 
               return {
+                rowState: { value: 'has-hover' },
                 activity: {
                   onClick: handleClick,
                   content: () => <StyledMaybeEmpty>{activityName}</StyledMaybeEmpty>,

--- a/src/modules/Dashboard/features/Applets/AppletsTable/AppletItem/AppletItem.test.tsx
+++ b/src/modules/Dashboard/features/Applets/AppletsTable/AppletItem/AppletItem.test.tsx
@@ -203,8 +203,8 @@ describe('AppletItem component tests', () => {
     const tableRow = await findByTestId('dashboard-applets-table-applet-row');
 
     expect(tableRow).toBeInTheDocument();
-    expect(tableRow).toHaveClass('has-hover');
-    expect(tableRow).not.toHaveClass('dragged-over');
+    expect(tableRow).toHaveClass('MuiTableRow-has-hover');
+    expect(tableRow).not.toHaveClass('MuiTableRow-dragged-over');
 
     jest.spyOn(appletsTableHooks, 'useAppletsDnd').mockReturnValue({
       isDragOver: true,
@@ -213,6 +213,6 @@ describe('AppletItem component tests', () => {
 
     rerender(getAppletItemComponent());
 
-    expect(tableRow).toHaveClass('has-hover dragged-over');
+    expect(tableRow).toHaveClass('MuiTableRow-has-hover MuiTableRow-dragged-over');
   });
 });

--- a/src/modules/Dashboard/features/Applets/AppletsTable/AppletsTable.styles.ts
+++ b/src/modules/Dashboard/features/Applets/AppletsTable/AppletsTable.styles.ts
@@ -2,7 +2,6 @@ import { Box, styled, TableCell, TableContainer } from '@mui/material';
 
 import { variables, StyledFlexTopCenter } from 'shared/styles';
 import { shouldForwardProp } from 'shared/utils/shouldForwardProp';
-import { tableRowHoverColor } from 'shared/utils/colors';
 
 export const StyledTableContainer = styled(TableContainer)`
   display: flex;
@@ -21,33 +20,6 @@ export const StyledTableContainer = styled(TableContainer)`
 
   .MuiTableCell-head {
     background: ${variables.palette.surface};
-  }
-
-  && .MuiTableRow-root.has-hover {
-    cursor: pointer;
-
-    &:hover {
-      background-color: ${tableRowHoverColor};
-    }
-  }
-
-  && .MuiTableRow-root.dragged-over {
-    .MuiTableCell-body {
-      border-top: ${variables.borderWidth.lg} solid ${variables.palette.primary};
-      border-bottom: ${variables.borderWidth.lg} solid ${variables.palette.primary};
-    }
-
-    .MuiTableCell-body:first-of-type {
-      border-left: ${variables.borderWidth.lg} solid ${variables.palette.primary};
-      border-top-left-radius: ${variables.borderRadius.xs} ${variables.borderRadius.xs};
-      border-bottom-left-radius: ${variables.borderRadius.xs} ${variables.borderRadius.xs};
-    }
-
-    .MuiTableCell-body:last-of-type {
-      border-right: ${variables.borderWidth.lg} solid ${variables.palette.primary};
-      border-top-right-radius: ${variables.borderRadius.xs} ${variables.borderRadius.xs};
-      border-bottom-right-radius: ${variables.borderRadius.xs} ${variables.borderRadius.xs};
-    }
   }
 `;
 

--- a/src/modules/Dashboard/features/Applets/AppletsTable/AppletsTable.utils.test.ts
+++ b/src/modules/Dashboard/features/Applets/AppletsTable/AppletsTable.utils.test.ts
@@ -2,9 +2,9 @@ import { getTableRowClassNames } from './AppletsTable.utils';
 
 describe('getTableRowClassNames', () => {
   test.each([
-    [{ hasHover: true, isDragOver: true }, 'dragged-over has-hover'],
-    [{ hasHover: true, isDragOver: false }, 'has-hover'],
-    [{ hasHover: false, isDragOver: true }, 'dragged-over'],
+    [{ hasHover: true, isDragOver: true }, 'MuiTableRow-dragged-over MuiTableRow-has-hover'],
+    [{ hasHover: true, isDragOver: false }, 'MuiTableRow-has-hover'],
+    [{ hasHover: false, isDragOver: true }, 'MuiTableRow-dragged-over'],
     [{ hasHover: false, isDragOver: false }, ''],
   ])('should return correct class names', (input, expected) => {
     expect(getTableRowClassNames(input)).toBe(expected);

--- a/src/modules/Dashboard/features/Applets/AppletsTable/AppletsTable.utils.ts
+++ b/src/modules/Dashboard/features/Applets/AppletsTable/AppletsTable.utils.ts
@@ -1,7 +1,10 @@
 import { GetTableRowClassNames } from './AppletsTable.types';
 
 export const getTableRowClassNames = ({ hasHover, isDragOver }: GetTableRowClassNames) => {
-  const classNames = [isDragOver && 'dragged-over', hasHover && 'has-hover'].filter(Boolean);
+  const classNames = [
+    isDragOver && 'MuiTableRow-dragged-over',
+    hasHover && 'MuiTableRow-has-hover',
+  ].filter(Boolean);
 
   return classNames.join(' ');
 };

--- a/src/modules/Dashboard/features/Applets/AppletsTable/FolderItem/FolderItem.test.tsx
+++ b/src/modules/Dashboard/features/Applets/AppletsTable/FolderItem/FolderItem.test.tsx
@@ -233,8 +233,8 @@ describe('FolderItem component tests', () => {
     const tableRow = await findByTestId('dashboard-applets-table-folder-row');
 
     expect(tableRow).toBeInTheDocument();
-    expect(tableRow).toHaveClass('has-hover');
-    expect(tableRow).not.toHaveClass('dragged-over');
+    expect(tableRow).toHaveClass('MuiTableRow-has-hover');
+    expect(tableRow).not.toHaveClass('MuiTableRow-dragged-over');
 
     jest.spyOn(appletsTableHooks, 'useAppletsDnd').mockReturnValue({
       isDragOver: true,
@@ -243,7 +243,7 @@ describe('FolderItem component tests', () => {
 
     rerender(getFolderItemComponent(false));
 
-    expect(tableRow).toHaveClass('has-hover dragged-over');
+    expect(tableRow).toHaveClass('MuiTableRow-has-hover MuiTableRow-dragged-over');
   });
 
   test('should not have classname for hover if folder is empty', async () => {
@@ -256,6 +256,6 @@ describe('FolderItem component tests', () => {
     const tableRow = await findByTestId('dashboard-applets-table-folder-row');
 
     expect(tableRow).toBeInTheDocument();
-    expect(tableRow).not.toHaveClass('has-hover');
+    expect(tableRow).not.toHaveClass('MuiTableRow-has-hover');
   });
 });

--- a/src/modules/Dashboard/features/Participants/Participants.test.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.test.tsx
@@ -18,6 +18,7 @@ import { initialStateData } from 'shared/state';
 import { page } from 'resources';
 import { ApiResponseCodes } from 'api';
 import { mockGetRequestResponses, mockSuccessfulHttpResponse } from 'shared/utils/axios-mocks';
+import { Respondent, RespondentStatus } from 'modules/Dashboard/types';
 
 import { Participants } from './Participants';
 
@@ -70,12 +71,10 @@ const mockedResponses = {
   [RESPONDENTS_ENDPOINT]: mockSuccessfulHttpResponse({ result: [] }),
 };
 
-const getMockedGetWithParticipants = (isAnonymousRespondent = false) => ({
+const getMockedGetWithParticipants = (respondentProps?: Partial<Respondent>) => ({
   status: ApiResponseCodes.SuccessfulResponse,
   data: {
-    result: isAnonymousRespondent
-      ? [{ ...mockedRespondent, isAnonymousRespondent: true }]
-      : [mockedRespondent],
+    result: [{ ...mockedRespondent, ...respondentProps }],
     count: 1,
   },
 });
@@ -170,6 +169,20 @@ describe('Participants component tests', () => {
     );
   });
 
+  test('participant row should not link to participant details page for pending participants', async () => {
+    mockGetRequestResponses({
+      ...mockedResponses,
+      [RESPONDENTS_ENDPOINT]: getMockedGetWithParticipants({ status: RespondentStatus.Pending }),
+    });
+    renderWithProviders(<Participants />, { preloadedState, route, routePath });
+    const firstParticipantSecretIdCell = await waitFor(() =>
+      screen.getByTestId('dashboard-participants-table-0-cell-secretIds'),
+    );
+    fireEvent.click(firstParticipantSecretIdCell);
+
+    expect(mockedUseNavigate).not.toHaveBeenCalled();
+  });
+
   test('should pin participant', async () => {
     mockGetRequestResponses({
       ...mockedResponses,
@@ -215,7 +228,7 @@ describe('Participants component tests', () => {
   test('actions should appear for anonymous participant', async () => {
     mockGetRequestResponses({
       ...mockedResponses,
-      [RESPONDENTS_ENDPOINT]: getMockedGetWithParticipants(true),
+      [RESPONDENTS_ENDPOINT]: getMockedGetWithParticipants({ isAnonymousRespondent: true }),
     });
     renderWithProviders(<Participants />, { preloadedState, route, routePath });
 

--- a/src/modules/Dashboard/features/Participants/Participants.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.tsx
@@ -347,6 +347,9 @@ export const Participants = () => {
         };
 
     return {
+      rowState: {
+        value: !isPending && 'has-hover',
+      },
       id: {
         value: respondentOrSubjectId,
         isHidden: true,

--- a/src/modules/Dashboard/features/Participants/Participants.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.tsx
@@ -335,14 +335,16 @@ export const Participants = () => {
     }[status];
     const isPending = status === RespondentStatus.Pending;
 
-    const defaultOnClick = () => {
-      navigate(
-        generatePath(page.appletParticipantDetails, {
-          appletId,
-          subjectId: detail.subjectId,
-        }),
-      );
-    };
+    const onClick = isPending
+      ? undefined
+      : () => {
+          navigate(
+            generatePath(page.appletParticipantDetails, {
+              appletId,
+              subjectId: detail.subjectId,
+            }),
+          );
+        };
 
     return {
       id: {
@@ -363,34 +365,34 @@ export const Participants = () => {
         ),
         value: '',
         width: ParticipantsColumnsWidth.Default,
-        onClick: defaultOnClick,
+        onClick,
       },
       secretIds: {
         content: () => secretId,
         value: secretId,
-        onClick: defaultOnClick,
+        onClick,
         maxWidth: ParticipantsColumnsWidth.Id,
       },
       nicknames: {
         content: () => nickname,
         value: nickname,
-        onClick: defaultOnClick,
+        onClick,
       },
       accountType: {
         content: () => <Chip color={isPending ? 'warning' : 'secondary'} title={accountType} />,
         value: accountType,
-        onClick: defaultOnClick,
+        onClick,
       },
       lastSeen: {
         content: () => <StyledMaybeEmpty>{latestActive}</StyledMaybeEmpty>,
         value: latestActive,
-        onClick: defaultOnClick,
+        onClick,
       },
       ...(appletId && {
         schedule: {
           content: () => schedule,
           value: schedule,
-          onClick: defaultOnClick,
+          onClick,
         },
       }),
       actions: {

--- a/src/shared/styles/theme.tsx
+++ b/src/shared/styles/theme.tsx
@@ -154,6 +154,26 @@ export const theme = createTheme({
               border: `${variables.borderWidth.md2} solid ${variables.palette.red}`,
             },
           },
+          '&.MuiTableRow-has-hover': {
+            cursor: 'pointer',
+            transition: variables.transitions.bgColor,
+            '&:hover': {
+              backgroundColor: variables.palette.on_surface_variant_alfa8,
+            },
+          },
+          '&.MuiTableRow-dragged-over': {
+            position: 'relative',
+            '.MuiTableCell-root:first-of-type::before': {
+              content: '""',
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              right: 0,
+              bottom: 0,
+              border: `${variables.borderWidth.lg} solid ${variables.palette.primary}`,
+              borderRadius: variables.borderRadius.xs,
+            },
+          },
           '&.MuiTableRow-error:first-of-type .MuiTableCell-root:first-of-type::before': {
             top: 0,
           },

--- a/src/shared/utils/colors.ts
+++ b/src/shared/utils/colors.ts
@@ -37,7 +37,4 @@ export const blendColorsNormal = (mainColor: string, overlayColor: string) => {
   }
 };
 
-export const tableRowHoverColor = blendColorsNormal(
-  variables.palette.surface,
-  variables.palette.on_surface_alfa12,
-);
+export const tableRowHoverColor = variables.palette.on_surface_variant_alfa8;


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added
- [ ] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

🔗 [Jira Ticket M2-8035](https://mindlogger.atlassian.net/browse/M2-8035)

Pending accounts shouldn't be selectable for either Take Now or Assign Activity. Updated the `useParticipantDropdown` hook to filter out pending accounts (by default, but it can still be overridden via a prop if ever desired).

Also disabled clicking pending participants from the Applet > Participants table (after confirming with product), to further prevent Take Now modals from being pre-populated with pending participants.

> [!NOTE]
> ✨ In making the change to Participants table row clickability, I felt it important to distinguish which rows were clickable vs. not by finally adding the table row hover effect, which was in fact always part of the original designs. To do so, I did some minor refactoring of table row hover styling, which was already present in the app on the Applets table. See [this commit](https://github.com/ChildMindInstitute/mindlogger-admin/pull/1968/commits/a01f0001524b7f4878a2e12e7d4f1c16a30c7e8d) for details.

### 📸 Screenshots

#### Participants table row clickability

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/20f1bf41-0533-4388-98af-4fd795756691"></video>|<video src="https://github.com/user-attachments/assets/781eb0e7-b9d2-43d1-b249-defefd920ced"></video>|

#### Take Now & Assign Activity dropdown lists

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/616b09c5-119b-4beb-960b-2fa55cde6e54"></video>|<video src="https://github.com/user-attachments/assets/f3948942-0ad4-4364-8049-85b4c39643fd"></video>|

#### Improvements to Applets table & Applet Overview table row styling

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/c9aa9148-ec18-489b-a45c-13891466e70b"></video>|<video src="https://github.com/user-attachments/assets/8797617f-db4c-4421-9652-3565603c0c40"></video>|

### 🪤 Peer Testing

1. Create a new full account and leave it in pending state.
2. Perform Take Now (from anywhere in the app) and try to select that account as the subject.
    **Expected outcome:** The pending account is not selectable from the dropdown list.
2. Perform Assign Activity (again, from anywhere in the app) and try to select that account as the subject of an assignment.
    **Expected outcome:** The pending account is not selectable from the dropdown list.
3. Navigate to **Applet > Participants** and try to access the pending account's PDP by clicking its row.
    **Expected outcome:** The row does not respond to being clicked.