### PR TITLE
feat: include legacy_user_id in data export (M2-8114)

### DIFF
--- a/src/shared/utils/exportData/getJourneyCSVObject.test.ts
+++ b/src/shared/utils/exportData/getJourneyCSVObject.test.ts
@@ -150,6 +150,7 @@ const result = {
   version: '2.0.0',
   event_id: null,
   timezone_offset: '',
+  legacy_user_id: '',
 };
 
 describe('getJourneyCSVObject', () => {

--- a/src/shared/utils/exportData/getJourneyCSVObject.ts
+++ b/src/shared/utils/exportData/getJourneyCSVObject.ts
@@ -72,9 +72,9 @@ export const getJourneyCSVReturn = ({
   response,
   options,
   version,
-  ...(legacy_user_id && { legacy_user_id }),
   event_id,
   timezone_offset: timezone_offset ?? '',
+  legacy_user_id: legacy_user_id ?? '',
 });
 
 export const getSplashScreen = (event: SuccessedEventDTO, nextExtendedEvent: ExtendedEvent) => {

--- a/src/shared/utils/exportData/getJourneyCSVObject.ts
+++ b/src/shared/utils/exportData/getJourneyCSVObject.ts
@@ -127,9 +127,9 @@ export const getSplashScreen = (event: SuccessedEventDTO, nextExtendedEvent: Ext
     response: '',
     options: '',
     version,
-    ...(legacyProfileId && { legacy_user_id: legacyProfileId }),
     event_id: null,
     timezone_offset: null,
+    legacy_user_id: legacyProfileId ?? '',
   });
 };
 
@@ -205,8 +205,8 @@ export const getJourneyCSVObject = <T>({
       rawAnswersObject,
     }),
     version,
-    ...(legacyProfileId && { legacy_user_id: legacyProfileId }),
     event_id: scheduledEventId,
     timezone_offset: tzOffset,
+    legacy_user_id: legacyProfileId ?? '',
   });
 };

--- a/src/shared/utils/exportData/getReportAndMediaData.test.ts
+++ b/src/shared/utils/exportData/getReportAndMediaData.test.ts
@@ -584,6 +584,7 @@ describe('getReportAndMediaData', () => {
           version: '1.1.1',
           event_id: '',
           timezone_offset: '',
+          legacy_user_id: '',
         },
         {
           activity_end_time: '1689770404000',
@@ -615,6 +616,7 @@ describe('getReportAndMediaData', () => {
           version: '1.1.1',
           event_id: '',
           timezone_offset: '',
+          legacy_user_id: '',
         },
       ]);
     });
@@ -671,6 +673,7 @@ describe('getReportAndMediaData', () => {
           version: '1.1.1',
           event_id: null,
           timezone_offset: '',
+          legacy_user_id: '',
         },
         {
           activity_end_time: '1689770404000',
@@ -702,6 +705,7 @@ describe('getReportAndMediaData', () => {
           version: '1.1.1',
           event_id: '',
           timezone_offset: '',
+          legacy_user_id: '',
         },
         {
           activity_end_time: '1689770404000',
@@ -733,6 +737,7 @@ describe('getReportAndMediaData', () => {
           version: '1.1.1',
           event_id: '',
           timezone_offset: '',
+          legacy_user_id: '',
         },
       ]);
     });

--- a/src/shared/utils/exportData/getReportAndMediaData.test.ts
+++ b/src/shared/utils/exportData/getReportAndMediaData.test.ts
@@ -256,6 +256,7 @@ describe('getReportAndMediaData', () => {
           reviewing_id: '',
           event_id: '',
           timezone_offset: '',
+          legacy_user_id: '',
         },
       ]);
     });
