### PR TITLE
fix: switches privacy and terms order (M2-8228)

### DIFF
--- a/src/shared/components/Footer/Footer.tsx
+++ b/src/shared/components/Footer/Footer.tsx
@@ -40,11 +40,11 @@ export const Footer = () => {
         <StyledLink target="_blank" href={ABOUT_LINK}>
           {t('about')}
         </StyledLink>
-        <StyledLink target="_blank" href={PRIVACY_LINK}>
-          {t('privacy')}
-        </StyledLink>
         <StyledLink target="_blank" href={TERMS_LINK}>
           {t('terms')}
+        </StyledLink>
+        <StyledLink target="_blank" href={PRIVACY_LINK}>
+          {t('privacy')}
         </StyledLink>
         <StyledLink target="_blank" href={CREDITS_LINK}>
           {t('credits')}


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-8228](https://mindlogger.atlassian.net/browse/M2-8228)
Simple PR to change the order of `Terms` and `Privacy` links on the footer.
Footer Order should be: About Terms Privacy Credits Support

### 📸 Screenshots
![Google Chrome 2024-11-15 13 02 56](https://github.com/user-attachments/assets/21256793-6c5b-4da6-b9c3-46191e001090)

### 🪤 Peer Testing

- The user opens the initial Admin page

    **Expected outcome:** The footer links order should be `About Terms Privacy Credits Support`
