### PR TITLE
fix: fixing date parse when there is error in date conditions M2-8275

### DIFF
--- a/src/modules/Builder/components/ConditionRow/Condition/SwitchCondition/SwitchCondition.tsx
+++ b/src/modules/Builder/components/ConditionRow/Condition/SwitchCondition/SwitchCondition.tsx
@@ -70,19 +70,15 @@ export const SwitchCondition = ({
     ],
   });
 
-  const parsedMinDateValue = minDateValue && new Date(minDateValue);
-  const parsedMaxDateValue = maxDateValue && new Date(maxDateValue);
-  const parsedDateValue = dateValue && new Date(dateValue);
-
   useEffect(() => {
     if (dateValue && typeof dateValue === 'string') {
-      setValue(dateValueName, new Date(dateValue));
+      setValue(dateValueName, new Date(`${dateValue}T00:00:00`));
     }
     if (minDateValue && typeof minDateValue === 'string') {
-      setValue(minDateValueName, new Date(minDateValue));
+      setValue(minDateValueName, new Date(`${minDateValue}T00:00:00`));
     }
     if (maxDateValue && typeof maxDateValue === 'string') {
-      setValue(maxDateValueName, new Date(maxDateValue));
+      setValue(maxDateValueName, new Date(`${maxDateValue}T00:00:00`));
     }
   }, [
     dateValue,
@@ -238,9 +234,9 @@ export const SwitchCondition = ({
       };
 
       const onCloseStartDateCallback = () => {
-        if (!parsedMinDateValue || !parsedMaxDateValue) return;
-        if (parsedMaxDateValue < parsedMinDateValue) {
-          setValue(maxDateValueName, addDays(parsedMinDateValue, 1));
+        if (!minDateValue || !maxDateValue) return;
+        if (maxDateValue < minDateValue) {
+          setValue(maxDateValueName, addDays(minDateValue, 1));
         }
       };
 
@@ -251,7 +247,6 @@ export const SwitchCondition = ({
             <StyledFlexTopCenter>
               <DatePicker
                 name={dateValueName}
-                value={parsedDateValue}
                 data-testid={`${dataTestid}-date-value`}
                 skipMinDate
                 {...commonDateInputProps}
@@ -262,7 +257,6 @@ export const SwitchCondition = ({
             <StyledFlexTopCenter>
               <DatePicker
                 name={minDateValueName}
-                value={parsedMinDateValue}
                 key={`min-date-value-${isRangeValueShown}`}
                 onCloseCallback={onCloseStartDateCallback}
                 data-testid={`${dataTestid}-start-date-value`}
@@ -272,7 +266,6 @@ export const SwitchCondition = ({
               <StyledBodyLarge sx={{ m: theme.spacing(0, 0.4) }}>{t('and')}</StyledBodyLarge>
               <DatePicker
                 name={maxDateValueName}
-                value={parsedMaxDateValue}
                 key={`max-date-value-${isRangeValueShown}`}
                 minDate={minValue as Date}
                 data-testid={`${dataTestid}-end-date-value`}

--- a/src/modules/Builder/components/ConditionRow/Condition/SwitchCondition/SwitchCondition.tsx
+++ b/src/modules/Builder/components/ConditionRow/Condition/SwitchCondition/SwitchCondition.tsx
@@ -1,7 +1,7 @@
 import { useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { addDays } from 'date-fns';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 
 import { useCustomFormContext } from 'modules/Builder/hooks/useCustomFormContext';
 import { DatePicker } from 'shared/components/DatePicker';
@@ -55,6 +55,7 @@ export const SwitchCondition = ({
     conditionPayload,
     items,
     conditionItem,
+    dateValue,
   ] = useWatch({
     name: [
       minValueName,
@@ -65,8 +66,34 @@ export const SwitchCondition = ({
       payloadName,
       itemsName,
       itemName,
+      dateValueName,
     ],
   });
+
+  const parsedMinDateValue = minDateValue && new Date(minDateValue);
+  const parsedMaxDateValue = maxDateValue && new Date(maxDateValue);
+  const parsedDateValue = dateValue && new Date(dateValue);
+
+  useEffect(() => {
+    if (dateValue && typeof dateValue === 'string') {
+      setValue(dateValueName, new Date(dateValue));
+    }
+    if (minDateValue && typeof minDateValue === 'string') {
+      setValue(minDateValueName, new Date(minDateValue));
+    }
+    if (maxDateValue && typeof maxDateValue === 'string') {
+      setValue(maxDateValueName, new Date(maxDateValue));
+    }
+  }, [
+    dateValue,
+    minDateValue,
+    maxDateValue,
+    setValue,
+    dateValueName,
+    minDateValueName,
+    maxDateValueName,
+  ]);
+
   const groupedItems = getObjectFromList<ItemFormValues>(items);
   const selectedItemForm = groupedItems[conditionItem];
 
@@ -211,9 +238,9 @@ export const SwitchCondition = ({
       };
 
       const onCloseStartDateCallback = () => {
-        if (!minDateValue || !maxDateValue) return;
-        if (maxDateValue < minDateValue) {
-          setValue(maxDateValueName, addDays(minDateValue, 1));
+        if (!parsedMinDateValue || !parsedMaxDateValue) return;
+        if (parsedMaxDateValue < parsedMinDateValue) {
+          setValue(maxDateValueName, addDays(parsedMinDateValue, 1));
         }
       };
 
@@ -224,6 +251,7 @@ export const SwitchCondition = ({
             <StyledFlexTopCenter>
               <DatePicker
                 name={dateValueName}
+                value={parsedDateValue}
                 data-testid={`${dataTestid}-date-value`}
                 skipMinDate
                 {...commonDateInputProps}
@@ -234,6 +262,7 @@ export const SwitchCondition = ({
             <StyledFlexTopCenter>
               <DatePicker
                 name={minDateValueName}
+                value={parsedMinDateValue}
                 key={`min-date-value-${isRangeValueShown}`}
                 onCloseCallback={onCloseStartDateCallback}
                 data-testid={`${dataTestid}-start-date-value`}
@@ -243,6 +272,7 @@ export const SwitchCondition = ({
               <StyledBodyLarge sx={{ m: theme.spacing(0, 0.4) }}>{t('and')}</StyledBodyLarge>
               <DatePicker
                 name={maxDateValueName}
+                value={parsedMaxDateValue}
                 key={`max-date-value-${isRangeValueShown}`}
                 minDate={minValue as Date}
                 data-testid={`${dataTestid}-end-date-value`}


### PR DESCRIPTION
### 📝 Description
🔗 [Jira Ticket M2-8275](https://mindlogger.atlassian.net/browse/M2-8275)
this PR was created to fix date parse  when there is  error in date conditions.

### 📸 Screenshots
Error (dev branch):
https://github.com/user-attachments/assets/4ab6ed60-6486-4b9e-bffc-00d3fa4204f7
https://github.com/user-attachments/assets/0d64e085-4024-4e36-aa08-0a727f1376d4

Solved:
https://github.com/user-attachments/assets/37882507-e5d6-461b-8e8a-4aba62f1e3fd
https://github.com/user-attachments/assets/1bbb4358-ea11-4cc1-a19a-036edce3c3e7


### 🪤 Peer Testing
1 - launch the admin app.
2 - create or edit an activity into an applet
3 - create a date item
4 - and create conditional logic 
5 - set the date and save then click in activity ( check if it will retrieve error or not)

### ✏️ Notes

for more information, check the the ticket, it contain a video with error or check the video I left on PR, the first 2 videos is retrieving error. 
