### PR TITLE
fix: Fix Phrase Builder drag & drop (M2-8262)

### DIFF
--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/PhrasalTemplate/PhrasalTemplatePhrase/PhrasalTemplatePhrase.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/PhrasalTemplate/PhrasalTemplatePhrase/PhrasalTemplatePhrase.tsx
@@ -48,7 +48,8 @@ export const PhrasalTemplatePhrase = ({
   const [addItemMenuAnchorEl, setAddItemMenuAnchorEl] = useState<null | HTMLElement>(null);
   const phraseFieldsName = `${name}.fields`;
   const { control, setValue, getValues, formState } = useCustomFormContext();
-  const { fields, append, remove, swap } = useFieldArray({
+
+  const { fields, append, remove, move } = useFieldArray({
     control: control as unknown as Control<{ values: TPhrasalTemplateField[] }>,
     name: phraseFieldsName as 'values',
   });
@@ -106,15 +107,9 @@ export const PhrasalTemplatePhrase = ({
   };
 
   const handleDragEnd: DragDropContextProps['onDragEnd'] = ({ destination, source }) => {
-    if (
-      !destination ||
-      source?.index === destination?.index ||
-      typeof source?.index !== 'number' ||
-      typeof destination?.index !== 'number'
-    )
-      return;
+    if (!destination || !source || source.index === destination.index) return;
 
-    swap(source.index, destination.index);
+    move(source.index, destination.index);
   };
 
   return (
@@ -217,6 +212,7 @@ export const PhrasalTemplatePhrase = ({
                     );
                   })}
                 </StyledPhraseTemplateFieldSet>
+                {provided.placeholder}
               </Box>
             )}
           </DndDroppable>


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-8262](https://mindlogger.atlassian.net/browse/M2-8262)

For some reason `swap` was being used when an item was drag & dropped to a new position, which isn't desirable. Fixed this by replacing with the `move` method.

Also made a couple minor tweaks to the code described in the commit.

### 📸 Screenshots

| Before                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| <video src="https://github.com/user-attachments/assets/659f9b7e-90eb-4143-b5b0-c3dcdfb90668"></video> | <video src="https://github.com/user-attachments/assets/bce83548-42b5-4b34-a732-6e9db454423b"></video> |

### 🪤 Peer Testing

1. Create a Phrase Builder item with a phrase containing at least 4 fields.
2. Drag the first field to the second-last position.
    **Expected outcome:** The first field should be moved to the second-last position, with the fields in between remaining in place (shifting up) and the last field preserved in the last position.
3. Perform more drag & drop testing to ensure fields are moved intuitively, and not swapped.