### PR TITLE
fix: Account for the way the mobile app represents number selections (M2-8176)

### DIFF
--- a/src/shared/utils/exportData/getSubscales.ts
+++ b/src/shared/utils/exportData/getSubscales.ts
@@ -126,7 +126,7 @@ export const calcScores = <T>(
       if (ageAnswer) {
         if (typeof ageAnswer === 'string') {
           reportedAge = ageAnswer;
-        } else if ('value' in ageAnswer && typeof ageAnswer.value === 'number') {
+        } else if ('value' in ageAnswer && ['number', 'string'].includes(typeof ageAnswer.value)) {
           reportedAge = String(ageAnswer.value);
         }
       }


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-8176](https://mindlogger.atlassian.net/browse/M2-8176)

This PR updates the T score calculation to account for the way the mobile app represents number selections. 

The mobile app will submit the answer to the age question as a number selection when the admin configures the field as a dropdown. However, its representation of this data differs from the web app: the mobile app will use a string, whereas the web app uses a number. Therefore, we need to account for both.

### 📸 Screenshots

#### Before

<img width="1552" alt="image" src="https://github.com/user-attachments/assets/cd80cdf7-8552-451c-8443-eb7a34e6f077">

#### After

<img width="1552" alt="image" src="https://github.com/user-attachments/assets/6afe3dd1-990f-4135-890d-045e37ee84ec">

> [!NOTE]
> Note that the last two scores on the blue line are higher than before, as they are now being mapped via the lookup table

### 🪤 Peer Testing

1. Create an activity with at least one scorable item
2. Create a subscale with a lookup table containing severity information
    <details>
      <summary>Here's a sample one</summary>
      
      ```csv
      score,rawScore,age,sex,optionalText,severity
     10,1,15,M,https://gist.githubusercontent.com/benbalter/3914310/raw/f757a33411082da23f0ad4a124b45fcdacc1b43f/Example--text.txt,Minimal
      20,2,15,M,https://gist.githubusercontent.com/benbalter/3914310/raw/f757a33411082da23f0ad4a124b45fcdacc1b43f/Example--text.txt,Mild
      30,3,15,M,Markdown Text Here,Moderate
      40,4,15,F,Good,Severe
      50,5,15,F,Nice,Severe
      ```
    </details>
3. Switch the age field type to dropdown in the subscale settings
4. Save and complete the activity via the web app. Complete the activity such that the total score will match one of the entries in the `rawScore` column of the lookup table
5. Complete the activity via the mobile app to get the same raw score
6. Verify the data viz entries are the same in the admin app

### ✏️ Notes

N/A