@@ -294,6 +295,7 @@ describe('getReportAndMediaData', () => {
           version: '2.1.0',
           event_id: '',
           timezone_offset: '',
+          legacy_user_id: '',
         },
         {
           activity_flow_submission_id: '',
@@ -320,6 +322,7 @@ describe('getReportAndMediaData', () => {
           version: '2.1.0',
           event_id: '',
           timezone_offset: '',
+          legacy_user_id: '',
         },
         {
           activity_flow_submission_id: '',
@@ -346,6 +349,7 @@ describe('getReportAndMediaData', () => {
           version: '2.1.0',
           event_id: '',
           timezone_offset: '',
+          legacy_user_id: '',
         },
       ]);
     });
@@ -387,6 +391,7 @@ describe('getReportAndMediaData', () => {
           version: '1.2.0',
           event_id: '',
           timezone_offset: '',
+          legacy_user_id: '',
         },
         {
           activity_flow_submission_id: '',
@@ -413,6 +418,7 @@ describe('getReportAndMediaData', () => {
           version: '1.2.0',
           event_id: '',
           timezone_offset: '',
+          legacy_user_id: '',
         },
         {
           activity_flow_submission_id: '',
@@ -440,6 +446,7 @@ describe('getReportAndMediaData', () => {
           version: '1.2.0',
           event_id: '',
           timezone_offset: '',
+          legacy_user_id: '',
         },
         {
           activity_flow_submission_id: '',
@@ -466,6 +473,7 @@ describe('getReportAndMediaData', () => {
           version: '1.2.0',
           event_id: '',
           timezone_offset: '',
+          legacy_user_id: '',
         },
         {
           activity_flow_submission_id: '',
@@ -492,6 +500,7 @@ describe('getReportAndMediaData', () => {
           version: '1.2.0',
           event_id: '',
           timezone_offset: '',
+          legacy_user_id: '',
         },
       ]);
     });

--- a/src/shared/utils/exportData/getReportCSVObject.test.ts
+++ b/src/shared/utils/exportData/getReportCSVObject.test.ts
@@ -137,6 +137,7 @@ const result = {
   version: '2.0.0',
   event_id: '',
   timezone_offset: '',
+  legacy_user_id: '',
 };
 
 describe('getReportCSVObject', () => {

--- a/src/shared/utils/exportData/getReportCSVObject.ts
+++ b/src/shared/utils/exportData/getReportCSVObject.ts
@@ -76,8 +76,8 @@ export const getReportCSVObject = <T>({
     version: version ?? '',
     rawScore: getRawScores(responseValues) || '',
     reviewing_id: reviewedFlowSubmitId ?? reviewedAnswerId ?? '',
-    ...(legacyProfileId && { legacy_user_id: legacyProfileId }),
     event_id: scheduledEventId ?? '',
     timezone_offset: tzOffset ?? '',
+    legacy_user_id: legacyProfileId ?? '',
   };
 };

--- a/src/shared/utils/exportData/prepareData.test.ts
+++ b/src/shared/utils/exportData/prepareData.test.ts
@@ -31,6 +31,7 @@ const mockedExportDataResult = {
       reviewing_id: 'c482d1fd-5b0f-4cae-b10d-77cbb4151386',
       event_id: '',
       timezone_offset: '',
+      legacy_user_id: '',
     },
     {
       id: '09b0cac4-303a-4ce9-94bd-dff922c24947',
@@ -57,6 +58,7 @@ const mockedExportDataResult = {
       reviewing_id: 'c482d1fd-5b0f-4cae-b10d-77cbb4151386',
       event_id: '',
       timezone_offset: '',
+      legacy_user_id: '',
     },
     {
       id: '09b0cac4-303a-4ce9-94bd-dff922c24947',
@@ -83,6 +85,7 @@ const mockedExportDataResult = {
       reviewing_id: 'c482d1fd-5b0f-4cae-b10d-77cbb4151386',
       event_id: '',
       timezone_offset: '',
+      legacy_user_id: '',
     },
   ],
   activityJourneyData: [],


### PR DESCRIPTION
- [x] Tests for the changes have been added
- [ ] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

Removes conditional validation to include `legacy_user_id` column and instead always places it at the end of the exported files. 

🔗 [Jira Ticket M2-8114](https://mindlogger.atlassian.net/browse/M2-8114)

Previously this column could appear at the last position or third from the end depending on when the first row with `legacy_user_id` appeared in the data. The decision was made to always include this column even if there are no rows with `legacy_user_id` for consistency.


### 📸 Screenshots


| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| ![CleanShot 2024-12-12 at 13 01 02](https://github.com/user-attachments/assets/8f25afd5-750c-42c9-9f8f-1df1960a5606) | ![CleanShot 2024-12-12 at 13 01 10](https://github.com/user-attachments/assets/1bccfe48-533b-4d23-ba35-6b7f6fe86e75) |

### 🪤 Peer Testing

- Navigate to any applet which has responses
- Export data
- `report.csv` and `user_activity_journey.csv` files should include the `legacy_user_id` column in the last position


### ✏️ Notes

Tested accounts with legacy ID in UAT.

![CleanShot 2024-12-12 at 13 04 34](https://github.com/user-attachments/assets/d0cc1c90-aed4-4dee-999e-fbf97b923bf8)
