### PR TITLE
feat: PDP last submission timestamp tooltip (M2-7858)

### DIFF
--- a/src/modules/Dashboard/api/api.types.ts
+++ b/src/modules/Dashboard/api/api.types.ts
@@ -101,10 +101,14 @@ export type ParticipantActivityOrFlowMetadata = {
   respondentsCount: number;
   /** # of submissions made with participant as the respondent */
   respondentSubmissionsCount: number;
+  /** Date of most recent submission with participant as the respondent */
+  respondentLastSubmissionDate: string | null;
   /** # of participants who the participant has responded about or are assigned as target subject */
   subjectsCount: number;
   /** # of submissions made with participant as the target subject */
   subjectSubmissionsCount: number;
+  /** Date of most recent submission with participant as the target subject */
+  subjectLastSubmissionDate: string | null;
 };
 
 export type AppletParticipantActivitiesMetadataResponse = {

--- a/src/modules/Dashboard/features/Participant/Assignments/AboutParticipant/AboutParticipant.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/AboutParticipant/AboutParticipant.tsx
@@ -2,11 +2,14 @@ import { useCallback, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@mui/material';
+import { format } from 'date-fns';
 
 import { useAsync } from 'shared/hooks';
 import { getAppletTargetSubjectActivitiesApi, ParticipantActivityOrFlow } from 'api';
 import { users } from 'redux/modules';
-import { ActionsMenu, Spinner, Svg } from 'shared/components';
+import { ActionsMenu, Spinner, Svg, Tooltip } from 'shared/components';
+import { StyledFlexTopCenter } from 'shared/styles';
+import { DateFormats } from 'shared/consts';
 
 import { AssignmentsTab, useAssignmentsTab } from '../AssignmentsTab';
 import { ActivitiesList } from '../ActivitiesList';
@@ -92,43 +95,59 @@ const AboutParticipant = () => {
           title={t('participantDetails.activitiesAndFlows')}
           count={fetchedActivities?.data.count ?? 0}
         >
-          {activities.map((activity, index) => (
-            <ActivityListItem key={activity.id} activityOrFlow={activity}>
-              <ActivityListItemCounter
-                icon="by-participant"
-                label={t('participantDetails.respondents')}
-                count={metadataById?.[activity.id]?.respondentsCount}
-                isLoading={isLoadingMetadata}
-              />
+          {activities.map((activity, index) => {
+            const lastSubmissionDate = metadataById?.[activity.id]?.subjectLastSubmissionDate;
+            const tooltip = lastSubmissionDate ? (
+              <>
+                <strong>{t('participantDetails.lastSubmission')}</strong>{' '}
+                {format(new Date(lastSubmissionDate), DateFormats.MonthDayYearTime)}
+              </>
+            ) : (
+              t('participantDetails.noDataYet')
+            );
 
-              <ActivityListItemCounter
-                icon="folder-opened"
-                label={t('participantDetails.submissions')}
-                count={metadataById?.[activity.id]?.subjectSubmissionsCount}
-                isLoading={isLoadingMetadata}
-              />
+            return (
+              <ActivityListItem key={activity.id} activityOrFlow={activity}>
+                <ActivityListItemCounter
+                  icon="by-participant"
+                  label={t('participantDetails.respondents')}
+                  count={metadataById?.[activity.id]?.respondentsCount}
+                  isLoading={isLoadingMetadata}
+                />
 
-              <Button
-                variant="outlined"
-                onClick={() => handleClickNavigateToData(activity)}
-                sx={{ mr: 0.4 }}
-                className="primary-button"
-                disableRipple
-                data-testid={`${dataTestId}-${index}-view-data`}
-              >
-                <Svg id="chart" width="18" height="18" fill="currentColor" />
-                {t('viewData')}
-              </Button>
+                <Tooltip tooltipTitle={tooltip} placement="top">
+                  <StyledFlexTopCenter sx={{ zIndex: 1 }}>
+                    <ActivityListItemCounter
+                      icon="folder-opened"
+                      label={t('participantDetails.submissions')}
+                      count={metadataById?.[activity.id]?.subjectSubmissionsCount}
+                      isLoading={isLoadingMetadata}
+                    />
+                  </StyledFlexTopCenter>
+                </Tooltip>
 
-              <ActionsMenu
-                anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-                transformOrigin={{ vertical: -6, horizontal: 'right' }}
-                buttonColor="secondary"
-                menuItems={getActionsMenu(activity)}
-                data-testid={`${dataTestId}-${index}`}
-              />
-            </ActivityListItem>
-          ))}
+                <Button
+                  variant="outlined"
+                  onClick={() => handleClickNavigateToData(activity)}
+                  sx={{ mr: 0.4 }}
+                  className="primary-button"
+                  disableRipple
+                  data-testid={`${dataTestId}-${index}-view-data`}
+                >
+                  <Svg id="chart" width="18" height="18" fill="currentColor" />
+                  {t('viewData')}
+                </Button>
+
+                <ActionsMenu
+                  anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                  transformOrigin={{ vertical: -6, horizontal: 'right' }}
+                  buttonColor="secondary"
+                  menuItems={getActionsMenu(activity)}
+                  data-testid={`${dataTestId}-${index}`}
+                />
+              </ActivityListItem>
+            );
+          })}
 
           {/* TODO: Add lazy load button
               https://mindlogger.atlassian.net/browse/M2-7827 */}

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -1100,7 +1100,9 @@
     "respondents": "Respondents",
     "subjects": "Subjects",
     "submissions": "Submissions",
-    "currentlyAssigned": "Currently Assigned"
+    "currentlyAssigned": "Currently Assigned",
+    "lastSubmission": "Last activity:",
+    "noDataYet": "No data yet"
   },
   "password": "Password",
   "passwordBlankSpaces": "Password must not contain spaces.",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -1099,7 +1099,9 @@
     "respondents": "Répondants",
     "subjects": "Sujets",
     "submissions": "Soumissions",
-    "currentlyAssigned": "Actuellement assigné"
+    "currentlyAssigned": "Actuellement assigné",
+    "lastSubmission": "Dernière activité :",
+    "noDataYet": "Pas encore de données"
   },
   "password": "Mot de passe",
   "passwordBlankSpaces": "Le mot de passe ne doit pas contenir d'espaces.",


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-7858](https://mindlogger.atlassian.net/browse/M2-7858)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Adds a tooltip to the **Submissions** counts on activities listed on the PDP, both on the About Participant tab and the By Participant tab.

### 📸 Screenshots


https://github.com/user-attachments/assets/8ba00b9f-95a9-4588-a775-fddbad07a30e


### 🪤 Peer Testing

**Preconditions:**

- An applet with activities or flows for which there are some submissions, both self-report and multi-informant

**Steps:**

1. Navigate to the PDP for any participant for whom there are submissions.
2. On the **About Participant** tab, observe the tooltips when hovering over the "Submissions #" counts for each activity.
    **Expected outcome:** If there are submissions, the date of the most recent submission (in UTC) for which the participant is the target subject should be shown. If there are no submissions for which the participant is the target subject, the tooltip should show "No data yet".
3. On the **By Participant** tab, observe the tooltips when hovering over the "Submissions #" counts for each activity.
    **Expected outcome:** If there are submissions, the date of the most recent submission (in UTC) for which the participant is the respondent should be shown. If there are no submissions for which the participant is the respondent, the tooltip should show "No data yet".
