### PR TITLE
fix: Remove MindLogger update version banner (M2-8082)

### DIFF
--- a/src/shared/hooks/useSessionBanners.test.ts
+++ b/src/shared/hooks/useSessionBanners.test.ts
@@ -18,7 +18,7 @@ const emptyState: PreloadedState<RootState> = {
 const populatedState: PreloadedState<RootState> = {
   banners: {
     data: {
-      banners: [{ key: 'VersionWarningBanner' }],
+      banners: [{ key: 'SaveSuccessBanner' }],
     },
   },
 };
@@ -27,22 +27,6 @@ const spyAccessToken = jest.spyOn(authStorage, 'getAccessToken');
 const spyUseStatus = jest.spyOn(auth, 'useStatus');
 
 describe('useSessionBanners', () => {
-  test('should add a banner when the session becomes valid', () => {
-    spyAccessToken.mockReturnValue(null);
-    spyUseStatus.mockReturnValue('idle');
-
-    const { rerender, store } = renderHookWithProviders(useSessionBanners, {
-      preloadedState: emptyState,
-    });
-
-    spyAccessToken.mockReturnValue('access-token');
-    spyUseStatus.mockReturnValue('success');
-
-    rerender();
-
-    expect(store.getState().banners).toEqual(populatedState.banners);
-  });
-
   test('should remove all banners when the session becomes invalid', () => {
     spyAccessToken.mockReturnValue('access-token');
     spyUseStatus.mockReturnValue('success');

--- a/src/shared/hooks/useSessionBanners.ts
+++ b/src/shared/hooks/useSessionBanners.ts
@@ -16,11 +16,9 @@ export const useSessionBanners = () => {
     // Only update banners when session status changes
     if (prevIsSessionValid.current !== isSessionValid) {
       if (!isSessionValid) {
-        // Add version warning banner when logging in
         dispatch(banners.actions.removeAllBanners());
       }
     }
-
     prevIsSessionValid.current = isSessionValid;
   }, [dispatch, isSessionValid]);
 };

--- a/src/shared/hooks/useSessionBanners.ts
+++ b/src/shared/hooks/useSessionBanners.ts
@@ -15,10 +15,8 @@ export const useSessionBanners = () => {
   useEffect(() => {
     // Only update banners when session status changes
     if (prevIsSessionValid.current !== isSessionValid) {
-      if (isSessionValid) {
+      if (!isSessionValid) {
         // Add version warning banner when logging in
-        dispatch(banners.actions.addBanner({ key: 'VersionWarningBanner' }));
-      } else {
         dispatch(banners.actions.removeAllBanners());
       }
     }


### PR DESCRIPTION
### 📝 Description
As an Admin I want the MindLogger version Info banner to be removed to avoid confusion for new Admin users.

🔗 [Jira Ticket M2-8082](https://mindlogger.atlassian.net/jira/software/c/projects/M2/boards/4?assignee=712020%3A6322a990-2eaf-42f4-9fed-30af94baf20e&selectedIssue=M2-8082)

Changes include:

- [Removed addBanner action when session status changes avoiding rendering VersionWarningBanner]
- [Updated tests for VersionWarningBanner and only testing for removing all banners action when sesion status changes]

### 📸 Screenshots


| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| ![image](https://github.com/user-attachments/assets/f73a8e05-99a4-406d-995d-e2b5596f63a4) | ![image](https://github.com/user-attachments/assets/789705c7-56c0-4782-ba56-9ef326e35f85) |

### 🪤 Peer Testing
1. Start your admin app
2. Login with your user
3. "Update version Banner" () shouldn't be displayed at the top of the screen

### ✏️ Notes
* After tlaking with Cari, Marty and Paul, we decided that the best approach was to avoid rendering the Banner component instead of entirely delete it because we might rehuse it in the future. 