### PR TITLE
fix: By Participant list for limited respondents (M2-8092)

### DIFF
--- a/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.tsx
+++ b/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.tsx
@@ -92,6 +92,7 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
     useState<ParticipantDropdownOption | null>(null);
   const [defaultSourceSubject, setDefaultSourceSubject] =
     useState<ParticipantDropdownOption | null>(null);
+  const [defaultIsSelfReporting, setDefaultIsSelfReporting] = useState<boolean>(true);
   const [multiInformantAssessmentId, setMultiInformantAssessmentId] = useState<string | null>(null);
   const workspaceRoles = workspaces.useRolesData();
   const roles = appletId ? workspaceRoles?.data?.[appletId] : undefined;
@@ -154,7 +155,7 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
     const [sourceSubject, setSourceSubject] = useState<ParticipantDropdownOption | null>(
       defaultSourceSubject,
     );
-    const [isSelfReporting, setIsSelfReporting] = useState<boolean>(true);
+    const [isSelfReporting, setIsSelfReporting] = useState<boolean>(defaultIsSelfReporting);
     const [loggedInUser, setLoggedInUser] = useState<ParticipantDropdownOption | null>(
       defaultSourceSubject?.userId ? defaultSourceSubject : null,
     );
@@ -512,7 +513,9 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
 
     if (sourceSubject) {
       setDefaultSourceSubject(sourceSubject);
-      event[MixpanelProps.SourceAccountType] = getAccountType(sourceSubject);
+      const accountType = getAccountType(sourceSubject);
+      setDefaultIsSelfReporting(accountType !== 'Limited');
+      event[MixpanelProps.SourceAccountType] = accountType;
     } else {
       setDefaultSourceSubject(enableParticipantMultiInformant ? null : loggedInTeamMember);
     }

