### PR TITLE
fix: admin no slide number is included in the preview (M2-8206)

### DIFF
--- a/src/modules/Builder/components/PreviewPhrasePopup/PreviewPhrasePopup.tsx
+++ b/src/modules/Builder/components/PreviewPhrasePopup/PreviewPhrasePopup.tsx
@@ -1,10 +1,10 @@
-import { useCallback } from 'react';
+import { Fragment, useCallback } from 'react';
 import { Box } from '@mui/material';
 import { FieldArrayWithId } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
 import { useCustomFormContext } from 'modules/Builder/hooks';
-import { PhrasalTemplateField } from 'redux/modules';
+import { PhrasalTemplateField, PhrasalTemplateItemResponseField } from 'redux/modules';
 import { Modal, ModalProps } from 'shared/components';
 import { StyledModalWrapper } from 'shared/styles';
 
@@ -20,43 +20,56 @@ export const PreviewPhrasePopup = ({
   name?: string;
   imageUrl?: string;
 }) => {
-  const { t } = useTranslation('app');
+  const { t } = useTranslation('app', { keyPrefix: 'phrasalTemplatePreviewPopup' });
   const { getValues } = useCustomFormContext();
+
+  const getPlaceholder = useCallback(
+    (fieldValue: PhrasalTemplateItemResponseField) =>
+      fieldValue._indexedItemLabel
+        ? t('responsePlaceholderWithLabel', {
+            itemName: fieldValue.itemName,
+            indexedItemLabel: fieldValue._indexedItemLabel.replace(/\s+/, '_'),
+          })
+        : t('responsePlaceholder', {
+            itemName: fieldValue.itemName,
+          }),
+    [t],
+  );
 
   const renderField = useCallback(
     (_: PhrasalTemplateField, index = 0) => {
-      const fieldValue = getValues(`${name}.${index}` as string);
+      const fieldValue = getValues(`${name}.${index}`);
 
       if (!fieldValue) {
-        return '';
+        return <Fragment key={index} />;
       }
-
-      const renderedName = ` ${t('phrasalTemplatePreviewPopup.responsePlaceholder', {
-        itemName: fieldValue?.itemName,
-      })} `;
 
       switch (fieldValue.type) {
         case 'sentence':
-          return <Box component="span">{fieldValue.text}</Box>;
+          return (
+            <Box key={index} component="span">
+              {fieldValue.text}
+            </Box>
+          );
         case 'line_break':
-          return <Box component="hr" sx={{ m: 0, height: 32, border: 'none' }} />;
+          return <Box key={index} component="hr" sx={{ m: 0, height: 32, border: 'none' }} />;
         case 'item_response':
           return ['sentence', 'sentence_option_row', 'sentence_row_option'].includes(
             fieldValue.displayMode,
           ) ? (
-            <Box component="span" fontWeight="bold">
-              {renderedName}
+            <Box key={index} component="span" fontWeight="bold">
+              {` ${getPlaceholder(fieldValue)} `}
             </Box>
           ) : (
-            <ul>
+            <ul key={index}>
               <Box component="li" fontWeight="bold">
-                {renderedName}
+                {` ${getPlaceholder(fieldValue)} `}
               </Box>
             </ul>
           );
       }
     },
-    [getValues, name, t],
+    [getPlaceholder, getValues, name],
   );
 
   return (

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/PhrasalTemplate/PhrasalTemplate.utils.ts
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/PhrasalTemplate/PhrasalTemplate.utils.ts
@@ -11,8 +11,6 @@ import { ItemResponseType } from 'shared/consts';
 
 import { KEYWORDS } from './PhrasalTemplateField/PhrasalTemplateField.const';
 
-// TODO: M2-7211 — Additional response types to be added with
-// additional UI for selecting discrete response values.
 const PHRASAL_TEMPLATE_COMPATIBLE_RESPONSE_TYPES = [
   ItemResponseType.Date,
   ItemResponseType.MultipleSelection,
@@ -36,7 +34,7 @@ const DEFAULT_PHRASE: PhrasalTemplateResponseValues['phrases'][number] = {
       type: KEYWORDS.ITEM_RESPONSE,
       itemName: '',
       displayMode: KEYWORDS.DISPLAY_SENTENCE,
-      itemIndex: 0,
+      itemIndex: null,
     },
     { type: KEYWORDS.SENTENCE, text: '' },
   ],
@@ -49,7 +47,12 @@ export const getNewDefaultField = (
 ): PhrasalTemplateField => {
   switch (type) {
     case KEYWORDS.ITEM_RESPONSE:
-      return { type, itemName: '', displayMode: KEYWORDS.SENTENCE, itemIndex: 0 };
+      return {
+        type,
+        itemName: '',
+        displayMode: KEYWORDS.SENTENCE,
+        itemIndex: null,
+      };
     case KEYWORDS.LINE_BREAK:
       return { type };
     case KEYWORDS.SENTENCE:

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/PhrasalTemplate/PhrasalTemplateField/PhrasalTemplateField.const.ts
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/PhrasalTemplate/PhrasalTemplateField/PhrasalTemplateField.const.ts
@@ -1,25 +1,28 @@
 import { ItemResponseType } from 'shared/consts';
 
-export const DisplayModeOptions: Readonly<
-  Record<ItemResponseType, { id: string; name: string }[] | undefined> & {
-    default: undefined;
-  }
-> = {
-  [ItemResponseType.MultipleSelection]: [
-    { id: 'sentence', name: 'Sentence' },
-    { id: 'bullet_list', name: 'Bullet List' },
-  ],
+export const DisplayMode = {
+  SENTENCE: 'sentence',
+  BULLET_LIST: 'bullet_list',
+  SENTENCE_OPTION_ROW: 'sentence_option_row',
+  SENTENCE_ROW_OPTION: 'sentence_row_option',
+  BULLET_LIST_OPTION_ROW: 'bullet_list_option_row',
+  BULLET_LIST_TEXT_ROW: 'bullet_list_text_row',
+} as const;
+export type DisplayMode = (typeof DisplayMode)[keyof typeof DisplayMode];
+
+export const DisplayModeOptions: Readonly<Record<ItemResponseType, DisplayMode[] | undefined>> = {
+  [ItemResponseType.MultipleSelection]: [DisplayMode.SENTENCE, DisplayMode.BULLET_LIST],
   [ItemResponseType.SingleSelectionPerRow]: [
-    { id: 'sentence_option_row', name: 'Sentence: Option Text, Row Text' },
-    { id: 'sentence_row_option', name: 'Sentence: Row Text, Option Text' },
-    { id: 'bullet_list_option_row', name: 'Bullet List: Option Text, Row Text' },
-    { id: 'bullet_list_text_row', name: 'Bullet List: Row Text, Option Text' },
+    DisplayMode.SENTENCE_OPTION_ROW,
+    DisplayMode.SENTENCE_ROW_OPTION,
+    DisplayMode.BULLET_LIST_OPTION_ROW,
+    DisplayMode.BULLET_LIST_TEXT_ROW,
   ],
   [ItemResponseType.MultipleSelectionPerRow]: [
-    { id: 'sentence_option_row', name: 'Sentence: Option Text, Row Text' },
-    { id: 'sentence_row_option', name: 'Sentence: Row Text, Option Text' },
-    { id: 'bullet_list_option_row', name: 'Bullet List: Option Text, Row Text' },
-    { id: 'bullet_list_text_row', name: 'Bullet List: Row Text, Option Text' },
+    DisplayMode.SENTENCE_OPTION_ROW,
+    DisplayMode.SENTENCE_ROW_OPTION,
+    DisplayMode.BULLET_LIST_OPTION_ROW,
+    DisplayMode.BULLET_LIST_TEXT_ROW,
   ],
   [ItemResponseType.ABTrails]: undefined,
   [ItemResponseType.Audio]: undefined,
@@ -44,7 +47,6 @@ export const DisplayModeOptions: Readonly<
   [ItemResponseType.TouchTest]: undefined,
   [ItemResponseType.Unity]: undefined,
   [ItemResponseType.Video]: undefined,
-  default: undefined,
 };
 
 export const KEYWORDS = {

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/PhrasalTemplate/PhrasalTemplateField/PhrasalTemplateField.styles.ts
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/PhrasalTemplate/PhrasalTemplateField/PhrasalTemplateField.styles.ts
@@ -1,8 +1,12 @@
 import { Box, styled } from '@mui/material';
 
 import { StyledFlexTopCenter, theme, variables } from 'shared/styles';
+import { shouldForwardProp } from 'shared/utils';
 
-export const StyledFlexTopCenterDraggable = styled(StyledFlexTopCenter)(
+export const StyledFlexTopCenterDraggable = styled(
+  StyledFlexTopCenter,
+  shouldForwardProp,
+)(
   ({ isDragging }: { isDragging: boolean }) => `
   padding: ${theme.spacing(0.8)};
   margin: ${theme.spacing(-0.8)};

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/PhrasalTemplate/PhrasalTemplateField/PhrasalTemplateRenderField.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/PhrasalTemplate/PhrasalTemplateField/PhrasalTemplateRenderField.tsx
@@ -67,8 +67,13 @@ export function RenderedField({
       setResponseFromOptions(responseItem.responseValues?.rows);
       setDisplayModes(undefined);
 
-      // Set default value for itemIndex if not set
-      if (typeof fieldValue.itemIndex !== 'number') setValue(`${name}.itemIndex`, 0);
+      // Set default value for itemIndex if not set, or out of range
+      if (
+        typeof fieldValue.itemIndex !== 'number' ||
+        fieldValue.itemIndex >= responseItem.responseValues?.rows.length
+      ) {
+        setValue(`${name}.itemIndex`, 0);
+      }
     } else {
       setResponseFromOptions(undefined);
       if (typeof fieldValue.itemIndex === 'number') setValue(`${name}.itemIndex`, null);

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/PhrasalTemplate/PhrasalTemplateField/PhrasalTemplateRenderField.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/PhrasalTemplate/PhrasalTemplateField/PhrasalTemplateRenderField.tsx
@@ -1,6 +1,7 @@
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useWatch } from 'react-hook-form';
 
 import { useCustomFormContext } from 'modules/Builder/hooks';
 import { StyledMdPreview } from 'modules/Builder/components/ItemFlowSelectController/StyledMdPreview/StyledMdPreview.styles';
@@ -15,10 +16,11 @@ import {
   variables,
 } from 'shared/styles';
 import { ItemResponseType } from 'shared/consts';
+import { getDictionaryText } from 'shared/utils';
 
 import { StyledLineBreak } from './PhrasalTemplateField.styles';
 import { PhrasalTemplateFieldProps } from './PhrasalTemplateField.types';
-import { DisplayModeOptions, KEYWORDS } from './PhrasalTemplateField.const';
+import { DisplayMode, DisplayModeOptions, KEYWORDS } from './PhrasalTemplateField.const';
 
 export function RenderedField({
   name = '',
@@ -26,39 +28,96 @@ export function RenderedField({
   type = KEYWORDS.SENTENCE,
   ...otherProps
 }: Omit<PhrasalTemplateFieldProps, 'canRemove' | 'onRemove' | 'setAnchorPopUp'>) {
-  const [displayMode, setDisplayMode] = useState<{
-    id: string;
-    items?: Array<{ id: string; name: string }>;
-  }>();
-  const [responseFrom, setResponseFrom] = useState<{
-    name: string;
-    items?: SliderRowsItemResponseValues[];
-  }>();
+  const [displayModes, setDisplayModes] = useState<DisplayMode[]>();
+  const [responseFromOptions, setResponseFromOptions] = useState<SliderRowsItemResponseValues[]>();
   const { t } = useTranslation('app');
   const params = useParams();
-  const { control, getValues, setValue } = useCustomFormContext();
-  const fieldValue = getValues(name as string);
-  const itemsFromStore = applet.useActivityItemsFromApplet(params?.activityId || '');
-  const { question: selectedOptionQuestion } =
-    responseOptions?.find(({ name }) => fieldValue?.itemName === name) ?? {};
 
-  const isFieldValueDeleted = fieldValue?.itemName?.includes('-deleted');
+  const { control, setValue: setValueProp } = useCustomFormContext();
+  // Save setValue to ref to eliminate problematic dependency on effects, avoiding unnecessary
+  // re-renders and visible performance degradation
+  const setValueRef = useRef(setValueProp);
+  const setValue = setValueRef.current;
+
+  const fieldValue = useWatch({ control, name });
+  const itemsFromStore = applet.useActivityItemsFromApplet(params?.activityId || '');
+  const responseItem = useMemo(
+    () =>
+      type === KEYWORDS.ITEM_RESPONSE
+        ? responseOptions?.find((item) => fieldValue?.itemName === item.name)
+        : undefined,
+    [fieldValue?.itemName, responseOptions, type],
+  );
+
+  // Update secondary dropdown options based on selected response item type
+  useEffect(() => {
+    if (type !== KEYWORDS.ITEM_RESPONSE || !responseItem) {
+      setResponseFromOptions(undefined);
+      setDisplayModes(undefined);
+
+      // Remove itemIndex and displayMode if not a response item type
+      if (fieldValue.displayMode !== undefined) setValue(`${name}.displayMode`, undefined);
+      if (fieldValue.itemIndex !== undefined) setValue(`${name}.itemIndex`, undefined);
+
+      return;
+    }
+
+    // Set up dropdown for item types supporting responseFrom property (SliderRows only)
+    if (responseItem.responseType === ItemResponseType.SliderRows) {
+      setResponseFromOptions(responseItem.responseValues?.rows);
+      setDisplayModes(undefined);
+
+      // Set default value for itemIndex if not set
+      if (typeof fieldValue.itemIndex !== 'number') setValue(`${name}.itemIndex`, 0);
+    } else {
+      setResponseFromOptions(undefined);
+      if (typeof fieldValue.itemIndex === 'number') setValue(`${name}.itemIndex`, null);
+    }
+
+    const displayModeOptions = DisplayModeOptions[responseItem.responseType];
+
+    // Set up dropdown for item types supporting displayMode property (undefined if unsupported)
+    setDisplayModes(displayModeOptions);
+    if (fieldValue.displayMode === undefined) {
+      // Set default value for displayMode if not set
+      setValue(`${name}.displayMode`, displayModeOptions?.[0] ?? KEYWORDS.DISPLAY_SENTENCE);
+    } else if (displayModeOptions && !displayModeOptions.includes(fieldValue.displayMode)) {
+      // Reset displayMode to the first option if not supported by the selected response item type
+      setValue(`${name}.displayMode`, displayModeOptions[0]);
+    }
+  }, [
+    responseItem,
+    fieldValue.itemIndex,
+    type,
+    responseOptions,
+    name,
+    setValue,
+    fieldValue.displayMode,
+  ]);
 
   useEffect(() => {
-    if (
-      fieldValue?.itemName &&
-      type === KEYWORDS.ITEM_RESPONSE &&
-      !selectedOptionQuestion &&
-      !isFieldValueDeleted
-    ) {
-      setValue(name, {
-        displayMode: KEYWORDS.DISPLAY_SENTENCE,
-        itemName: `${fieldValue.itemName}-deleted`,
-        type: KEYWORDS.ITEM_RESPONSE,
-        itemIndex: 0,
-      });
+    if (fieldValue?.itemName && type === KEYWORDS.ITEM_RESPONSE) {
+      // Flag deleted items
+      if (!responseItem && !fieldValue.itemName.includes('-deleted')) {
+        setValue(`${name}.itemName`, `${fieldValue.itemName}-deleted`);
+      }
+
+      // Update indexed item label in form context to be consumed by PreviewPhrasePopup
+      if (fieldValue.itemIndex !== undefined && responseFromOptions) {
+        setValue(`${name}._indexedItemLabel`, responseFromOptions[fieldValue.itemIndex]?.label, {
+          shouldDirty: false,
+        });
+      }
     }
-  }, [isFieldValueDeleted, fieldValue, name, setValue, selectedOptionQuestion, type]);
+  }, [
+    fieldValue.itemName,
+    fieldValue.itemIndex,
+    responseItem,
+    type,
+    responseFromOptions,
+    name,
+    setValue,
+  ]);
 
   const getRenderedValue = (value: unknown) => {
     if (!value) {
@@ -69,54 +128,11 @@ export function RenderedField({
       );
     }
 
-    const selectedItem = responseOptions.find(({ name }) => name === value);
-
-    if (!selectedItem) {
-      const missedItem = itemsFromStore?.find((item) => {
-        if (fieldValue?.itemName?.includes(item?.name)) {
-          return item;
-        }
-
-        return null;
-      });
-
-      return missedItem?.name;
+    if (!responseItem) {
+      return itemsFromStore?.find((item) => fieldValue?.itemName?.includes(item.name))?.name;
     }
 
-    if (
-      selectedItem?.responseType !== displayMode?.id &&
-      selectedItem?.responseType !== ItemResponseType.SliderRows
-    ) {
-      const items = DisplayModeOptions[selectedItem?.responseType || 'default'];
-
-      setDisplayMode({
-        id: selectedItem?.responseType as string,
-        items,
-      });
-      setResponseFrom(undefined);
-      setValue(name, {
-        ...fieldValue,
-        itemIndex: 0,
-        displayMode: items ? fieldValue?.displayMode : KEYWORDS.DISPLAY_SENTENCE,
-      });
-    }
-
-    if (
-      selectedItem?.name !== responseFrom?.name &&
-      selectedItem?.responseType === ItemResponseType.SliderRows
-    ) {
-      setResponseFrom({
-        name: selectedItem?.name,
-        items: selectedItem?.responseValues?.rows,
-      });
-      setDisplayMode(undefined);
-      setValue(name, {
-        ...fieldValue,
-        displayMode: KEYWORDS.DISPLAY_SENTENCE,
-      });
-    }
-
-    return selectedItem?.name;
+    return responseItem.name;
   };
 
   const getDisplayModeRenderedValue = (value: unknown) => {
@@ -132,7 +148,7 @@ export function RenderedField({
   };
 
   const getResponseFromRenderedValue = (value: unknown) => {
-    if (!value && typeof Number(value) !== 'number') {
+    if (typeof value !== 'number') {
       return (
         <StyledBodyLarge color={variables.palette.outline}>
           {t('phrasalTemplateItem.fieldResponsePlaceholder')}
@@ -140,9 +156,7 @@ export function RenderedField({
       );
     }
 
-    const selectedFromResponse = responseFrom?.items?.[Number(value)];
-
-    return selectedFromResponse?.label;
+    return responseFromOptions?.[value]?.label;
   };
 
   switch (type) {
@@ -156,7 +170,8 @@ export function RenderedField({
             fullWidth
             options={responseOptions.map(({ name, question }) => ({
               labelKey: name,
-              tooltip: <StyledMdPreview modelValue={(question as unknown as string) ?? ''} />,
+              tooltip: <StyledMdPreview modelValue={getDictionaryText(question)} />,
+              tooltipPlacement: 'left',
               value: name ?? '',
             }))}
             SelectProps={{
@@ -166,44 +181,41 @@ export function RenderedField({
             }}
             TooltipProps={{
               placement: 'left',
-              tooltipTitle: selectedOptionQuestion ? (
-                <StyledMdPreview modelValue={(selectedOptionQuestion as unknown as string) ?? ''} />
+              tooltipTitle: responseItem ? (
+                <StyledMdPreview modelValue={getDictionaryText(responseItem.question)} />
               ) : null,
             }}
           />
-          {displayMode?.items && (
+          {displayModes && (
             <SelectController
               name={`${name}.displayMode`}
               control={control}
-              defaultValue=""
+              defaultValue={displayModes[0]}
               fullWidth
-              options={displayMode?.items.map(({ name, id }) => ({
+              options={displayModes.map((id) => ({
                 labelKey: t(`phrasalTemplateItem.displayModes.${id}`),
-                tooltip: <StyledMdPreview modelValue={(name as unknown as string) ?? ''} />,
-                value: id ?? '',
+                value: id,
               }))}
               SelectProps={{
                 displayEmpty: true,
                 renderValue: getDisplayModeRenderedValue,
-                startAdornment: <Svg aria-hidden id="commentDots" />,
               }}
             />
           )}
-          {responseFrom?.items && (
+          {responseFromOptions && (
             <SelectController
               name={`${name}.itemIndex`}
               control={control}
-              defaultValue=""
+              defaultValue={0}
               fullWidth
-              options={responseFrom?.items.map(({ label }, index) => ({
+              isLabelNeedTranslation={false}
+              options={responseFromOptions.map(({ label }, index) => ({
                 labelKey: label as string,
-                tooltip: <StyledMdPreview modelValue={(name as unknown as string) ?? ''} />,
-                value: `${index}`,
+                value: index as unknown as string,
               }))}
               SelectProps={{
                 displayEmpty: true,
                 renderValue: getResponseFromRenderedValue,
-                startAdornment: <Svg aria-hidden id="commentDots" />,
               }}
             />
           )}

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/PhrasalTemplate/PhrasalTemplatePhrase/PhrasalTemplatePhrase.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/PhrasalTemplate/PhrasalTemplatePhrase/PhrasalTemplatePhrase.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable import/order */
 import { Box, Button, IconButton } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { useCallback, useState, useEffect } from 'react';
+import { Fragment, useCallback, useState, useEffect } from 'react';
 import { Control, useFieldArray } from 'react-hook-form';
 import { DragDropContext, DragDropContextProps } from 'react-beautiful-dnd';
 
@@ -194,9 +194,8 @@ export const PhrasalTemplatePhrase = ({
                     const hasMinimumFields = fields.length > 2;
 
                     return (
-                      <>
+                      <Fragment key={`draggable-item-${field.id}`}>
                         <PhrasalTemplateField
-                          key={`draggable-item-${field.id}`}
                           itemId={`draggable-item-${field.id}`}
                           index={fieldIndex}
                           canRemove={
@@ -208,7 +207,7 @@ export const PhrasalTemplatePhrase = ({
                           type={field.type}
                           placeholder={fieldPlaceholders[fieldIndex]}
                         />
-                      </>
+                      </Fragment>
                     );
                   })}
                 </StyledPhraseTemplateFieldSet>

--- a/src/modules/Builder/hooks/useCustomFormContext.test.ts
+++ b/src/modules/Builder/hooks/useCustomFormContext.test.ts
@@ -16,7 +16,7 @@ describe('useCustomFormContext', () => {
     ${undefined}             | ${'Original setValue should be called with { shouldDirty: true } if options are not provided'}
     ${{}}                    | ${'Original setValue should be called with { shouldDirty: true } if options are empty object'}
     ${{ shouldTouch: true }} | ${'Original setValue should be called with { shouldDirty: true, ...providedOptions } if options contain parameters differ from "shouldDirty"'}
-    ${{ shouldDirty: true }} | ${'Original setValue should be called with { shouldDirty: true } if { shouldDirty: false} is provided with options'}
+    ${{ shouldDirty: true }} | ${'Original setValue should be called with { shouldDirty: false } if { shouldDirty: false} is provided with options'}
   `('$description', ({ options }) => {
     const { result } = renderHook(useCustomFormContext);
 

--- a/src/modules/Builder/hooks/useCustomFormContext.ts
+++ b/src/modules/Builder/hooks/useCustomFormContext.ts
@@ -4,7 +4,7 @@ export function useCustomFormContext() {
   const { setValue: originalSetValue, ...formContext } = useFormContext() || {};
 
   const setValue: UseFormSetValue<FieldValues> = (name, value, options = {}) => {
-    originalSetValue(name, value, { ...options, shouldDirty: true });
+    originalSetValue(name, value, { shouldDirty: true, ...options });
   };
 
   return { ...formContext, setValue };

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -1144,7 +1144,8 @@
   },
   "phrasalTemplatePreviewPopup": {
     "title": "Preview Phrase {{index}}",
-    "responsePlaceholder": "[{{itemName}} Response]"
+    "responsePlaceholder": "[{{itemName}} response]",
+    "responsePlaceholderWithLabel": "[{{itemName}} {{indexedItemLabel}} response]"
   },
   "phrasalTemplateItem": {
     "btnAddField": "Add…",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -1138,7 +1138,8 @@
   "phrasalTemplate": "Constructeur de phrases",
   "phrasalTemplatePreviewPopup": {
     "title": "Aperçu de la phrase {{index}}",
-    "responsePlaceholder": "[{{itemName}} réponse]"
+    "responsePlaceholder": "[{{itemName}} réponse]",
+    "responsePlaceholderWithLabel": "[{{itemName}} {{indexedItemLabel}} réponse]"
   },
   "phrasalTemplateRemovePopup": {
     "title": "Supprimer la phrase",

--- a/src/shared/state/Applet/Applet.schema.ts
+++ b/src/shared/state/Applet/Applet.schema.ts
@@ -359,15 +359,28 @@ export type PhrasalTemplateFieldDisplayMode =
   | 'sentence_option_row'
   | 'sentence_row_option';
 
+export type PhrasalTemplateSentenceField = {
+  type: 'sentence';
+  text: string;
+};
+
+export type PhrasalTemplateItemResponseField = {
+  type: 'item_response';
+  itemName: string;
+  displayMode: PhrasalTemplateFieldDisplayMode;
+  itemIndex: number | null;
+  /** Slider label, used internally by PreviewPhrasePopup */
+  _indexedItemLabel?: string;
+};
+
+export type PhrasalTemplateLineBreakField = {
+  type: 'line_break';
+};
+
 export type PhrasalTemplateField =
-  | { type: 'sentence'; text: string }
-  | {
-      type: 'item_response';
-      itemName: string;
-      displayMode: PhrasalTemplateFieldDisplayMode;
-      itemIndex: number;
-    }
-  | { type: 'line_break' };
+  | PhrasalTemplateSentenceField
+  | PhrasalTemplateItemResponseField
+  | PhrasalTemplateLineBreakField;
 
 export type PhrasalTemplateFieldType = PhrasalTemplateField['type'];
 


### PR DESCRIPTION
<!--
- [ ] Tests for the changes have been added
-->

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-8206](https://mindlogger.atlassian.net/browse/M2-8206)

This PR started out just to fix a bug whereby placeholder text for **Slider Row** item response fields in the Phrase Builder phrase preview modal didn't include the name of the slider selected in the dropdown (see the [ticket description](https://mindlogger.atlassian.net/browse/M2-820)).

However, I also took it as an opportunity to fix some structural implementation issues with the Phrase Builder UI that I knew were going to cause issues down the road, but at the time of implementation weren't worth blocking merging of the work as they weren't hindering usability in any obvious way. In implementing the above fix, however, I began to see React warnings of one of those structural issues (specifically, setting state in the render thread).

Please [read the full commit message history](https://github.com/ChildMindInstitute/mindlogger-admin/pull/1978/commits) to understand the steps I took to fix some state management issues, take care of some UI polish, as well as eliminate some other unrelated but annoying console warnings.

### 🪤 Peer Testing

**Prerequisites:**
- An applet with 1 activity containing a **Slider Rows** item followed by a **Phrase Builder** item.

**Steps:**

1. Add an **Item (Response)** field to any Phrase in the Phrase Builder item and select the **Slider Rows** item for it. Ensure all fields are filled out so that the **Preview** button is enabled.
2. Click the **Preview** button for the phrase and view the output.
    **Expected outcome:** The placeholder for the Slider Rows item should have the format `[ItemName Slider_Name response]`, per the placeholder format [decided upon by design](https://www.figma.com/design/3wcZ6bxK2QVo733ADxVjBw?node-id=1743-47758#1032616161).
3. **Save & Publish** the applet.
4. Without making any changes, again click the **Preview** button for the phrase and view the output.
    **Expected outcome:** The placeholder for the Slider Rows item should be correct as before.

