### PR TITLE
chore: remove enable admin app soft lock feature flag (M2-7271)

### DIFF
--- a/src/shared/hooks/useLogout.ts
+++ b/src/shared/hooks/useLogout.ts
@@ -8,14 +8,10 @@ import { alerts, auth, workspaces } from 'redux/modules';
 import { deleteAccessTokenApi, deleteRefreshTokenApi } from 'modules/Auth/api';
 import { Mixpanel, MixpanelEventType } from 'shared/utils/mixpanel';
 import { FeatureFlags } from 'shared/utils/featureFlags';
-import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 
 export const useLogout = () => {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
-  const {
-    featureFlags: { enableAdminAppSoftLock },
-  } = useFeatureFlags();
 
   const userData = auth.useData();
   const { email } = userData?.user || {};
@@ -24,9 +20,6 @@ export const useLogout = () => {
   // TODO: rewrite to reset the global state data besides the data needed in LockForm (if
   // completing LockForm implementation still planned, now that auth soft-lock is present).
   return async ({ shouldSoftLock = false } = {}) => {
-    // Disable soft-lock feature (avoid logging out at all) with soft-lock feature flag disabled
-    if (shouldSoftLock && !enableAdminAppSoftLock) return;
-
     try {
       await deleteAccessTokenApi();
     } catch (e) {

--- a/src/shared/types/featureFlags.ts
+++ b/src/shared/types/featureFlags.ts
@@ -12,7 +12,6 @@ export const FeatureFlagsKeys = {
   enableParticipantConnections: 'enableParticipantConnections',
   enableLorisIntegration: 'enableLorisIntegration',
   enableItemFlowExtendedItems: 'enableItemFlowExtendedItems',
-  enableAdminAppSoftLock: 'enableAdminAppSoftLock',
   enableParagraphTextItem: 'enableParagraphTextItem',
   enablePhrasalTemplate: 'enablePhrasalTemplate',
   enableShareToLibrary: 'enableShareToLibrary',

--- a/src/shared/types/featureFlags.ts
+++ b/src/shared/types/featureFlags.ts
@@ -20,10 +20,4 @@ export const FeatureFlagsKeys = {
   enableCahmiSubscaleScoring: 'enableCahmiSubscaleScoring',
 };
 
-export enum FeatureFlagsIntegrations {
-  LORIS = 'enable-loris-integration',
-}
-
-export type FeatureFlagsIntegrationKeys = keyof typeof FeatureFlagsIntegrations;
-
 export type FeatureFlags = Partial<Record<keyof typeof FeatureFlagsKeys, LDFlagValue>>;


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-7271](https://mindlogger.atlassian.net/browse/M2-7271)

Deleted references to the `enableAdminSoftLock` feature flag.

Also deleted never-used type definitions for LORIS in our `featureFlags.ts` file that diverged from the standard way we define feature flags, and I guess never got used because `enableLorisIntegration` was eventually added using the standard pattern.

### 🪤 Peer Testing

1. Perform **Take Now** on any activity or flow
2. Complete the assessment in the web app and return to the admin app.
    **Expected outcome:** You should be soft-locked of the Admin App, same as Take Now normally works.