--- a/src/modules/Dashboard/features/Participant/Assignments/AssignmentsTab/AssignmentsTab.hooks.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/AssignmentsTab/AssignmentsTab.hooks.tsx
@@ -199,6 +199,7 @@ export const useAssignmentsTab = ({
           EditablePerformanceTasks.includes(performanceTaskType ?? ''));
       const isAssignable =
         status === ActivityAssignmentStatus.Active || status === ActivityAssignmentStatus.Inactive;
+      const isLimitedRespondent = !respondentSubject?.userId;
       const isTargetTeamMember = targetSubjectArg?.tag === 'Team';
       const isAssigned = !!assignments?.some(
         (a) =>
@@ -207,7 +208,7 @@ export const useAssignmentsTab = ({
       );
       const isAssignDisplayed =
         canAssign && (!autoAssign || status === ActivityAssignmentStatus.Hidden);
-      const isAssignDisabled = !isAssignable || isTargetTeamMember;
+      const isAssignDisabled = !isAssignable || isTargetTeamMember || isLimitedRespondent;
       const isUnassignDisplayed = canAssign && isAssignable && (autoAssign || isAssigned);
 
       let assignTooltip: string | undefined;
@@ -217,6 +218,8 @@ export const useAssignmentsTab = ({
           : t('assignActivityDisabledTooltip');
       } else if (isTargetTeamMember) {
         assignTooltip = t('assignToTeamMemberTooltip');
+      } else if (isLimitedRespondent) {
+        assignTooltip = t('assignToLimitedRespondentTooltip');
       }
 
       const showDivider =

--- a/src/modules/Dashboard/features/Participant/Assignments/AssignmentsTab/AssignmentsTab.hooks.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/AssignmentsTab/AssignmentsTab.hooks.tsx
@@ -199,7 +199,7 @@ export const useAssignmentsTab = ({
           EditablePerformanceTasks.includes(performanceTaskType ?? ''));
       const isAssignable =
         status === ActivityAssignmentStatus.Active || status === ActivityAssignmentStatus.Inactive;
-      const isLimitedRespondent = !respondentSubject?.userId;
+      const isLimitedRespondent = respondentSubject && !respondentSubject.userId;
       const isTargetTeamMember = targetSubjectArg?.tag === 'Team';
       const isAssigned = !!assignments?.some(
         (a) =>
@@ -207,9 +207,11 @@ export const useAssignmentsTab = ({
           a.respondentSubject.id === respondentSubject?.id,
       );
       const isAssignDisplayed =
-        canAssign && (!autoAssign || status === ActivityAssignmentStatus.Hidden);
+        canAssign &&
+        (!autoAssign || status === ActivityAssignmentStatus.Hidden || isLimitedRespondent);
       const isAssignDisabled = !isAssignable || isTargetTeamMember || isLimitedRespondent;
-      const isUnassignDisplayed = canAssign && isAssignable && (autoAssign || isAssigned);
+      const isUnassignDisplayed =
+        canAssign && isAssignable && (autoAssign || isAssigned) && !isLimitedRespondent;
 
       let assignTooltip: string | undefined;
       if (status === ActivityAssignmentStatus.Hidden) {

--- a/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ByParticipant.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ByParticipant.tsx
@@ -61,8 +61,7 @@ const ByParticipant = () => {
   );
 
   const handleRefetchActivities = useCallback(() => {
-    // Avoid fetching activities for respondent if respondent is a limited account
-    if (!appletId || !respondentSubject?.id || !respondentSubject.userId) return;
+    if (!appletId || !respondentSubject?.id) return;
 
     fetchActivities({ appletId, subjectId: respondentSubject.id });
   }, [appletId, fetchActivities, respondentSubject]);

--- a/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ByParticipant.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ByParticipant.tsx
@@ -136,7 +136,7 @@ const ByParticipant = () => {
               ? t('participantDetails.byParticipantEmptyLimitedAccount')
               : t('participantDetails.byParticipantEmpty')
           }
-          width={isRespondentLimited ? '57.2rem' : undefined}
+          maxWidth={isRespondentLimited ? '57.2rem' : undefined}
         />
       )}
 

--- a/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ByParticipant.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ByParticipant.tsx
@@ -136,6 +136,7 @@ const ByParticipant = () => {
               ? t('participantDetails.byParticipantEmptyLimitedAccount')
               : t('participantDetails.byParticipantEmpty')
           }
+          width={isRespondentLimited ? '57.2rem' : undefined}
         />
       )}
 

--- a/src/modules/Dashboard/features/Participant/Assignments/EmptyState/EmptyState.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/EmptyState/EmptyState.tsx
@@ -6,12 +6,12 @@ import { StyledFlexAllCenter, StyledFlexColumn, StyledHeadline, variables } from
 
 import { EmptyStateProps } from './EmptyState.types';
 
-export const EmptyState = ({ icon, title, onClickAssign }: EmptyStateProps) => {
+export const EmptyState = ({ icon, title, onClickAssign, width = '50.7rem' }: EmptyStateProps) => {
   const { t } = useTranslation('app', { keyPrefix: 'participantDetails' });
 
   return (
     <StyledFlexAllCenter sx={{ flexDirection: 'column', flex: 1, m: 'auto', textAlign: 'center' }}>
-      <StyledFlexColumn sx={{ alignItems: 'center', gap: 1.6, maxWidth: '50.7rem' }}>
+      <StyledFlexColumn sx={{ alignItems: 'center', gap: 1.6, maxWidth: width }}>
         <Svg id={icon} width="80" height="80" fill={variables.palette.outline} />
         <StyledHeadline as="h2" sx={{ color: variables.palette.outline, m: 0 }}>
           {title}

--- a/src/modules/Dashboard/features/Participant/Assignments/EmptyState/EmptyState.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/EmptyState/EmptyState.tsx
@@ -6,12 +6,17 @@ import { StyledFlexAllCenter, StyledFlexColumn, StyledHeadline, variables } from
 
 import { EmptyStateProps } from './EmptyState.types';
 
-export const EmptyState = ({ icon, title, onClickAssign, width = '50.7rem' }: EmptyStateProps) => {
+export const EmptyState = ({
+  icon,
+  title,
+  onClickAssign,
+  maxWidth = '50.7rem',
+}: EmptyStateProps) => {
   const { t } = useTranslation('app', { keyPrefix: 'participantDetails' });
 
   return (
     <StyledFlexAllCenter sx={{ flexDirection: 'column', flex: 1, m: 'auto', textAlign: 'center' }}>
-      <StyledFlexColumn sx={{ alignItems: 'center', gap: 1.6, maxWidth: width }}>
+      <StyledFlexColumn sx={{ alignItems: 'center', gap: 1.6, maxWidth }}>
         <Svg id={icon} width="80" height="80" fill={variables.palette.outline} />
         <StyledHeadline as="h2" sx={{ color: variables.palette.outline, m: 0 }}>
           {title}

--- a/src/modules/Dashboard/features/Participant/Assignments/EmptyState/EmptyState.types.ts
+++ b/src/modules/Dashboard/features/Participant/Assignments/EmptyState/EmptyState.types.ts
@@ -4,4 +4,6 @@ export type EmptyStateProps = {
   icon: Icons;
   title: string;
   onClickAssign?: () => void;
+  /** @default '50.7rem' */
+  width?: string;
 };

--- a/src/modules/Dashboard/features/Participant/Assignments/EmptyState/EmptyState.types.ts
+++ b/src/modules/Dashboard/features/Participant/Assignments/EmptyState/EmptyState.types.ts
@@ -5,5 +5,5 @@ export type EmptyStateProps = {
   title: string;
   onClickAssign?: () => void;
   /** @default '50.7rem' */
-  width?: string;
+  maxWidth?: string;
 };

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -291,6 +291,7 @@
   "assignActivityDisabledTooltip": "This activity is set to ‘Hidden’ in the Activity Builder and therefore cannot be assigned here.",
   "assignFlowDisabledTooltip": "This flow is set to ‘Hidden’ in the Activity Flow Builder and therefore cannot be assigned here.",
   "assignToTeamMemberTooltip": "The current Participant is a Team Member and therefore cannot be assigned as the subject of an Activity or Flow.",
+  "assignToLimitedRespondentTooltip": "The current Participant is a Limited Account and therefore cannot be assigned as the respondent of an Activity or Flow.",
   "assignments": "Assignments",
   "assessment": "Assessment",
   "at": "At",

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -1089,7 +1089,7 @@
     "aboutParticipant": "About Participant",
     "aboutParticipantEmpty": "No Activities are assigned to be completed about this Participant.",
     "byParticipantEmpty": "No Activities are assigned for this Participant to complete.",
-    "byParticipantEmptyLimitedAccount": "This Participant has a Limited Account and cannot be assigned to complete Activities.",
+    "byParticipantEmptyLimitedAccount": "This Participant has a Limited Account and may only complete Activities through the Take Now option.",
     "aboutParticipantEmptyTeamMember": "This Participant is a Team Member and Activities cannot be completed about them.",
     "assignActivityButton": "Assign Activity",
     "activitiesAndFlows": "Activities & Flows",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -1089,7 +1089,7 @@
     "aboutParticipantEmpty": "Aucune activité n'est attribuée à être complétée à propos de ce participant.",
     "aboutParticipantEmptyTeamMember": "Ce participant est un membre de l'équipe et les activités ne peuvent pas être complétées à son sujet.",
     "byParticipantEmpty": "Aucune activité n'est attribuée à ce participant pour être complétée.",
-    "byParticipantEmptyLimitedAccount": "Ce participant a un compte limité et ne peut pas être assigné pour compléter des activités.",
+    "byParticipantEmptyLimitedAccount": "Ce participant a un compte limité et ne peut compléter des activités que via l'option Prendre maintenant.",
     "assignActivityButton": "Attribuer une activité",
     "activitiesAndFlows": "Activités & Flux",
     "toggleSubjectsView": "Basculer la vue des sujets",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -291,6 +291,7 @@
   "assignActivityDisabledTooltip": "Cette activité est définie sur « Caché » dans le Créateur d'Activités et ne peut donc pas être attribuée ici.",
   "assignFlowDisabledTooltip": "Ce flux est défini sur « Caché » dans le Créateur de Flux d'Activités et ne peut donc pas être attribué ici.",
   "assignToTeamMemberTooltip": "Le participant actuel est un membre de l'équipe et ne peut donc pas être assigné en tant que sujet d'une activité ou d'un flux.",
+  "assignToLimitedRespondentTooltip": "Le participant actuel a un compte limité et ne peut donc pas être assigné en tant que répondant d'une activité ou d'un flux.",
   "assignments": "Attributions",
   "assessment": "Évaluation",
   "at": "À",


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [ ] ~~Tests for the changes have been added~~ Will to be done as part of M2&zwnj;-&zwnj;8024 (specific tests for this PR can't be added until general PDP tests have been added)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-8092](https://mindlogger.atlassian.net/browse/M2-8092)

This PR adds support for viewing the PDP **By Participants** tab for a limited account, since they can be possible valid respondents if they had submissions done on their behalf via Take Now.

Also updated the copy for the limited account empty state on this tab to reflect this nuance.

> [!NOTE]
> Testing this PR requires being connected to the backend containing the changes in https://github.com/ChildMindInstitute/mindlogger-backend-refactor/pull/1654.

### 📸 Screenshots

#### With submissions:
https://github.com/user-attachments/assets/c68958a9-afbc-4bce-a794-1cbe3ecdb904

#### Without submissions:
![CleanShot 2024-11-07 at 14 46 50@2x](https://github.com/user-attachments/assets/8bc6adf2-6172-45a2-9a7c-e93bffe667f5)

### 🪤 Peer Testing

#### Preconditions:

An applet with at least one activity or flow, and a new limited account.

#### Steps:

1. Navigate to the PDP for the limited account, then the **By Participant** tab.
    **Expected outcome:** The empty state displays the [updated copy](https://www.figma.com/design/6BNx63peNVzrHAF1FoZ78x/Multi-Informant-2024?node-id=13935-119943&t=ubTxBcV95pvhJbap-4).
1. Navigate to the **Applet > Activities** tab.
2. For any activity or flow, click **Take Now** from the ⋯ menu, providing the limited account for the **Who will be providing the responses?** dropdown, and any participants for the **Who will be inputting the responses?** and **Who are the responses about?** dropdowns.
3. Complete the assessment in the Web App so that there is at least one submission by the limited account as the respondent.
4. Navigate to the PDP for the limited account, then the **By Participant** tab.
    **Expected outcome:** The activity or flow just completed should be listed in `Inactive` state.
6. Expand the card for the activity or flow.
    **Expected outcome:** One subject entry should be listed for the assessment just completed via Take Now.
7. Open the ⋯ menu for that activity or flow, and hover over the **Assign** menu item.
    **Expected outcome:** A tooltip explaining why it's disabled should be shown.
6. Click the **Take Now** menu item.
    **Expected outcome:**
    The Take Now dialogue should be pre-populated with the limited account in the **Who will be providing the responses?** dropdown, and the participant shown in the row that you clicked the ⋯ menu item from in the **Who are the responses about?** dropdown. The checkbox should be disabled and unchecked, and the **Who will be inputting the responses?** dropdown should be empty.