### PR TITLE
feat: Separate Extended IFCL Items into 3 groups (M2-8402)

### DIFF
--- a/src/modules/Builder/components/ConditionRow/ConditionRow.tsx
+++ b/src/modules/Builder/components/ConditionRow/ConditionRow.tsx
@@ -11,6 +11,7 @@ import { ConditionRowType, ItemFormValues } from 'modules/Builder/types';
 import { useCustomFormContext } from 'modules/Builder/hooks';
 import { StyledErrorText, theme } from 'shared/styles';
 import { CONDITION_TYPES_TO_HAVE_OPTION_ID } from 'modules/Builder/pages/BuilderApplet/BuilderApplet.const';
+import { useFeatureFlags } from 'shared/hooks';
 
 import { ConditionRowProps } from './ConditionRow.types';
 import {
@@ -38,6 +39,7 @@ export const ConditionRow = ({
   isItemFlow = false,
 }: ConditionRowProps) => {
   const { t } = useTranslation('app');
+  const { enableItemFlowItemsG2, enableItemFlowItemsG3 } = useFeatureFlags().featureFlags;
   const {
     setValue,
     trigger,
@@ -72,9 +74,15 @@ export const ConditionRow = ({
   const selectedScore =
     scores?.find((score: ScoreReport) => getEntityKey(score, false) === scoreKey) ?? {};
   const options = {
-    [ConditionRowType.Item]: getItemOptions(items, type, isItemFlow),
+    [ConditionRowType.Item]: getItemOptions(
+      items,
+      type,
+      isItemFlow,
+      enableItemFlowItemsG2,
+      enableItemFlowItemsG3,
+    ),
     [ConditionRowType.Section]: [
-      ...getItemOptions(items, type, isItemFlow),
+      ...getItemOptions(items, type, isItemFlow, enableItemFlowItemsG2, enableItemFlowItemsG3),
       ...((scores?.length && getScoreOptions(scores)) || []),
       ...((scores?.length && getScoreConditionalsOptions(scores)) || []),
     ],

--- a/src/modules/Builder/components/ConditionRow/ConditionRow.utils.tsx
+++ b/src/modules/Builder/components/ConditionRow/ConditionRow.utils.tsx
@@ -58,26 +58,52 @@ const scoreItemTypes = [
   ItemResponseType.SingleSelection,
   ItemResponseType.MultipleSelection,
 ];
-const itemFlowItemTypes = [
-  ...scoreItemTypes,
-  ItemResponseType.Date,
-  ItemResponseType.NumberSelection,
-  ItemResponseType.Time,
-  ItemResponseType.TimeRange,
-  ItemResponseType.SingleSelectionPerRow,
-  ItemResponseType.MultipleSelectionPerRow,
-  ItemResponseType.SliderRows,
+
+const itemFlowItemGroups = [
+  [...scoreItemTypes, ItemResponseType.NumberSelection], // Group 1
+  [ItemResponseType.Date, ItemResponseType.Time, ItemResponseType.TimeRange], // Group 2
+  [
+    ItemResponseType.SingleSelectionPerRow,
+    ItemResponseType.MultipleSelectionPerRow,
+    ItemResponseType.SliderRows,
+  ], // Group 3
 ];
-const checkIfShouldBeIncluded = (responseType: ItemResponseType, isItemFlow = false) =>
-  (isItemFlow ? itemFlowItemTypes : scoreItemTypes).some((value) => value === responseType);
+
+function getItemsSubset(includeGroup2: boolean, includeGroup3: boolean) {
+  let subset = itemFlowItemGroups[0];
+
+  if (includeGroup2) subset = [...subset, ...itemFlowItemGroups[1]];
+  if (includeGroup3) subset = [...subset, ...itemFlowItemGroups[2]];
+
+  return subset;
+}
+
+const checkIfShouldBeIncluded = (
+  responseType: ItemResponseType,
+  isItemFlow = false,
+  group2 = false,
+  group3 = false,
+) =>
+  (isItemFlow ? getItemsSubset(group2, group3) : scoreItemTypes).some(
+    (value) => value === responseType,
+  );
 
 export const getItemOptions = (
   items: ItemFormValues[],
   conditionRowType: ConditionRowType,
   isItemFlow = false,
+  enableItemFlowItemsG2 = false,
+  enableItemFlowItemsG3 = false,
 ) =>
   items?.reduce((optionList: OptionListItem[], item) => {
-    if (checkIfShouldBeIncluded(item.responseType, isItemFlow)) {
+    if (
+      checkIfShouldBeIncluded(
+        item.responseType,
+        isItemFlow,
+        enableItemFlowItemsG2,
+        enableItemFlowItemsG3,
+      )
+    ) {
       return [
         ...optionList,
         {

--- a/src/modules/Builder/components/ConditionRow/ConditionRow.utils.tsx
+++ b/src/modules/Builder/components/ConditionRow/ConditionRow.utils.tsx
@@ -60,13 +60,13 @@ const scoreItemTypes = [
 ];
 
 const itemFlowItemGroups = [
-  [...scoreItemTypes, ItemResponseType.NumberSelection], // Group 1
-  [ItemResponseType.Date, ItemResponseType.Time, ItemResponseType.TimeRange], // Group 2
+  [...scoreItemTypes, ItemResponseType.NumberSelection],
+  [ItemResponseType.Date, ItemResponseType.Time, ItemResponseType.TimeRange],
   [
     ItemResponseType.SingleSelectionPerRow,
     ItemResponseType.MultipleSelectionPerRow,
     ItemResponseType.SliderRows,
-  ], // Group 3
+  ],
 ];
 
 function getItemsSubset(includeGroup2: boolean, includeGroup3: boolean) {

--- a/src/modules/Builder/features/ActivityItemsFlow/ActivityItemsFlow.test.tsx
+++ b/src/modules/Builder/features/ActivityItemsFlow/ActivityItemsFlow.test.tsx
@@ -32,6 +32,7 @@ import {
 import { createArray, getEntityKey } from 'shared/utils';
 import { renderWithAppletFormData } from 'shared/utils/renderWithAppletFormData';
 import { getNewActivity } from 'modules/Builder/pages/BuilderApplet/BuilderApplet.utils';
+import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 
 import { ActivityItemsFlow } from './ActivityItemsFlow';
 
@@ -105,6 +106,12 @@ const mockedOrderedSummaryItemItems = [
   mockedPhrasalTemplateActivityItem,
 ];
 
+jest.mock('shared/hooks/useFeatureFlags', () => ({
+  useFeatureFlags: jest.fn(),
+}));
+
+const mockUseFeatureFlags = jest.mocked(useFeatureFlags);
+
 const renderActivityItemsFlow = (formData) => {
   const ref = createRef();
 
@@ -127,6 +134,16 @@ const renderActivityItemsFlow = (formData) => {
 describe('Activity Items Flow', () => {
   beforeEach(() => {
     mockIntersectionObserver();
+    mockUseFeatureFlags.mockReturnValue({
+      featureFlags: {
+        enableItemFlowExtendedItems: true,
+      },
+      resetLDContext: jest.fn(),
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
   });
 
   test.each`
@@ -260,6 +277,13 @@ describe('Activity Items Flow', () => {
   });
 
   test('Condition Item: all items except Text/ParagraphText/Audio/Video/Photo/AudioPlayer/Drawing/Message are available', () => {
+    mockUseFeatureFlags.mockReturnValue({
+      featureFlags: {
+        enableItemFlowItemsG2: true,
+        enableItemFlowItemsG3: true,
+      },
+    });
+
     renderActivityItemsFlow(mockedAppletWithAllItemTypes);
 
     fireEvent.click(screen.getByTestId(`${mockedTestid}-add`));
@@ -276,6 +300,104 @@ describe('Activity Items Flow', () => {
     items.forEach((item, index) => {
       expect(item).toHaveAttribute('data-value', mockedOrderedConditionNameItems[index].id);
       expect(item).toHaveTextContent(mockedOrderedConditionNameItems[index].name);
+    });
+  });
+
+  test('Condition Item: Group 1 items Single/Multiple/Slider/Number Select are available', () => {
+    const mockedItems = [
+      mockedSingleActivityItem,
+      mockedMultiActivityItem,
+      mockedSliderActivityItem,
+      mockedNumberSelectActivityItem,
+    ];
+
+    renderActivityItemsFlow(mockedAppletWithAllItemTypes);
+
+    fireEvent.click(screen.getByTestId(`${mockedTestid}-add`));
+
+    fireEvent.mouseDown(
+      screen.getByTestId(`${mockedTestid}-0-condition-0-name`).querySelector('[role="button"]'),
+    );
+    const nameDropdown = screen.getByTestId(`${mockedTestid}-0-condition-0-name-dropdown`);
+    expect(nameDropdown).toBeVisible();
+
+    const items = nameDropdown.querySelectorAll('li');
+    expect(items).toHaveLength(mockedItems.length);
+
+    items.forEach((item, index) => {
+      expect(item).toHaveAttribute('data-value', mockedItems[index].id);
+      expect(item).toHaveTextContent(mockedItems[index].name);
+    });
+  });
+
+  test('Condition Item: Group 1 + Group 2 items Date/Time/TimeRange are available', () => {
+    mockUseFeatureFlags.mockReturnValue({
+      featureFlags: {
+        enableItemFlowItemsG2: true,
+      },
+    });
+    const mockedItems = [
+      mockedSingleActivityItem,
+      mockedMultiActivityItem,
+      mockedDateActivityItem,
+      mockedTimeActivityItem,
+      mockedSliderActivityItem,
+      mockedTimeRangeActivityItem,
+      mockedNumberSelectActivityItem,
+    ];
+
+    renderActivityItemsFlow(mockedAppletWithAllItemTypes);
+
+    fireEvent.click(screen.getByTestId(`${mockedTestid}-add`));
+
+    fireEvent.mouseDown(
+      screen.getByTestId(`${mockedTestid}-0-condition-0-name`).querySelector('[role="button"]'),
+    );
+    const nameDropdown = screen.getByTestId(`${mockedTestid}-0-condition-0-name-dropdown`);
+    expect(nameDropdown).toBeVisible();
+
+    const items = nameDropdown.querySelectorAll('li');
+    expect(items).toHaveLength(mockedItems.length);
+
+    items.forEach((item, index) => {
+      expect(item).toHaveAttribute('data-value', mockedItems[index].id);
+      expect(item).toHaveTextContent(mockedItems[index].name);
+    });
+  });
+
+  test('Condition Item: Group 1 + Group 3 items MatrixSliders/MatrxMultiSelect/MatrixSingleSelect are available', () => {
+    mockUseFeatureFlags.mockReturnValue({
+      featureFlags: {
+        enableItemFlowItemsG3: true,
+      },
+    });
+
+    const mockedItems = [
+      mockedSingleActivityItem,
+      mockedMultiActivityItem,
+      mockedSliderActivityItem,
+      mockedSliderRowsActivityItem,
+      mockedNumberSelectActivityItem,
+      mockedMultiSelectRowsActivityItem,
+      mockedSingleSelectRowsActivityItem,
+    ];
+
+    renderActivityItemsFlow(mockedAppletWithAllItemTypes);
+
+    fireEvent.click(screen.getByTestId(`${mockedTestid}-add`));
+
+    fireEvent.mouseDown(
+      screen.getByTestId(`${mockedTestid}-0-condition-0-name`).querySelector('[role="button"]'),
+    );
+    const nameDropdown = screen.getByTestId(`${mockedTestid}-0-condition-0-name-dropdown`);
+    expect(nameDropdown).toBeVisible();
+
+    const items = nameDropdown.querySelectorAll('li');
+    expect(items).toHaveLength(mockedItems.length);
+
+    items.forEach((item, index) => {
+      expect(item).toHaveAttribute('data-value', mockedItems[index].id);
+      expect(item).toHaveTextContent(mockedItems[index].name);
     });
   });
 

--- a/src/shared/types/featureFlags.ts
+++ b/src/shared/types/featureFlags.ts
@@ -12,6 +12,8 @@ export const FeatureFlagsKeys = {
   enableParticipantConnections: 'enableParticipantConnections',
   enableLorisIntegration: 'enableLorisIntegration',
   enableItemFlowExtendedItems: 'enableItemFlowExtendedItems',
+  enableItemFlowItemsG2: 'enableItemFlowItemsG2',
+  enableItemFlowItemsG3: 'enableItemFlowItemsG3',
   enableParagraphTextItem: 'enableParagraphTextItem',
   enablePhrasalTemplate: 'enablePhrasalTemplate',
   enableShareToLibrary: 'enableShareToLibrary',


### PR DESCRIPTION
- [ ] Tests for the changes have been added
- [ ] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

Add 2 additional feature flags that adjust the behavior from the `enableItemFlowExtendedItems` feature flag to limit which items are visible when creating Item Flow conditional logic, in order to allow for an increased rollout of the extended items.

🔗 [Jira Ticket M2-8402](https://mindlogger.atlassian.net/browse/M2-8402)


### 📸 Screenshots


| All Items Visible                      | G2 Enabled, G3 Disabled                                | G2 Disabled, G3 Enabled                                  |
| -------------------------------------- | ------------------------------------- | ------------------------------------- |
| ![CleanShot 2024-12-18 at 15 04 53](https://github.com/user-attachments/assets/3f9fd5cd-63c1-40d1-b7f7-3cde25b272c0) | ![CleanShot 2024-12-18 at 15 05 27](https://github.com/user-attachments/assets/f103c9a2-3d55-48c7-80f6-2b3e47baa9f6) | ![CleanShot 2024-12-18 at 15 05 10](https://github.com/user-attachments/assets/abfe123e-30ca-4b27-a1b8-4f3ec625b1fd) | 

### 🪤 Peer Testing

The `enableItemFlowExtendedItems` feature flag should be enabled to display the updated behavior.

* Create an applet with multiple item types, including "extended" support items. For example: Slider Select, Number Select, Date, Matrix Multi-Select. 
* Add Item Flow Conditional logic
* Items in the top row should be controlled by the 3 related feature flags.

### ✏️ Notes

In order to facilitate testing, you may adjust the return value in the `useFeatureFlags` hook to control which groups are visible.