### PR TITLE
chore: Rename symbols – "respondent" ⇒ "subject"/"participant"

### DIFF
--- a/src/modules/Dashboard/api/api.types.ts
+++ b/src/modules/Dashboard/api/api.types.ts
@@ -5,7 +5,7 @@ import { RetentionPeriods, EncryptedAnswerSharedProps, ExportActivity } from 'sh
 import { Encryption } from 'shared/utils';
 import { User } from 'modules/Auth/state';
 
-import { RespondentDetails } from '../types';
+import { SubjectDetails } from '../types';
 
 export type GetAppletsParams = {
   params: {
@@ -47,8 +47,8 @@ export type HydratedAssignment = {
   id: string;
   activityId: string | null;
   activityFlowId: string | null;
-  respondentSubject: RespondentDetails;
-  targetSubject: RespondentDetails;
+  respondentSubject: SubjectDetails;
+  targetSubject: SubjectDetails;
 };
 
 export type AssignedActivity = Activity & { assignments?: HydratedAssignment[] };
@@ -628,7 +628,7 @@ export type ActivityAnswer = {
   identifier: string | null;
   createdAt: string;
   endDatetime: string;
-  sourceSubject: RespondentDetails;
+  sourceSubject: SubjectDetails;
 };
 
 export type ActivityHistoryFull = Omit<ExportActivity, 'isPerformanceTask' | 'subscaleSetting'> & {
@@ -727,7 +727,7 @@ export type GetTargetSubjectsByRespondentParams = SubjectId & {
 };
 
 export type TargetSubjectsByRespondent = Array<
-  RespondentDetails &
+  SubjectDetails &
     AppletId & {
       submissionCount: number;
       currentlyAssigned: boolean;

--- a/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityAssignDrawer.test.tsx
+++ b/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityAssignDrawer.test.tsx
@@ -9,12 +9,12 @@ import {
   mockedAppletId,
   mockedCurrentWorkspace,
   mockedEncryption,
-  mockedLimitedRespondent,
+  mockedLimitedParticipant,
   mockedLimitedSubjectId,
   mockedOwnerId,
-  mockedOwnerRespondent,
-  mockedRespondent,
-  mockedRespondent2,
+  mockedOwnerParticipant,
+  mockedFullParticipant,
+  mockedFullParticipant2,
   mockedUserData,
 } from 'shared/mock';
 import { Roles } from 'shared/consts';
@@ -52,20 +52,25 @@ const mockedGetApplet = {
 };
 
 const mockedGetAppletParticipants = mockSuccessfulHttpResponse<ParticipantsData>({
-  result: [mockedRespondent, mockedRespondent2, mockedOwnerRespondent, mockedLimitedRespondent],
+  result: [
+    mockedFullParticipant,
+    mockedFullParticipant2,
+    mockedOwnerParticipant,
+    mockedLimitedParticipant,
+  ],
   count: 4,
 });
 
 const mockedGetAppletManagers = mockSuccessfulHttpResponse<ManagersData>({
   result: [
     {
-      id: mockedOwnerRespondent.id,
+      id: mockedOwnerParticipant.id,
       firstName: mockedUserData.firstName,
       lastName: mockedUserData.lastName,
-      email: mockedOwnerRespondent.email,
+      email: mockedOwnerParticipant.email,
       roles: [Roles.Owner],
       lastSeen: new Date().toDateString(),
-      isPinned: mockedOwnerRespondent.isPinned,
+      isPinned: mockedOwnerParticipant.isPinned,
       applets: [
         {
           id: mockedApplet.id,
@@ -93,15 +98,15 @@ const mockedGetAppletManagers = mockSuccessfulHttpResponse<ManagersData>({
 const mockedAssignment = {
   activityId: mockedAppletData.activities[0].id,
   activityFlowId: null,
-  respondentSubjectId: mockedRespondent.details[0].subjectId,
-  targetSubjectId: mockedRespondent.details[0].subjectId,
+  respondentSubjectId: mockedFullParticipant.details[0].subjectId,
+  targetSubjectId: mockedFullParticipant.details[0].subjectId,
 };
 
 const mockedLimitedAssignment = {
   activityId: mockedAppletData.activities[0].id,
   activityFlowId: null,
-  respondentSubjectId: mockedRespondent.details[0].subjectId,
-  targetSubjectId: mockedLimitedRespondent.details[0].subjectId,
+  respondentSubjectId: mockedFullParticipant.details[0].subjectId,
+  targetSubjectId: mockedLimitedParticipant.details[0].subjectId,
 };
 
 const GET_APPLET_URL = `/applets/${mockedAppletId}`;
@@ -150,9 +155,9 @@ describe('ActivityAssignDrawer', () => {
       [GET_APPLET_ACTIVITIES_URL]: mockedGetAppletActivities,
       [GET_WORKSPACE_MANAGERS_URL]: mockedGetAppletManagers,
       [GET_WORKSPACE_RESPONDENTS_URL]: (params) => {
-        if (params.userId === mockedOwnerRespondent.id) {
+        if (params.userId === mockedOwnerParticipant.id) {
           return mockSuccessfulHttpResponse<ParticipantsData>({
-            result: [mockedOwnerRespondent],
+            result: [mockedOwnerParticipant],
             count: 1,
           });
         }
@@ -278,7 +283,7 @@ describe('ActivityAssignDrawer', () => {
     renderWithProviders(
       <ActivityAssignDrawer
         appletId={mockedAppletId}
-        respondentSubjectId={mockedOwnerRespondent.details[0].subjectId}
+        respondentSubjectId={mockedOwnerParticipant.details[0].subjectId}
         open
         onClose={mockedOnClose}
       />,
@@ -287,7 +292,7 @@ describe('ActivityAssignDrawer', () => {
 
     jest.advanceTimersToNextTimer();
     await waitFor(() => {
-      checkAssignment(`${mockedOwnerRespondent.nicknames[0]} (Team)`, '');
+      checkAssignment(`${mockedOwnerParticipant.nicknames[0]} (Team)`, '');
 
       expect(
         within(screen.getByRole('alert')).getByText(
@@ -312,10 +317,10 @@ describe('ActivityAssignDrawer', () => {
 
     jest.advanceTimersToNextTimer();
     await waitFor(() => {
-      const subjectTag = t(`participantTag.${mockedLimitedRespondent.details[0].subjectTag}`);
+      const subjectTag = t(`participantTag.${mockedLimitedParticipant.details[0].subjectTag}`);
       checkAssignment(
         '',
-        `${mockedLimitedRespondent.secretIds[0]} (${mockedLimitedRespondent.nicknames[0]}) (${subjectTag})`,
+        `${mockedLimitedParticipant.secretIds[0]} (${mockedLimitedParticipant.nicknames[0]}) (${subjectTag})`,
       );
 
       expect(screen.getByText('Add Respondent')).toBeVisible();
@@ -334,8 +339,8 @@ describe('ActivityAssignDrawer', () => {
     renderWithProviders(
       <ActivityAssignDrawer
         appletId={mockedAppletId}
-        respondentSubjectId={mockedRespondent.details[0].subjectId}
-        targetSubjectId={mockedRespondent.details[0].subjectId}
+        respondentSubjectId={mockedFullParticipant.details[0].subjectId}
+        targetSubjectId={mockedFullParticipant.details[0].subjectId}
         open
         onClose={mockedOnClose}
       />,
@@ -344,9 +349,9 @@ describe('ActivityAssignDrawer', () => {
 
     jest.advanceTimersToNextTimer();
     await waitFor(() => {
-      const subjectTag = t(`participantTag.${mockedRespondent.details[0].subjectTag}`);
+      const subjectTag = t(`participantTag.${mockedFullParticipant.details[0].subjectTag}`);
       checkAssignment(
-        `${mockedRespondent.secretIds[0]} (${mockedRespondent.nicknames[0]}) (${subjectTag})`,
+        `${mockedFullParticipant.secretIds[0]} (${mockedFullParticipant.nicknames[0]}) (${subjectTag})`,
         'Self',
       );
 
@@ -365,8 +370,8 @@ describe('ActivityAssignDrawer', () => {
       <ActivityAssignDrawer
         appletId={mockedAppletId}
         activityId={mockedAppletData.activities[0].id}
-        respondentSubjectId={mockedRespondent.details[0].subjectId}
-        targetSubjectId={mockedLimitedRespondent.details[0].subjectId}
+        respondentSubjectId={mockedFullParticipant.details[0].subjectId}
+        targetSubjectId={mockedLimitedParticipant.details[0].subjectId}
         open
         onClose={mockedOnClose}
       />,
@@ -397,8 +402,8 @@ describe('ActivityAssignDrawer', () => {
       <ActivityAssignDrawer
         appletId={mockedAppletId}
         activityId={mockedAppletData.activities[0].id}
-        respondentSubjectId={mockedRespondent.details[0].subjectId}
-        targetSubjectId={mockedRespondent.details[0].subjectId}
+        respondentSubjectId={mockedFullParticipant.details[0].subjectId}
+        targetSubjectId={mockedFullParticipant.details[0].subjectId}
         open
         onClose={mockedOnClose}
       />,
@@ -417,8 +422,8 @@ describe('ActivityAssignDrawer', () => {
     const addButton = screen.getByRole('button', { name: 'Add Row' });
     fireEvent.click(addButton);
 
-    await selectParticipant('respondent', mockedRespondent.details[0].subjectId, 1);
-    await selectParticipant('target-subject', mockedLimitedRespondent.details[0].subjectId, 1);
+    await selectParticipant('respondent', mockedFullParticipant.details[0].subjectId, 1);
+    await selectParticipant('target-subject', mockedLimitedParticipant.details[0].subjectId, 1);
 
     const submitButton = screen.getByText('Next');
     await waitFor(() => expect(submitButton).toBeEnabled());
@@ -441,8 +446,8 @@ describe('ActivityAssignDrawer', () => {
       <ActivityAssignDrawer
         appletId={mockedAppletId}
         activityId={mockedAppletData.activities[0].id}
-        respondentSubjectId={mockedRespondent.details[0].subjectId}
-        targetSubjectId={mockedRespondent.details[0].subjectId}
+        respondentSubjectId={mockedFullParticipant.details[0].subjectId}
+        targetSubjectId={mockedFullParticipant.details[0].subjectId}
         open
         onClose={mockedOnClose}
       />,
@@ -479,8 +484,8 @@ describe('ActivityAssignDrawer', () => {
       <ActivityAssignDrawer
         appletId={mockedAppletId}
         activityId={mockedAppletData.activities[0].id}
-        respondentSubjectId={mockedRespondent.details[0].subjectId}
-        targetSubjectId={mockedRespondent.details[0].subjectId}
+        respondentSubjectId={mockedFullParticipant.details[0].subjectId}
+        targetSubjectId={mockedFullParticipant.details[0].subjectId}
         open
         onClose={mockedOnClose}
       />,
@@ -499,8 +504,8 @@ describe('ActivityAssignDrawer', () => {
     const addButton = screen.getByRole('button', { name: 'Add Row' });
     fireEvent.click(addButton);
 
-    await selectParticipant('respondent', mockedRespondent.details[0].subjectId, 1);
-    await selectParticipant('target-subject', mockedRespondent.details[0].subjectId, 1);
+    await selectParticipant('respondent', mockedFullParticipant.details[0].subjectId, 1);
+    await selectParticipant('target-subject', mockedFullParticipant.details[0].subjectId, 1);
 
     const submitButton = screen.getByText('Next');
     await waitFor(() => expect(submitButton).toBeEnabled());
@@ -518,7 +523,7 @@ describe('ActivityAssignDrawer', () => {
       ).toBeInTheDocument();
     });
 
-    await selectParticipant('target-subject', mockedLimitedRespondent.details[0].subjectId, 1);
+    await selectParticipant('target-subject', mockedLimitedParticipant.details[0].subjectId, 1);
     await waitFor(() => {
       expect(submitButton).toBeEnabled();
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
@@ -539,8 +544,8 @@ describe('ActivityAssignDrawer', () => {
       <ActivityAssignDrawer
         appletId={mockedAppletId}
         activityId={mockedAppletData.activities[0].id}
-        respondentSubjectId={mockedRespondent.details[0].subjectId}
-        targetSubjectId={mockedRespondent.details[0].subjectId}
+        respondentSubjectId={mockedFullParticipant.details[0].subjectId}
+        targetSubjectId={mockedFullParticipant.details[0].subjectId}
         open
         onClose={mockedOnClose}
       />,
@@ -559,8 +564,8 @@ describe('ActivityAssignDrawer', () => {
     const addButton = screen.getByRole('button', { name: 'Add Row' });
     fireEvent.click(addButton);
 
-    await selectParticipant('respondent', mockedRespondent.details[0].subjectId, 1);
-    await selectParticipant('target-subject', mockedLimitedRespondent.details[0].subjectId, 1);
+    await selectParticipant('respondent', mockedFullParticipant.details[0].subjectId, 1);
+    await selectParticipant('target-subject', mockedLimitedParticipant.details[0].subjectId, 1);
 
     const submitButton = screen.getByText('Next');
     await waitFor(() => expect(submitButton).toBeEnabled());

--- a/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityAssignDrawer.test.tsx
+++ b/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityAssignDrawer.test.tsx
@@ -13,7 +13,7 @@ import {
   mockedLimitedSubjectId,
   mockedOwnerId,
   mockedOwnerParticipant,
-  mockedFullParticipant,
+  mockedFullParticipant1,
   mockedFullParticipant2,
   mockedUserData,
 } from 'shared/mock';
@@ -53,7 +53,7 @@ const mockedGetApplet = {
 
 const mockedGetAppletParticipants = mockSuccessfulHttpResponse<ParticipantsData>({
   result: [
-    mockedFullParticipant,
+    mockedFullParticipant1,
     mockedFullParticipant2,
     mockedOwnerParticipant,
     mockedLimitedParticipant,
@@ -98,14 +98,14 @@ const mockedGetAppletManagers = mockSuccessfulHttpResponse<ManagersData>({
 const mockedAssignment = {
   activityId: mockedAppletData.activities[0].id,
   activityFlowId: null,
-  respondentSubjectId: mockedFullParticipant.details[0].subjectId,
-  targetSubjectId: mockedFullParticipant.details[0].subjectId,
+  respondentSubjectId: mockedFullParticipant1.details[0].subjectId,
+  targetSubjectId: mockedFullParticipant1.details[0].subjectId,
 };
 
 const mockedLimitedAssignment = {
   activityId: mockedAppletData.activities[0].id,
   activityFlowId: null,
-  respondentSubjectId: mockedFullParticipant.details[0].subjectId,
+  respondentSubjectId: mockedFullParticipant1.details[0].subjectId,
   targetSubjectId: mockedLimitedParticipant.details[0].subjectId,
 };
 
@@ -339,8 +339,8 @@ describe('ActivityAssignDrawer', () => {
     renderWithProviders(
       <ActivityAssignDrawer
         appletId={mockedAppletId}
-        respondentSubjectId={mockedFullParticipant.details[0].subjectId}
-        targetSubjectId={mockedFullParticipant.details[0].subjectId}
+        respondentSubjectId={mockedFullParticipant1.details[0].subjectId}
+        targetSubjectId={mockedFullParticipant1.details[0].subjectId}
         open
         onClose={mockedOnClose}
       />,
@@ -349,9 +349,9 @@ describe('ActivityAssignDrawer', () => {
 
     jest.advanceTimersToNextTimer();
     await waitFor(() => {
-      const subjectTag = t(`participantTag.${mockedFullParticipant.details[0].subjectTag}`);
+      const subjectTag = t(`participantTag.${mockedFullParticipant1.details[0].subjectTag}`);
       checkAssignment(
-        `${mockedFullParticipant.secretIds[0]} (${mockedFullParticipant.nicknames[0]}) (${subjectTag})`,
+        `${mockedFullParticipant1.secretIds[0]} (${mockedFullParticipant1.nicknames[0]}) (${subjectTag})`,
         'Self',
       );
 
@@ -370,7 +370,7 @@ describe('ActivityAssignDrawer', () => {
       <ActivityAssignDrawer
         appletId={mockedAppletId}
         activityId={mockedAppletData.activities[0].id}
-        respondentSubjectId={mockedFullParticipant.details[0].subjectId}
+        respondentSubjectId={mockedFullParticipant1.details[0].subjectId}
         targetSubjectId={mockedLimitedParticipant.details[0].subjectId}
         open
         onClose={mockedOnClose}
@@ -402,8 +402,8 @@ describe('ActivityAssignDrawer', () => {
       <ActivityAssignDrawer
         appletId={mockedAppletId}
         activityId={mockedAppletData.activities[0].id}
-        respondentSubjectId={mockedFullParticipant.details[0].subjectId}
-        targetSubjectId={mockedFullParticipant.details[0].subjectId}
+        respondentSubjectId={mockedFullParticipant1.details[0].subjectId}
+        targetSubjectId={mockedFullParticipant1.details[0].subjectId}
         open
         onClose={mockedOnClose}
       />,
@@ -422,7 +422,7 @@ describe('ActivityAssignDrawer', () => {
     const addButton = screen.getByRole('button', { name: 'Add Row' });
     fireEvent.click(addButton);
 
-    await selectParticipant('respondent', mockedFullParticipant.details[0].subjectId, 1);
+    await selectParticipant('respondent', mockedFullParticipant1.details[0].subjectId, 1);
     await selectParticipant('target-subject', mockedLimitedParticipant.details[0].subjectId, 1);
 
     const submitButton = screen.getByText('Next');
@@ -446,8 +446,8 @@ describe('ActivityAssignDrawer', () => {
       <ActivityAssignDrawer
         appletId={mockedAppletId}
         activityId={mockedAppletData.activities[0].id}
-        respondentSubjectId={mockedFullParticipant.details[0].subjectId}
-        targetSubjectId={mockedFullParticipant.details[0].subjectId}
+        respondentSubjectId={mockedFullParticipant1.details[0].subjectId}
+        targetSubjectId={mockedFullParticipant1.details[0].subjectId}
         open
         onClose={mockedOnClose}
       />,
@@ -484,8 +484,8 @@ describe('ActivityAssignDrawer', () => {
       <ActivityAssignDrawer
         appletId={mockedAppletId}
         activityId={mockedAppletData.activities[0].id}
-        respondentSubjectId={mockedFullParticipant.details[0].subjectId}
-        targetSubjectId={mockedFullParticipant.details[0].subjectId}
+        respondentSubjectId={mockedFullParticipant1.details[0].subjectId}
+        targetSubjectId={mockedFullParticipant1.details[0].subjectId}
         open
         onClose={mockedOnClose}
       />,
@@ -504,8 +504,8 @@ describe('ActivityAssignDrawer', () => {
     const addButton = screen.getByRole('button', { name: 'Add Row' });
     fireEvent.click(addButton);
 
-    await selectParticipant('respondent', mockedFullParticipant.details[0].subjectId, 1);
-    await selectParticipant('target-subject', mockedFullParticipant.details[0].subjectId, 1);
+    await selectParticipant('respondent', mockedFullParticipant1.details[0].subjectId, 1);
+    await selectParticipant('target-subject', mockedFullParticipant1.details[0].subjectId, 1);
 
     const submitButton = screen.getByText('Next');
     await waitFor(() => expect(submitButton).toBeEnabled());
@@ -544,8 +544,8 @@ describe('ActivityAssignDrawer', () => {
       <ActivityAssignDrawer
         appletId={mockedAppletId}
         activityId={mockedAppletData.activities[0].id}
-        respondentSubjectId={mockedFullParticipant.details[0].subjectId}
-        targetSubjectId={mockedFullParticipant.details[0].subjectId}
+        respondentSubjectId={mockedFullParticipant1.details[0].subjectId}
+        targetSubjectId={mockedFullParticipant1.details[0].subjectId}
         open
         onClose={mockedOnClose}
       />,
@@ -564,7 +564,7 @@ describe('ActivityAssignDrawer', () => {
     const addButton = screen.getByRole('button', { name: 'Add Row' });
     fireEvent.click(addButton);
 
-    await selectParticipant('respondent', mockedFullParticipant.details[0].subjectId, 1);
+    await selectParticipant('respondent', mockedFullParticipant1.details[0].subjectId, 1);
     await selectParticipant('target-subject', mockedLimitedParticipant.details[0].subjectId, 1);
 
     const submitButton = screen.getByText('Next');

--- a/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityReview/ActivityReview.test.tsx
+++ b/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityReview/ActivityReview.test.tsx
@@ -17,7 +17,7 @@ import { useParticipantDropdown } from 'modules/Dashboard/components';
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
 import { mockGetRequestResponses, mockSuccessfulHttpResponse } from 'shared/utils/axios-mocks';
 import { ParticipantTag, Roles } from 'shared/consts';
-import { RespondentStatus } from 'modules/Dashboard/types';
+import { ParticipantStatus } from 'modules/Dashboard/types';
 import { ParticipantsData } from 'modules/Dashboard/features/Participants';
 import { ManagersData } from 'modules/Dashboard/features';
 
@@ -63,7 +63,7 @@ const mockedOwnerRespondent = {
       invitation: null,
     },
   ],
-  status: RespondentStatus.Invited,
+  status: ParticipantStatus.Invited,
   email: mockedUserData.email,
 };
 

--- a/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityReview/ActivityReview.test.tsx
+++ b/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityReview/ActivityReview.test.tsx
@@ -9,7 +9,7 @@ import {
   mockedEncryption,
   mockedLimitedParticipant,
   mockedOwnerId,
-  mockedFullParticipant,
+  mockedFullParticipant1,
   mockedFullParticipant2,
   mockedUserData,
 } from 'shared/mock';
@@ -27,8 +27,8 @@ import { ActivityReview } from './ActivityReview';
 const mockActivity = mockedAppletData.activities[0] as unknown as Activity;
 const mockAssignments = [
   {
-    respondentSubjectId: mockedFullParticipant.details[0].subjectId,
-    targetSubjectId: mockedFullParticipant.details[0].subjectId,
+    respondentSubjectId: mockedFullParticipant1.details[0].subjectId,
+    targetSubjectId: mockedFullParticipant1.details[0].subjectId,
   },
   {
     respondentSubjectId: mockedFullParticipant2.details[0].subjectId,
@@ -69,7 +69,7 @@ const mockedOwnerRespondent = {
 
 const mockedGetAppletParticipants = mockSuccessfulHttpResponse<ParticipantsData>({
   result: [
-    mockedFullParticipant,
+    mockedFullParticipant1,
     mockedFullParticipant2,
     mockedOwnerRespondent,
     mockedLimitedParticipant,
@@ -179,10 +179,10 @@ describe('ActivityReview component', () => {
     await waitFor(() => {
       // Respondent 1
       expect(
-        screen.getByText(mockedFullParticipant.details[0].respondentSecretId),
+        screen.getByText(mockedFullParticipant1.details[0].respondentSecretId),
       ).toBeInTheDocument();
       expect(
-        screen.getByText(mockedFullParticipant.details[0].respondentNickname),
+        screen.getByText(mockedFullParticipant1.details[0].respondentNickname),
       ).toBeInTheDocument();
 
       // Subject 1

--- a/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityReview/ActivityReview.test.tsx
+++ b/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityReview/ActivityReview.test.tsx
@@ -7,10 +7,10 @@ import {
   mockedAppletId,
   mockedCurrentWorkspace,
   mockedEncryption,
-  mockedLimitedRespondent,
+  mockedLimitedParticipant,
   mockedOwnerId,
-  mockedRespondent,
-  mockedRespondent2,
+  mockedFullParticipant,
+  mockedFullParticipant2,
   mockedUserData,
 } from 'shared/mock';
 import { useParticipantDropdown } from 'modules/Dashboard/components';
@@ -27,12 +27,12 @@ import { ActivityReview } from './ActivityReview';
 const mockActivity = mockedAppletData.activities[0] as unknown as Activity;
 const mockAssignments = [
   {
-    respondentSubjectId: mockedRespondent.details[0].subjectId,
-    targetSubjectId: mockedRespondent.details[0].subjectId,
+    respondentSubjectId: mockedFullParticipant.details[0].subjectId,
+    targetSubjectId: mockedFullParticipant.details[0].subjectId,
   },
   {
-    respondentSubjectId: mockedRespondent2.details[0].subjectId,
-    targetSubjectId: mockedLimitedRespondent.details[0].subjectId,
+    respondentSubjectId: mockedFullParticipant2.details[0].subjectId,
+    targetSubjectId: mockedLimitedParticipant.details[0].subjectId,
   },
 ];
 
@@ -68,7 +68,12 @@ const mockedOwnerRespondent = {
 };
 
 const mockedGetAppletParticipants = mockSuccessfulHttpResponse<ParticipantsData>({
-  result: [mockedRespondent, mockedRespondent2, mockedOwnerRespondent, mockedLimitedRespondent],
+  result: [
+    mockedFullParticipant,
+    mockedFullParticipant2,
+    mockedOwnerRespondent,
+    mockedLimitedParticipant,
+  ],
   count: 4,
 });
 
@@ -173,22 +178,30 @@ describe('ActivityReview component', () => {
 
     await waitFor(() => {
       // Respondent 1
-      expect(screen.getByText(mockedRespondent.details[0].respondentSecretId)).toBeInTheDocument();
-      expect(screen.getByText(mockedRespondent.details[0].respondentNickname)).toBeInTheDocument();
+      expect(
+        screen.getByText(mockedFullParticipant.details[0].respondentSecretId),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(mockedFullParticipant.details[0].respondentNickname),
+      ).toBeInTheDocument();
 
       // Subject 1
       expect(screen.getByText('Self')).toBeInTheDocument();
 
       // Respondent 2
-      expect(screen.getByText(mockedRespondent2.details[0].respondentSecretId)).toBeInTheDocument();
-      expect(screen.getByText(mockedRespondent2.details[0].respondentNickname)).toBeInTheDocument();
+      expect(
+        screen.getByText(mockedFullParticipant2.details[0].respondentSecretId),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(mockedFullParticipant2.details[0].respondentNickname),
+      ).toBeInTheDocument();
 
       // Subject 2
       expect(
-        screen.getByText(mockedLimitedRespondent.details[0].respondentSecretId),
+        screen.getByText(mockedLimitedParticipant.details[0].respondentSecretId),
       ).toBeInTheDocument();
       expect(
-        screen.getByText(mockedLimitedRespondent.details[0].respondentNickname),
+        screen.getByText(mockedLimitedParticipant.details[0].respondentNickname),
       ).toBeInTheDocument();
 
       // Assignment counts

--- a/src/modules/Dashboard/components/ActivityAssignDrawer/AssignmentsTable/AssignmentsTable.test.tsx
+++ b/src/modules/Dashboard/components/ActivityAssignDrawer/AssignmentsTable/AssignmentsTable.test.tsx
@@ -9,11 +9,11 @@ import {
   mockedAppletId,
   mockedCurrentWorkspace,
   mockedEncryption,
-  mockedLimitedRespondent,
+  mockedLimitedParticipant,
   mockedOwnerId,
-  mockedOwnerRespondent,
-  mockedRespondent,
-  mockedRespondent2,
+  mockedOwnerParticipant,
+  mockedFullParticipant,
+  mockedFullParticipant2,
   mockedUserData,
 } from 'shared/mock';
 import { mockGetRequestResponses, mockSuccessfulHttpResponse } from 'shared/utils/axios-mocks';
@@ -35,8 +35,8 @@ import { AssignmentsTableProps } from './AssignmentsTable.types';
 const mockOnChange = jest.fn();
 const mockTestId = 'test-id';
 const mockedAssignment = {
-  respondentSubjectId: mockedRespondent.details[0].subjectId,
-  targetSubjectId: mockedRespondent2.details[0].subjectId,
+  respondentSubjectId: mockedFullParticipant.details[0].subjectId,
+  targetSubjectId: mockedFullParticipant2.details[0].subjectId,
 };
 
 const mockedGetAppletActivities = {
@@ -55,20 +55,25 @@ const mockedGetApplet = {
 };
 
 const mockedGetAppletParticipants = mockSuccessfulHttpResponse<ParticipantsData>({
-  result: [mockedRespondent, mockedRespondent2, mockedOwnerRespondent, mockedLimitedRespondent],
+  result: [
+    mockedFullParticipant,
+    mockedFullParticipant2,
+    mockedOwnerParticipant,
+    mockedLimitedParticipant,
+  ],
   count: 4,
 });
 
 const mockedGetAppletManagers = mockSuccessfulHttpResponse<ManagersData>({
   result: [
     {
-      id: mockedOwnerRespondent.id,
+      id: mockedOwnerParticipant.id,
       firstName: mockedUserData.firstName,
       lastName: mockedUserData.lastName,
-      email: mockedOwnerRespondent.email,
+      email: mockedOwnerParticipant.email,
       roles: [Roles.Owner],
       lastSeen: new Date().toDateString(),
-      isPinned: mockedOwnerRespondent.isPinned,
+      isPinned: mockedOwnerParticipant.isPinned,
       applets: [
         {
           id: mockedApplet.id,
@@ -151,9 +156,9 @@ describe('AssignmentsTable', () => {
       [GET_APPLET_ACTIVITIES_URL]: mockedGetAppletActivities,
       [GET_WORKSPACE_MANAGERS_URL]: mockedGetAppletManagers,
       [GET_WORKSPACE_RESPONDENTS_URL]: (params) => {
-        if (params.userId === mockedOwnerRespondent.id) {
+        if (params.userId === mockedOwnerParticipant.id) {
           return mockSuccessfulHttpResponse<ParticipantsData>({
-            result: [mockedOwnerRespondent],
+            result: [mockedOwnerParticipant],
             count: 1,
           });
         }
@@ -176,11 +181,16 @@ describe('AssignmentsTable', () => {
   it('when full account respondent is selected, should set both assignment respondent and target subject', async () => {
     renderWithProviders(<AssignmentsTableTest assignments={[{}]} />, { preloadedState });
 
-    await selectParticipant('respondent', mockedRespondent.details[0].subjectId, 0, mockTestId);
+    await selectParticipant(
+      'respondent',
+      mockedFullParticipant.details[0].subjectId,
+      0,
+      mockTestId,
+    );
     expect(mockOnChange).toHaveBeenLastCalledWith([
       {
-        respondentSubjectId: mockedRespondent.details[0].subjectId,
-        targetSubjectId: mockedRespondent.details[0].subjectId,
+        respondentSubjectId: mockedFullParticipant.details[0].subjectId,
+        targetSubjectId: mockedFullParticipant.details[0].subjectId,
       },
     ]);
   });
@@ -190,21 +200,26 @@ describe('AssignmentsTable', () => {
 
     await selectParticipant(
       'respondent',
-      mockedOwnerRespondent.details[0].subjectId,
+      mockedOwnerParticipant.details[0].subjectId,
       0,
       mockTestId,
     );
     expect(mockOnChange).toHaveBeenLastCalledWith([
-      { respondentSubjectId: mockedOwnerRespondent.details[0].subjectId },
+      { respondentSubjectId: mockedOwnerParticipant.details[0].subjectId },
     ]);
   });
 
   it('when full account target subject is selected, should set assignment target subject', async () => {
     renderWithProviders(<AssignmentsTableTest assignments={[{}]} />, { preloadedState });
 
-    await selectParticipant('target-subject', mockedRespondent.details[0].subjectId, 0, mockTestId);
+    await selectParticipant(
+      'target-subject',
+      mockedFullParticipant.details[0].subjectId,
+      0,
+      mockTestId,
+    );
     expect(mockOnChange).toHaveBeenLastCalledWith([
-      { targetSubjectId: mockedRespondent.details[0].subjectId },
+      { targetSubjectId: mockedFullParticipant.details[0].subjectId },
     ]);
   });
 
@@ -213,12 +228,12 @@ describe('AssignmentsTable', () => {
 
     await selectParticipant(
       'target-subject',
-      mockedLimitedRespondent.details[0].subjectId,
+      mockedLimitedParticipant.details[0].subjectId,
       0,
       mockTestId,
     );
     expect(mockOnChange).toHaveBeenLastCalledWith([
-      { targetSubjectId: mockedLimitedRespondent.details[0].subjectId },
+      { targetSubjectId: mockedLimitedParticipant.details[0].subjectId },
     ]);
 
     expect(screen.getByText('Add Respondent')).toBeInTheDocument();
@@ -228,7 +243,7 @@ describe('AssignmentsTable', () => {
     renderWithProviders(
       <AssignmentsTableTest
         assignments={[mockedAssignment, mockedAssignment]}
-        errors={{ duplicateRows: [`${mockedRespondent.id}_${mockedRespondent2.id}`] }}
+        errors={{ duplicateRows: [`${mockedFullParticipant.id}_${mockedFullParticipant2.id}`] }}
         data-testid="assignments-table"
       />,
       { preloadedState },
@@ -263,19 +278,27 @@ describe('AssignmentsTable', () => {
     const subjectCell = screen.getByTestId(`${mockTestId}-0-cell-targetSubjectId`);
 
     await waitFor(() => {
-      expect(within(respondentCell).getByText(mockedRespondent.secretIds[0])).toBeInTheDocument();
-      expect(within(respondentCell).getByText(mockedRespondent.nicknames[0])).toBeInTheDocument();
+      expect(
+        within(respondentCell).getByText(mockedFullParticipant.secretIds[0]),
+      ).toBeInTheDocument();
+      expect(
+        within(respondentCell).getByText(mockedFullParticipant.nicknames[0]),
+      ).toBeInTheDocument();
       expect(
         within(respondentCell).getByText(
-          t(`participantTag.${mockedRespondent.details[0].subjectTag}`),
+          t(`participantTag.${mockedFullParticipant.details[0].subjectTag}`),
         ),
       ).toBeInTheDocument();
 
-      expect(within(subjectCell).getByText(mockedRespondent2.secretIds[0])).toBeInTheDocument();
-      expect(within(subjectCell).getByText(mockedRespondent2.nicknames[0])).toBeInTheDocument();
+      expect(
+        within(subjectCell).getByText(mockedFullParticipant2.secretIds[0]),
+      ).toBeInTheDocument();
+      expect(
+        within(subjectCell).getByText(mockedFullParticipant2.nicknames[0]),
+      ).toBeInTheDocument();
       expect(
         within(subjectCell).getByText(
-          t(`participantTag.${mockedRespondent2.details[0].subjectTag}`),
+          t(`participantTag.${mockedFullParticipant2.details[0].subjectTag}`),
         ),
       ).toBeInTheDocument();
     });

--- a/src/modules/Dashboard/components/ActivityAssignDrawer/AssignmentsTable/AssignmentsTable.test.tsx
+++ b/src/modules/Dashboard/components/ActivityAssignDrawer/AssignmentsTable/AssignmentsTable.test.tsx
@@ -12,7 +12,7 @@ import {
   mockedLimitedParticipant,
   mockedOwnerId,
   mockedOwnerParticipant,
-  mockedFullParticipant,
+  mockedFullParticipant1,
   mockedFullParticipant2,
   mockedUserData,
 } from 'shared/mock';
@@ -35,7 +35,7 @@ import { AssignmentsTableProps } from './AssignmentsTable.types';
 const mockOnChange = jest.fn();
 const mockTestId = 'test-id';
 const mockedAssignment = {
-  respondentSubjectId: mockedFullParticipant.details[0].subjectId,
+  respondentSubjectId: mockedFullParticipant1.details[0].subjectId,
   targetSubjectId: mockedFullParticipant2.details[0].subjectId,
 };
 
@@ -56,7 +56,7 @@ const mockedGetApplet = {
 
 const mockedGetAppletParticipants = mockSuccessfulHttpResponse<ParticipantsData>({
   result: [
-    mockedFullParticipant,
+    mockedFullParticipant1,
     mockedFullParticipant2,
     mockedOwnerParticipant,
     mockedLimitedParticipant,
@@ -183,14 +183,14 @@ describe('AssignmentsTable', () => {
 
     await selectParticipant(
       'respondent',
-      mockedFullParticipant.details[0].subjectId,
+      mockedFullParticipant1.details[0].subjectId,
       0,
       mockTestId,
     );
     expect(mockOnChange).toHaveBeenLastCalledWith([
       {
-        respondentSubjectId: mockedFullParticipant.details[0].subjectId,
-        targetSubjectId: mockedFullParticipant.details[0].subjectId,
+        respondentSubjectId: mockedFullParticipant1.details[0].subjectId,
+        targetSubjectId: mockedFullParticipant1.details[0].subjectId,
       },
     ]);
   });
@@ -214,12 +214,12 @@ describe('AssignmentsTable', () => {
 
     await selectParticipant(
       'target-subject',
-      mockedFullParticipant.details[0].subjectId,
+      mockedFullParticipant1.details[0].subjectId,
       0,
       mockTestId,
     );
     expect(mockOnChange).toHaveBeenLastCalledWith([
-      { targetSubjectId: mockedFullParticipant.details[0].subjectId },
+      { targetSubjectId: mockedFullParticipant1.details[0].subjectId },
     ]);
   });
 
@@ -243,7 +243,7 @@ describe('AssignmentsTable', () => {
     renderWithProviders(
       <AssignmentsTableTest
         assignments={[mockedAssignment, mockedAssignment]}
-        errors={{ duplicateRows: [`${mockedFullParticipant.id}_${mockedFullParticipant2.id}`] }}
+        errors={{ duplicateRows: [`${mockedFullParticipant1.id}_${mockedFullParticipant2.id}`] }}
         data-testid="assignments-table"
       />,
       { preloadedState },
@@ -279,14 +279,14 @@ describe('AssignmentsTable', () => {
 
     await waitFor(() => {
       expect(
-        within(respondentCell).getByText(mockedFullParticipant.secretIds[0]),
+        within(respondentCell).getByText(mockedFullParticipant1.secretIds[0]),
       ).toBeInTheDocument();
       expect(
-        within(respondentCell).getByText(mockedFullParticipant.nicknames[0]),
+        within(respondentCell).getByText(mockedFullParticipant1.nicknames[0]),
       ).toBeInTheDocument();
       expect(
         within(respondentCell).getByText(
-          t(`participantTag.${mockedFullParticipant.details[0].subjectTag}`),
+          t(`participantTag.${mockedFullParticipant1.details[0].subjectTag}`),
         ),
       ).toBeInTheDocument();
 

--- a/src/modules/Dashboard/components/ActivityUnassignDrawer/ActivityUnassignDrawer.test-utils.ts
+++ b/src/modules/Dashboard/components/ActivityUnassignDrawer/ActivityUnassignDrawer.test-utils.ts
@@ -1,6 +1,6 @@
 import { screen, within } from '@testing-library/react';
 
-import { RespondentDetails } from 'modules/Dashboard/types';
+import { SubjectDetails } from 'modules/Dashboard/types';
 
 const DEFAULT_TEST_ID = 'applet-activity-unassign-assignments-table';
 
@@ -8,8 +8,8 @@ const DEFAULT_TEST_ID = 'applet-activity-unassign-assignments-table';
  * Check the values of an assignment
  */
 export const checkAssignment = (
-  respondentSubject: RespondentDetails,
-  targetSubject: RespondentDetails,
+  respondentSubject: SubjectDetails,
+  targetSubject: SubjectDetails,
   index = 0,
   testId = DEFAULT_TEST_ID,
 ) => {

--- a/src/modules/Dashboard/components/ActivityUnassignDrawer/ActivityUnassignDrawer.test.tsx
+++ b/src/modules/Dashboard/components/ActivityUnassignDrawer/ActivityUnassignDrawer.test.tsx
@@ -6,9 +6,9 @@ import {
   mockedAppletData,
   mockedAppletId,
   mockedCurrentWorkspace,
-  mockedLimitedRespondent,
+  mockedLimitedParticipant,
   mockedOwnerSubject,
-  mockedRespondent,
+  mockedFullParticipant,
 } from 'shared/mock';
 import { mockSuccessfulHttpResponse } from 'shared/utils/axios-mocks';
 import { Activity, initialStateData } from 'redux/modules';
@@ -34,14 +34,14 @@ const mockedAssignment1: HydratedAssignment = {
   activityFlowId: null,
   respondentSubject: mockedOwnerSubject,
   targetSubject: {
-    id: mockedLimitedRespondent.details[0].subjectId,
-    nickname: mockedLimitedRespondent.nicknames[0],
-    tag: mockedLimitedRespondent.details[0].subjectTag,
-    secretUserId: mockedLimitedRespondent.secretIds[0],
-    lastSeen: mockedLimitedRespondent.lastSeen,
+    id: mockedLimitedParticipant.details[0].subjectId,
+    nickname: mockedLimitedParticipant.nicknames[0],
+    tag: mockedLimitedParticipant.details[0].subjectTag,
+    secretUserId: mockedLimitedParticipant.secretIds[0],
+    lastSeen: mockedLimitedParticipant.lastSeen,
     userId: null,
-    firstName: mockedLimitedRespondent.details[0].subjectFirstName,
-    lastName: mockedLimitedRespondent.details[0].subjectLastName,
+    firstName: mockedLimitedParticipant.details[0].subjectFirstName,
+    lastName: mockedLimitedParticipant.details[0].subjectLastName,
   },
 };
 
@@ -51,14 +51,14 @@ const mockedAssignment2 = {
   activityFlowId: null,
   respondentSubject: mockedOwnerSubject,
   targetSubject: {
-    id: mockedRespondent.details[0].subjectId,
-    nickname: mockedRespondent.nicknames[0],
-    tag: mockedRespondent.details[0].subjectTag,
-    secretUserId: mockedRespondent.secretIds[0],
-    lastSeen: mockedRespondent.lastSeen,
+    id: mockedFullParticipant.details[0].subjectId,
+    nickname: mockedFullParticipant.nicknames[0],
+    tag: mockedFullParticipant.details[0].subjectTag,
+    secretUserId: mockedFullParticipant.secretIds[0],
+    lastSeen: mockedFullParticipant.lastSeen,
     userId: null,
-    firstName: mockedRespondent.details[0].subjectFirstName,
-    lastName: mockedRespondent.details[0].subjectLastName,
+    firstName: mockedFullParticipant.details[0].subjectFirstName,
+    lastName: mockedFullParticipant.details[0].subjectLastName,
   },
 };
 

--- a/src/modules/Dashboard/components/ActivityUnassignDrawer/ActivityUnassignDrawer.test.tsx
+++ b/src/modules/Dashboard/components/ActivityUnassignDrawer/ActivityUnassignDrawer.test.tsx
@@ -8,7 +8,7 @@ import {
   mockedCurrentWorkspace,
   mockedLimitedParticipant,
   mockedOwnerSubject,
-  mockedFullParticipant,
+  mockedFullParticipant1,
 } from 'shared/mock';
 import { mockSuccessfulHttpResponse } from 'shared/utils/axios-mocks';
 import { Activity, initialStateData } from 'redux/modules';
@@ -51,14 +51,14 @@ const mockedAssignment2 = {
   activityFlowId: null,
   respondentSubject: mockedOwnerSubject,
   targetSubject: {
-    id: mockedFullParticipant.details[0].subjectId,
-    nickname: mockedFullParticipant.nicknames[0],
-    tag: mockedFullParticipant.details[0].subjectTag,
-    secretUserId: mockedFullParticipant.secretIds[0],
-    lastSeen: mockedFullParticipant.lastSeen,
+    id: mockedFullParticipant1.details[0].subjectId,
+    nickname: mockedFullParticipant1.nicknames[0],
+    tag: mockedFullParticipant1.details[0].subjectTag,
+    secretUserId: mockedFullParticipant1.secretIds[0],
+    lastSeen: mockedFullParticipant1.lastSeen,
     userId: null,
-    firstName: mockedFullParticipant.details[0].subjectFirstName,
-    lastName: mockedFullParticipant.details[0].subjectLastName,
+    firstName: mockedFullParticipant1.details[0].subjectFirstName,
+    lastName: mockedFullParticipant1.details[0].subjectLastName,
   },
 };
 

--- a/src/modules/Dashboard/components/ActivityUnassignDrawer/ActivityUnassignDrawer.utils.tsx
+++ b/src/modules/Dashboard/components/ActivityUnassignDrawer/ActivityUnassignDrawer.utils.tsx
@@ -1,11 +1,11 @@
 import { Trans } from 'react-i18next';
 import { t } from 'i18next';
 
-import { RespondentDetails } from 'modules/Dashboard/types';
+import { SubjectDetails } from 'modules/Dashboard/types';
 
 import { ActivityUnassignFormValues } from './ActivityUnassignDrawer.types';
 
-const getSubjectLabel = (subject?: RespondentDetails) => {
+const getSubjectLabel = (subject?: SubjectDetails) => {
   if (!subject) {
     return '';
   }

--- a/src/modules/Dashboard/components/ActivityUnassignDrawer/AssignmentsTable/AssignmentsTable.test.tsx
+++ b/src/modules/Dashboard/components/ActivityUnassignDrawer/AssignmentsTable/AssignmentsTable.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { t } from 'i18next';
 
-import { mockedActivityId, mockedOwnerSubject, mockedRespondent } from 'shared/mock';
+import { mockedActivityId, mockedOwnerSubject, mockedFullParticipant } from 'shared/mock';
 import { HydratedAssignment } from 'api';
 
 import { AssignmentsTable } from './AssignmentsTable';
@@ -18,14 +18,14 @@ const mockedAssignment: HydratedAssignment = {
   activityFlowId: null,
   respondentSubject: mockedOwnerSubject,
   targetSubject: {
-    id: mockedRespondent.details[0].subjectId,
-    userId: mockedRespondent.id,
-    lastSeen: mockedRespondent.lastSeen,
-    firstName: mockedRespondent.details[0].subjectFirstName,
-    lastName: mockedRespondent.details[0].subjectLastName,
-    secretUserId: mockedRespondent.details[0].respondentSecretId,
-    nickname: mockedRespondent.details[0].respondentNickname,
-    tag: mockedRespondent.details[0].subjectTag,
+    id: mockedFullParticipant.details[0].subjectId,
+    userId: mockedFullParticipant.id,
+    lastSeen: mockedFullParticipant.lastSeen,
+    firstName: mockedFullParticipant.details[0].subjectFirstName,
+    lastName: mockedFullParticipant.details[0].subjectLastName,
+    secretUserId: mockedFullParticipant.details[0].respondentSecretId,
+    nickname: mockedFullParticipant.details[0].respondentNickname,
+    tag: mockedFullParticipant.details[0].subjectTag,
   },
 };
 

--- a/src/modules/Dashboard/components/ActivityUnassignDrawer/AssignmentsTable/AssignmentsTable.test.tsx
+++ b/src/modules/Dashboard/components/ActivityUnassignDrawer/AssignmentsTable/AssignmentsTable.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { t } from 'i18next';
 
-import { mockedActivityId, mockedOwnerSubject, mockedFullParticipant } from 'shared/mock';
+import { mockedActivityId, mockedOwnerSubject, mockedFullParticipant1 } from 'shared/mock';
 import { HydratedAssignment } from 'api';
 
 import { AssignmentsTable } from './AssignmentsTable';
@@ -18,14 +18,14 @@ const mockedAssignment: HydratedAssignment = {
   activityFlowId: null,
   respondentSubject: mockedOwnerSubject,
   targetSubject: {
-    id: mockedFullParticipant.details[0].subjectId,
-    userId: mockedFullParticipant.id,
-    lastSeen: mockedFullParticipant.lastSeen,
-    firstName: mockedFullParticipant.details[0].subjectFirstName,
-    lastName: mockedFullParticipant.details[0].subjectLastName,
-    secretUserId: mockedFullParticipant.details[0].respondentSecretId,
-    nickname: mockedFullParticipant.details[0].respondentNickname,
-    tag: mockedFullParticipant.details[0].subjectTag,
+    id: mockedFullParticipant1.details[0].subjectId,
+    userId: mockedFullParticipant1.id,
+    lastSeen: mockedFullParticipant1.lastSeen,
+    firstName: mockedFullParticipant1.details[0].subjectFirstName,
+    lastName: mockedFullParticipant1.details[0].subjectLastName,
+    secretUserId: mockedFullParticipant1.details[0].respondentSecretId,
+    nickname: mockedFullParticipant1.details[0].respondentNickname,
+    tag: mockedFullParticipant1.details[0].subjectTag,
   },
 };
 

--- a/src/modules/Dashboard/components/FlowGrid/FlowGrid.types.ts
+++ b/src/modules/Dashboard/components/FlowGrid/FlowGrid.types.ts
@@ -1,13 +1,13 @@
 import { BoxProps } from '@mui/material';
 
-import { RespondentDetails } from 'modules/Dashboard/types';
+import { SubjectDetails } from 'modules/Dashboard/types';
 import { Activity, ActivityFlow, SingleApplet } from 'redux/modules';
 
 export interface FlowGridProps extends BoxProps {
   applet?: SingleApplet;
   flows?: ActivityFlow[];
   activities?: Activity[];
-  subject?: RespondentDetails;
+  subject?: SubjectDetails;
   onClickAssign: (flowId: string) => void;
   onClickUnassign?: (flowId: string) => void;
   onClickItem?: (props: { activityFlowId: string }) => void;
@@ -18,7 +18,7 @@ export type UseFlowGridMenuProps = {
   appletId?: string;
   hasParticipants?: boolean;
   testId: string;
-  subject?: RespondentDetails;
+  subject?: SubjectDetails;
   onClickExportData: (flowId: string) => void;
   onClickAssign: (flowId: string) => void;
   onClickUnassign?: (flowId: string) => void;

--- a/src/modules/Dashboard/components/ParticipantDropdown/ParticipantDropdown.hooks.ts
+++ b/src/modules/Dashboard/components/ParticipantDropdown/ParticipantDropdown.hooks.ts
@@ -4,7 +4,7 @@ import { DEFAULT_ROWS_PER_PAGE, Roles } from 'shared/consts';
 import { ParticipantsData } from 'modules/Dashboard/features/Participants';
 import { getWorkspaceManagersApi, getWorkspaceRespondentsApi } from 'api';
 import { useAsync } from 'shared/hooks';
-import { Manager, Respondent, RespondentStatus } from 'modules/Dashboard/types';
+import { Manager, Participant, ParticipantStatus } from 'modules/Dashboard/types';
 import { auth, workspaces } from 'redux/modules';
 
 import {
@@ -38,8 +38,9 @@ export const useParticipantDropdown = ({
   const userData = auth.useData();
 
   const isParticipantValid = useCallback(
-    (r: Respondent) =>
-      !r.isAnonymousRespondent && (includePendingAccounts || r.status !== RespondentStatus.Pending),
+    (r: Participant) =>
+      !r.isAnonymousRespondent &&
+      (includePendingAccounts || r.status !== ParticipantStatus.Pending),
     [includePendingAccounts],
   );
 
@@ -202,7 +203,7 @@ export const useParticipantDropdown = ({
       ).filter((manager) => manager.roles.some((role) => ALLOWED_TEAM_MEMBER_ROLES.includes(role)));
 
       const participantsSearchResults = (
-        (participantsResponse?.data.result as Respondent[]) ?? []
+        (participantsResponse?.data.result as Participant[]) ?? []
       ).filter((participant) => {
         if (!isParticipantValid(participant)) return false;
 

--- a/src/modules/Dashboard/components/ParticipantDropdown/ParticipantDropdown.utils.ts
+++ b/src/modules/Dashboard/components/ParticipantDropdown/ParticipantDropdown.utils.ts
@@ -1,10 +1,10 @@
-import { Respondent } from 'modules/Dashboard/types';
+import { Participant } from 'modules/Dashboard/types';
 import { joinWihComma } from 'shared/utils';
 import i18n from 'i18n';
 
 import { ParticipantDropdownOption } from './ParticipantDropdown.types';
 
-export const participantToOption = (participant: Respondent): ParticipantDropdownOption => {
+export const participantToOption = (participant: Participant): ParticipantDropdownOption => {
   const stringNicknames = joinWihComma(participant.nicknames, true);
   const stringSecretIds = joinWihComma(participant.secretIds, true);
 

--- a/src/modules/Dashboard/features/Applet/Activities/Activities.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Activities/Activities.test.tsx
@@ -12,7 +12,7 @@ import {
   mockedAppletId,
   mockedEncryption,
   mockedOwnerId,
-  mockedFullParticipant,
+  mockedFullParticipant1,
   mockedFullParticipant2,
   mockedUserData,
 } from 'shared/mock';
@@ -427,7 +427,7 @@ describe('Dashboard > Applet > Activities screen', () => {
       };
 
       const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
-        result: [mockedFullParticipant, mockedFullParticipant2, mockedOwnerRespondent],
+        result: [mockedFullParticipant1, mockedFullParticipant2, mockedOwnerRespondent],
         count: 3,
       });
 
@@ -512,7 +512,7 @@ describe('Dashboard > Applet > Activities screen', () => {
         `${mockedUserData.firstName} ${mockedUserData.lastName} (Team)`,
       );
 
-      selectParticipant(testId, 'target', mockedFullParticipant.details[0].subjectId);
+      selectParticipant(testId, 'target', mockedFullParticipant1.details[0].subjectId);
 
       expectMixpanelTrack({ action: MixpanelEventType.ResponsesAboutDropdownOpened });
       expectMixpanelTrack({
@@ -568,7 +568,7 @@ describe('Dashboard > Applet > Activities screen', () => {
       };
 
       const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
-        result: [mockedFullParticipant, mockedFullParticipant2, mockedOwnerRespondent],
+        result: [mockedFullParticipant1, mockedFullParticipant2, mockedOwnerRespondent],
         count: 3,
       });
 
@@ -640,7 +640,7 @@ describe('Dashboard > Applet > Activities screen', () => {
 
       await openTakeNowModal(testId);
 
-      selectParticipant(testId, 'source', mockedFullParticipant.details[0].subjectId);
+      selectParticipant(testId, 'source', mockedFullParticipant1.details[0].subjectId);
 
       expectMixpanelTrack({ action: MixpanelEventType.ProvidingResponsesDropdownOpened });
       expectMixpanelTrack({
@@ -686,7 +686,7 @@ describe('Dashboard > Applet > Activities screen', () => {
       };
 
       const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
-        result: [mockedFullParticipant, mockedFullParticipant2, mockedOwnerRespondent],
+        result: [mockedFullParticipant1, mockedFullParticipant2, mockedOwnerRespondent],
         count: 3,
       });
 
@@ -795,7 +795,7 @@ describe('Dashboard > Applet > Activities screen', () => {
           option.getAttribute('data-testid')?.replace(dropdownOptionTestIdRegex, '') || '',
       );
 
-      expect(optionsText).not.toContain(mockedFullParticipant.details[0].subjectId);
+      expect(optionsText).not.toContain(mockedFullParticipant1.details[0].subjectId);
       expect(optionsText).not.toContain(mockedFullParticipant2.details[0].subjectId);
 
       selectParticipant(testId, 'loggedin', mockedOwnerRespondent.details[0].subjectId);
@@ -849,7 +849,7 @@ describe('Dashboard > Applet > Activities screen', () => {
         };
 
         const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
-          result: [mockedFullParticipant, mockedFullParticipant2, mockedOwnerRespondent],
+          result: [mockedFullParticipant1, mockedFullParticipant2, mockedOwnerRespondent],
           count: 3,
         });
 
@@ -967,7 +967,7 @@ describe('Dashboard > Applet > Activities screen', () => {
         };
 
         const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
-          result: [mockedFullParticipant, mockedFullParticipant2, mockedOwnerRespondent],
+          result: [mockedFullParticipant1, mockedFullParticipant2, mockedOwnerRespondent],
           count: 3,
         });
 
@@ -1076,7 +1076,7 @@ describe('Dashboard > Applet > Activities screen', () => {
             option.getAttribute('data-testid')?.replace(dropdownOptionTestIdRegex, '') || '',
         );
 
-        expect(optionsText).toContain(mockedFullParticipant.details[0].subjectId);
+        expect(optionsText).toContain(mockedFullParticipant1.details[0].subjectId);
         expect(optionsText).toContain(mockedFullParticipant2.details[0].subjectId);
       });
 
@@ -1113,7 +1113,7 @@ describe('Dashboard > Applet > Activities screen', () => {
         };
 
         const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
-          result: [mockedFullParticipant, mockedFullParticipant2, mockedOwnerRespondent],
+          result: [mockedFullParticipant1, mockedFullParticipant2, mockedOwnerRespondent],
           count: 3,
         });
 

--- a/src/modules/Dashboard/features/Applet/Activities/Activities.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Activities/Activities.test.tsx
@@ -25,7 +25,7 @@ import {
 } from 'shared/utils/axios-mocks';
 import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 import { ParticipantsData } from 'modules/Dashboard/features/Participants';
-import { RespondentStatus } from 'modules/Dashboard/types';
+import { ParticipantStatus } from 'modules/Dashboard/types';
 import { ManagersData } from 'modules/Dashboard/features/Managers';
 import {
   expectMixpanelTrack,
@@ -422,7 +422,7 @@ describe('Dashboard > Applet > Activities screen', () => {
             invitation: null,
           },
         ],
-        status: RespondentStatus.Invited,
+        status: ParticipantStatus.Invited,
         email: mockedUserData.email,
       };
 
@@ -563,7 +563,7 @@ describe('Dashboard > Applet > Activities screen', () => {
             invitation: null,
           },
         ],
-        status: RespondentStatus.Invited,
+        status: ParticipantStatus.Invited,
         email: mockedUserData.email,
       };
 
@@ -681,7 +681,7 @@ describe('Dashboard > Applet > Activities screen', () => {
             invitation: null,
           },
         ],
-        status: RespondentStatus.Invited,
+        status: ParticipantStatus.Invited,
         email: mockedUserData.email,
       };
 
@@ -844,7 +844,7 @@ describe('Dashboard > Applet > Activities screen', () => {
               invitation: null,
             },
           ],
-          status: RespondentStatus.Invited,
+          status: ParticipantStatus.Invited,
           email: mockedUserData.email,
         };
 
@@ -962,7 +962,7 @@ describe('Dashboard > Applet > Activities screen', () => {
               invitation: null,
             },
           ],
-          status: RespondentStatus.Invited,
+          status: ParticipantStatus.Invited,
           email: mockedUserData.email,
         };
 
@@ -1108,7 +1108,7 @@ describe('Dashboard > Applet > Activities screen', () => {
               invitation: null,
             },
           ],
-          status: RespondentStatus.Invited,
+          status: ParticipantStatus.Invited,
           email: mockedUserData.email,
         };
 

--- a/src/modules/Dashboard/features/Applet/Activities/Activities.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Activities/Activities.test.tsx
@@ -12,8 +12,8 @@ import {
   mockedAppletId,
   mockedEncryption,
   mockedOwnerId,
-  mockedRespondent,
-  mockedRespondent2,
+  mockedFullParticipant,
+  mockedFullParticipant2,
   mockedUserData,
 } from 'shared/mock';
 import { getPreloadedState } from 'shared/tests/getPreloadedState';
@@ -427,7 +427,7 @@ describe('Dashboard > Applet > Activities screen', () => {
       };
 
       const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
-        result: [mockedRespondent, mockedRespondent2, mockedOwnerRespondent],
+        result: [mockedFullParticipant, mockedFullParticipant2, mockedOwnerRespondent],
         count: 3,
       });
 
@@ -512,7 +512,7 @@ describe('Dashboard > Applet > Activities screen', () => {
         `${mockedUserData.firstName} ${mockedUserData.lastName} (Team)`,
       );
 
-      selectParticipant(testId, 'target', mockedRespondent.details[0].subjectId);
+      selectParticipant(testId, 'target', mockedFullParticipant.details[0].subjectId);
 
       expectMixpanelTrack({ action: MixpanelEventType.ResponsesAboutDropdownOpened });
       expectMixpanelTrack({
@@ -568,7 +568,7 @@ describe('Dashboard > Applet > Activities screen', () => {
       };
 
       const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
-        result: [mockedRespondent, mockedRespondent2, mockedOwnerRespondent],
+        result: [mockedFullParticipant, mockedFullParticipant2, mockedOwnerRespondent],
         count: 3,
       });
 
@@ -640,7 +640,7 @@ describe('Dashboard > Applet > Activities screen', () => {
 
       await openTakeNowModal(testId);
 
-      selectParticipant(testId, 'source', mockedRespondent.details[0].subjectId);
+      selectParticipant(testId, 'source', mockedFullParticipant.details[0].subjectId);
 
       expectMixpanelTrack({ action: MixpanelEventType.ProvidingResponsesDropdownOpened });
       expectMixpanelTrack({
@@ -686,7 +686,7 @@ describe('Dashboard > Applet > Activities screen', () => {
       };
 
       const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
-        result: [mockedRespondent, mockedRespondent2, mockedOwnerRespondent],
+        result: [mockedFullParticipant, mockedFullParticipant2, mockedOwnerRespondent],
         count: 3,
       });
 
@@ -795,8 +795,8 @@ describe('Dashboard > Applet > Activities screen', () => {
           option.getAttribute('data-testid')?.replace(dropdownOptionTestIdRegex, '') || '',
       );
 
-      expect(optionsText).not.toContain(mockedRespondent.details[0].subjectId);
-      expect(optionsText).not.toContain(mockedRespondent2.details[0].subjectId);
+      expect(optionsText).not.toContain(mockedFullParticipant.details[0].subjectId);
+      expect(optionsText).not.toContain(mockedFullParticipant2.details[0].subjectId);
 
       selectParticipant(testId, 'loggedin', mockedOwnerRespondent.details[0].subjectId);
 
@@ -849,7 +849,7 @@ describe('Dashboard > Applet > Activities screen', () => {
         };
 
         const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
-          result: [mockedRespondent, mockedRespondent2, mockedOwnerRespondent],
+          result: [mockedFullParticipant, mockedFullParticipant2, mockedOwnerRespondent],
           count: 3,
         });
 
@@ -967,7 +967,7 @@ describe('Dashboard > Applet > Activities screen', () => {
         };
 
         const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
-          result: [mockedRespondent, mockedRespondent2, mockedOwnerRespondent],
+          result: [mockedFullParticipant, mockedFullParticipant2, mockedOwnerRespondent],
           count: 3,
         });
 
@@ -1076,8 +1076,8 @@ describe('Dashboard > Applet > Activities screen', () => {
             option.getAttribute('data-testid')?.replace(dropdownOptionTestIdRegex, '') || '',
         );
 
-        expect(optionsText).toContain(mockedRespondent.details[0].subjectId);
-        expect(optionsText).toContain(mockedRespondent2.details[0].subjectId);
+        expect(optionsText).toContain(mockedFullParticipant.details[0].subjectId);
+        expect(optionsText).toContain(mockedFullParticipant2.details[0].subjectId);
       });
 
       test('should not pre-populate admin in Take Now modal', async () => {
@@ -1113,7 +1113,7 @@ describe('Dashboard > Applet > Activities screen', () => {
         };
 
         const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
-          result: [mockedRespondent, mockedRespondent2, mockedOwnerRespondent],
+          result: [mockedFullParticipant, mockedFullParticipant2, mockedOwnerRespondent],
           count: 3,
         });
 

--- a/src/modules/Dashboard/features/Applet/Popups/UpgradeAccountPopup/UpgradeAccountPopup.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/UpgradeAccountPopup/UpgradeAccountPopup.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import mockAxios from 'jest-mock-axios';
 
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
-import { mockedAppletId, mockedSubjectId1 } from 'shared/mock';
+import { mockedAppletId, mockedFullSubjectId1 } from 'shared/mock';
 import { Mixpanel, MixpanelProps, expectBanner, MixpanelEventType } from 'shared/utils';
 import { ParticipantTag } from 'shared/consts';
 
@@ -17,7 +17,7 @@ const props = {
   onClose: onCloseMock,
   popupVisible: true,
   appletId: mockedAppletId,
-  subjectId: mockedSubjectId1,
+  subjectId: mockedFullSubjectId1,
   secretId: 'test secret id',
   nickname: 'test nickname',
   tag: 'Child' as ParticipantTag,

--- a/src/modules/Dashboard/features/Applet/Schedule/ClearScheduledEventsPopup/ClearScheduledEventsPopup.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/ClearScheduledEventsPopup/ClearScheduledEventsPopup.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import mockAxios from 'jest-mock-axios';
 
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
-import { mockedAppletId, mockedFullParticipantId } from 'shared/mock';
+import { mockedAppletId, mockedFullParticipantId1 } from 'shared/mock';
 
 import { ClearScheduledEventsPopup } from './ClearScheduledEventsPopup';
 
@@ -46,7 +46,7 @@ describe('ClearScheduledEventsPopup', () => {
   test('should delete events for individual schedule', async () => {
     mockAxios.delete.mockResolvedValueOnce(null);
     renderWithProviders(
-      <ClearScheduledEventsPopup {...basicProps} userId={mockedFullParticipantId} />,
+      <ClearScheduledEventsPopup {...basicProps} userId={mockedFullParticipantId1} />,
     );
 
     const popupText = screen.getByTestId(`${dataTestid}-text`);
@@ -59,7 +59,7 @@ describe('ClearScheduledEventsPopup', () => {
     expect(
       expect(mockAxios.delete).nthCalledWith(
         1,
-        `/applets/${mockedAppletId}/events/delete_individual/${mockedFullParticipantId}`,
+        `/applets/${mockedAppletId}/events/delete_individual/${mockedFullParticipantId1}`,
         {
           signal: undefined,
         },

--- a/src/modules/Dashboard/features/Applet/Schedule/ClearScheduledEventsPopup/ClearScheduledEventsPopup.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/ClearScheduledEventsPopup/ClearScheduledEventsPopup.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import mockAxios from 'jest-mock-axios';
 
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
-import { mockedAppletId, mockedRespondentId } from 'shared/mock';
+import { mockedAppletId, mockedFullParticipantId } from 'shared/mock';
 
 import { ClearScheduledEventsPopup } from './ClearScheduledEventsPopup';
 
@@ -45,7 +45,9 @@ describe('ClearScheduledEventsPopup', () => {
 
   test('should delete events for individual schedule', async () => {
     mockAxios.delete.mockResolvedValueOnce(null);
-    renderWithProviders(<ClearScheduledEventsPopup {...basicProps} userId={mockedRespondentId} />);
+    renderWithProviders(
+      <ClearScheduledEventsPopup {...basicProps} userId={mockedFullParticipantId} />,
+    );
 
     const popupText = screen.getByTestId(`${dataTestid}-text`);
     expect(popupText).toHaveTextContent(
@@ -57,7 +59,7 @@ describe('ClearScheduledEventsPopup', () => {
     expect(
       expect(mockAxios.delete).nthCalledWith(
         1,
-        `/applets/${mockedAppletId}/events/delete_individual/${mockedRespondentId}`,
+        `/applets/${mockedAppletId}/events/delete_individual/${mockedFullParticipantId}`,
         {
           signal: undefined,
         },

--- a/src/modules/Dashboard/features/Applet/Schedule/RemoveIndividualSchedulePopup/RemoveIndividualSchedulePopup.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/RemoveIndividualSchedulePopup/RemoveIndividualSchedulePopup.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import mockAxios from 'jest-mock-axios';
 
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
-import { mockedAppletId, mockedFullParticipantId } from 'shared/mock';
+import { mockedAppletId, mockedFullParticipantId1 } from 'shared/mock';
 
 import { RemoveIndividualSchedulePopup } from './RemoveIndividualSchedulePopup';
 
@@ -14,7 +14,7 @@ const commonProps = {
   appletId: mockedAppletId,
   onClose: onCloseMock,
   open: true,
-  userId: mockedFullParticipantId,
+  userId: mockedFullParticipantId1,
   userName: 'John Doe',
 };
 
@@ -46,7 +46,7 @@ describe('RemoveIndividualSchedulePopup', () => {
         fireEvent.click(screen.getByText('Remove'));
 
         expect(mockAxios.delete).toBeCalledWith(
-          `/applets/${mockedAppletId}/events/remove_individual/${mockedFullParticipantId}`,
+          `/applets/${mockedAppletId}/events/remove_individual/${mockedFullParticipantId1}`,
           { signal: undefined },
         );
       });
@@ -94,7 +94,7 @@ describe('RemoveIndividualSchedulePopup', () => {
         fireEvent.click(screen.getByText('Remove'));
 
         expect(mockAxios.delete).toBeCalledWith(
-          `/applets/${mockedAppletId}/events/remove_individual/${mockedFullParticipantId}`,
+          `/applets/${mockedAppletId}/events/remove_individual/${mockedFullParticipantId1}`,
           { signal: undefined },
         );
       });

--- a/src/modules/Dashboard/features/Applet/Schedule/RemoveIndividualSchedulePopup/RemoveIndividualSchedulePopup.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/RemoveIndividualSchedulePopup/RemoveIndividualSchedulePopup.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import mockAxios from 'jest-mock-axios';
 
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
-import { mockedAppletId, mockedRespondentId } from 'shared/mock';
+import { mockedAppletId, mockedFullParticipantId } from 'shared/mock';
 
 import { RemoveIndividualSchedulePopup } from './RemoveIndividualSchedulePopup';
 
@@ -14,7 +14,7 @@ const commonProps = {
   appletId: mockedAppletId,
   onClose: onCloseMock,
   open: true,
-  userId: mockedRespondentId,
+  userId: mockedFullParticipantId,
   userName: 'John Doe',
 };
 
@@ -46,7 +46,7 @@ describe('RemoveIndividualSchedulePopup', () => {
         fireEvent.click(screen.getByText('Remove'));
 
         expect(mockAxios.delete).toBeCalledWith(
-          `/applets/${mockedAppletId}/events/remove_individual/${mockedRespondentId}`,
+          `/applets/${mockedAppletId}/events/remove_individual/${mockedFullParticipantId}`,
           { signal: undefined },
         );
       });
@@ -94,7 +94,7 @@ describe('RemoveIndividualSchedulePopup', () => {
         fireEvent.click(screen.getByText('Remove'));
 
         expect(mockAxios.delete).toBeCalledWith(
-          `/applets/${mockedAppletId}/events/remove_individual/${mockedRespondentId}`,
+          `/applets/${mockedAppletId}/events/remove_individual/${mockedFullParticipantId}`,
           { signal: undefined },
         );
       });

--- a/src/modules/Dashboard/features/Managers/Popups/AddManagerPopup/AddManagerForm/AddManagerForm.test.tsx
+++ b/src/modules/Dashboard/features/Managers/Popups/AddManagerPopup/AddManagerForm/AddManagerForm.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 
-import { mockedFullParticipant, mockedFullParticipant2 } from 'shared/mock';
+import { mockedFullParticipant1, mockedFullParticipant2 } from 'shared/mock';
 import { ParticipantTag, Roles } from 'shared/consts';
 
 import { AddManagerForm } from './AddManagerForm';
@@ -13,7 +13,7 @@ import { AddManagerPopupSchema } from '../AddManagerPopup.schema';
 const mockOnSubmit = jest.fn();
 const dataTestid = 'test-id';
 
-const mockedParticipants = [mockedFullParticipant, mockedFullParticipant2].map(({ details }) => {
+const mockedParticipants = [mockedFullParticipant1, mockedFullParticipant2].map(({ details }) => {
   const { respondentSecretId, respondentNickname, subjectId } = details[0];
 
   return {

--- a/src/modules/Dashboard/features/Managers/Popups/AddManagerPopup/AddManagerForm/AddManagerForm.test.tsx
+++ b/src/modules/Dashboard/features/Managers/Popups/AddManagerPopup/AddManagerForm/AddManagerForm.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 
-import { mockedRespondent, mockedRespondent2 } from 'shared/mock';
+import { mockedFullParticipant, mockedFullParticipant2 } from 'shared/mock';
 import { ParticipantTag, Roles } from 'shared/consts';
 
 import { AddManagerForm } from './AddManagerForm';
@@ -13,7 +13,7 @@ import { AddManagerPopupSchema } from '../AddManagerPopup.schema';
 const mockOnSubmit = jest.fn();
 const dataTestid = 'test-id';
 
-const mockedParticipants = [mockedRespondent, mockedRespondent2].map(({ details }) => {
+const mockedParticipants = [mockedFullParticipant, mockedFullParticipant2].map(({ details }) => {
   const { respondentSecretId, respondentNickname, subjectId } = details[0];
 
   return {

--- a/src/modules/Dashboard/features/Managers/Popups/ManagersEditAccessPopup/ManagersEditAccessPopup.test.tsx
+++ b/src/modules/Dashboard/features/Managers/Popups/ManagersEditAccessPopup/ManagersEditAccessPopup.test.tsx
@@ -9,8 +9,8 @@ import {
   mockedAppletId,
   mockedCurrentWorkspace,
   mockedOwnerId,
-  mockedSubjectId1,
-  mockedSubjectId2,
+  mockedFullSubjectId1,
+  mockedFullSubjectId2,
   mockedUserData,
 } from 'shared/mock';
 import { Roles } from 'shared/consts';
@@ -71,7 +71,7 @@ const preloadedState = {
                 accessId: 'f49a8aa2-bc9c-46cc-a9b5-03f191d908a2',
                 respondentNickname: 'John Doe',
                 respondentSecretId: '66947648-8eea-4106-9081-4b66117ef2e6',
-                subjectId: mockedSubjectId1,
+                subjectId: mockedFullSubjectId1,
               },
             ],
           },
@@ -87,7 +87,7 @@ const preloadedState = {
                 accessId: '71d4840d-ab38-4b88-a65e-417918d8d329',
                 respondentNickname: 'Sam Carter',
                 respondentSecretId: '78ec50c9-cac8-46fe-9232-352c4c561a33',
-                subjectId: mockedSubjectId2,
+                subjectId: mockedFullSubjectId2,
               },
             ],
           },

--- a/src/modules/Dashboard/features/Managers/Popups/SelectRespondentsPopup/SelectRespondentsPopup.test.tsx
+++ b/src/modules/Dashboard/features/Managers/Popups/SelectRespondentsPopup/SelectRespondentsPopup.test.tsx
@@ -7,7 +7,7 @@ import {
   mockedAppletId,
   mockedCurrentWorkspace,
   mockedManager,
-  mockedFullParticipant,
+  mockedFullParticipant1,
   mockedFullParticipant2,
   mockedFullSubjectId1,
 } from 'shared/mock';
@@ -38,7 +38,7 @@ const preloadedState = {
     allRespondents: {
       ...initialStateData,
       data: {
-        result: [mockedFullParticipant, mockedFullParticipant2],
+        result: [mockedFullParticipant1, mockedFullParticipant2],
         count: 2,
       },
     },
@@ -66,7 +66,7 @@ const getPopup = (withSelectedRespondents = true) => (
 const successfulResponse = {
   status: ApiResponseCodes.SuccessfulResponse,
   data: {
-    result: [mockedFullParticipant, mockedFullParticipant2],
+    result: [mockedFullParticipant1, mockedFullParticipant2],
     count: 2,
   },
 };

--- a/src/modules/Dashboard/features/Managers/Popups/SelectRespondentsPopup/SelectRespondentsPopup.test.tsx
+++ b/src/modules/Dashboard/features/Managers/Popups/SelectRespondentsPopup/SelectRespondentsPopup.test.tsx
@@ -7,9 +7,9 @@ import {
   mockedAppletId,
   mockedCurrentWorkspace,
   mockedManager,
-  mockedRespondent,
-  mockedRespondent2,
-  mockedSubjectId1,
+  mockedFullParticipant,
+  mockedFullParticipant2,
+  mockedFullSubjectId1,
 } from 'shared/mock';
 import { Roles } from 'shared/consts';
 import { initialStateData } from 'shared/state';
@@ -38,7 +38,7 @@ const preloadedState = {
     allRespondents: {
       ...initialStateData,
       data: {
-        result: [mockedRespondent, mockedRespondent2],
+        result: [mockedFullParticipant, mockedFullParticipant2],
         count: 2,
       },
     },
@@ -57,7 +57,7 @@ const getPopup = (withSelectedRespondents = true) => (
     appletName="testName"
     appletId={mockedAppletId}
     user={mockedManager}
-    selectedRespondents={withSelectedRespondents ? [mockedSubjectId1] : []}
+    selectedRespondents={withSelectedRespondents ? [mockedFullSubjectId1] : []}
     selectRespondentsPopupVisible={true}
     onClose={mockedCloseFn}
   />
@@ -66,7 +66,7 @@ const getPopup = (withSelectedRespondents = true) => (
 const successfulResponse = {
   status: ApiResponseCodes.SuccessfulResponse,
   data: {
-    result: [mockedRespondent, mockedRespondent2],
+    result: [mockedFullParticipant, mockedFullParticipant2],
     count: 2,
   },
 };
@@ -107,7 +107,7 @@ describe('SelectRespondentsPopup component tests', () => {
     fireEvent.click(screen.getByText('Confirm'));
 
     await waitFor(() => {
-      expect(mockedCloseFn).toBeCalledWith([mockedSubjectId1]);
+      expect(mockedCloseFn).toBeCalledWith([mockedFullSubjectId1]);
     });
   });
 

--- a/src/modules/Dashboard/features/Participant/Activities/Activities.test.tsx
+++ b/src/modules/Dashboard/features/Participant/Activities/Activities.test.tsx
@@ -15,7 +15,7 @@ import {
   mockedOwnerId,
   mockedOwnerParticipant,
   mockedOwnerSubject,
-  mockedFullParticipant,
+  mockedFullParticipant1,
   mockedFullParticipant2,
   mockedUserData,
 } from 'shared/mock';
@@ -289,7 +289,7 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
 
     test('should pre-populate admin and participant in Take Now modal', async () => {
       const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
-        result: [mockedFullParticipant, mockedFullParticipant2, mockedOwnerParticipant],
+        result: [mockedFullParticipant1, mockedFullParticipant2, mockedOwnerParticipant],
         count: 3,
       });
 
@@ -380,7 +380,7 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
 
     test('Full account participants cannot self-report', async () => {
       const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
-        result: [mockedFullParticipant, mockedFullParticipant2, mockedOwnerParticipant],
+        result: [mockedFullParticipant1, mockedFullParticipant2, mockedOwnerParticipant],
         count: 3,
       });
 
@@ -462,7 +462,7 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
 
       const fullAccountParticipantOption = getByTestId(
         `${sourceSubjectDropdownTestId(testId)}-option-${
-          mockedFullParticipant.details[0].subjectId
+          mockedFullParticipant1.details[0].subjectId
         }`,
       );
 
@@ -475,7 +475,7 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
 
     test('Full account participants are not present in the inputting dropdown', async () => {
       const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
-        result: [mockedFullParticipant, mockedFullParticipant2, mockedOwnerParticipant],
+        result: [mockedFullParticipant1, mockedFullParticipant2, mockedOwnerParticipant],
         count: 3,
       });
 
@@ -589,7 +589,7 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
           option.getAttribute('data-testid')?.replace(dropdownOptionTestIdRegex, '') || '',
       );
 
-      expect(optionsText).not.toContain(mockedFullParticipant.details[0].subjectId);
+      expect(optionsText).not.toContain(mockedFullParticipant1.details[0].subjectId);
       expect(optionsText).not.toContain(mockedFullParticipant2.details[0].subjectId);
     });
 
@@ -605,7 +605,7 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
 
       test('should pre-populate only participant in Take Now modal', async () => {
         const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
-          result: [mockedFullParticipant, mockedFullParticipant2, mockedOwnerParticipant],
+          result: [mockedFullParticipant1, mockedFullParticipant2, mockedOwnerParticipant],
           count: 3,
         });
 
@@ -695,7 +695,7 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
 
       test('Full account participants can self-report', async () => {
         const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
-          result: [mockedFullParticipant, mockedFullParticipant2, mockedOwnerParticipant],
+          result: [mockedFullParticipant1, mockedFullParticipant2, mockedOwnerParticipant],
           count: 3,
         });
 
@@ -767,7 +767,7 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
 
         await openTakeNowModal(testId);
 
-        selectParticipant(testId, 'source', mockedFullParticipant.details[0].subjectId);
+        selectParticipant(testId, 'source', mockedFullParticipant1.details[0].subjectId);
 
         expectMixpanelTrack({ action: MixpanelEventType.ProvidingResponsesDropdownOpened });
         expectMixpanelTrack({
@@ -782,7 +782,7 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
 
       test('Full account participants are present in the inputting dropdown', async () => {
         const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
-          result: [mockedFullParticipant, mockedFullParticipant2, mockedOwnerParticipant],
+          result: [mockedFullParticipant1, mockedFullParticipant2, mockedOwnerParticipant],
           count: 3,
         });
 
@@ -891,7 +891,7 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
             option.getAttribute('data-testid')?.replace(dropdownOptionTestIdRegex, '') || '',
         );
 
-        expect(optionsText).toContain(mockedFullParticipant.details[0].subjectId);
+        expect(optionsText).toContain(mockedFullParticipant1.details[0].subjectId);
         expect(optionsText).toContain(mockedFullParticipant2.details[0].subjectId);
       });
     });

--- a/src/modules/Dashboard/features/Participant/Activities/Activities.test.tsx
+++ b/src/modules/Dashboard/features/Participant/Activities/Activities.test.tsx
@@ -13,10 +13,10 @@ import {
   mockedAppletId,
   mockedEncryption,
   mockedOwnerId,
-  mockedOwnerRespondent,
+  mockedOwnerParticipant,
   mockedOwnerSubject,
-  mockedRespondent,
-  mockedRespondent2,
+  mockedFullParticipant,
+  mockedFullParticipant2,
   mockedUserData,
 } from 'shared/mock';
 import { getPreloadedState } from 'shared/tests/getPreloadedState';
@@ -101,12 +101,12 @@ const successfulEmptyHttpResponseMock: HttpResponse = {
 
 const getAppletUrl = `/applets/${mockedAppletId}`;
 const getAppletActivitiesUrl = `/activities/applet/${mockedAppletId}`;
-const getAppletSubjectActivitiesUrl = `/activities/applet/${mockedAppletId}/subject/${mockedOwnerRespondent.details[0].subjectId}`;
+const getAppletSubjectActivitiesUrl = `/activities/applet/${mockedAppletId}/subject/${mockedOwnerParticipant.details[0].subjectId}`;
 const getWorkspaceRespondentsUrl = `/workspaces/${mockedOwnerId}/applets/${mockedAppletId}/respondents`;
 const getWorkspaceManagersUrl = `/workspaces/${mockedOwnerId}/applets/${mockedAppletId}/managers`;
 
 const testId = 'dashboard-applet-participant-activities';
-const route = `/dashboard/${mockedAppletId}/participants/${mockedOwnerRespondent.details[0].subjectId}`;
+const route = `/dashboard/${mockedAppletId}/participants/${mockedOwnerParticipant.details[0].subjectId}`;
 const routePath = page.appletParticipantDetails;
 
 const preloadedState: PreloadedState<RootState> = {
@@ -289,20 +289,20 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
 
     test('should pre-populate admin and participant in Take Now modal', async () => {
       const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
-        result: [mockedRespondent, mockedRespondent2, mockedOwnerRespondent],
+        result: [mockedFullParticipant, mockedFullParticipant2, mockedOwnerParticipant],
         count: 3,
       });
 
       const successfulGetAppletManagersMock = mockSuccessfulHttpResponse<ManagersData>({
         result: [
           {
-            id: mockedOwnerRespondent.id,
+            id: mockedOwnerParticipant.id,
             firstName: mockedUserData.firstName,
             lastName: mockedUserData.lastName,
-            email: mockedOwnerRespondent.email,
+            email: mockedOwnerParticipant.email,
             roles: [Roles.Owner],
             lastSeen: new Date().toDateString(),
-            isPinned: mockedOwnerRespondent.isPinned,
+            isPinned: mockedOwnerParticipant.isPinned,
             applets: [
               {
                 id: mockedApplet.id,
@@ -332,9 +332,9 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
         [getAppletActivitiesUrl]: successfulGetAppletActivitiesMock,
         [getAppletSubjectActivitiesUrl]: successfulGetAppletSubjectActivitiesMock,
         [getWorkspaceRespondentsUrl]: (params) => {
-          if (params.userId === mockedOwnerRespondent.id) {
+          if (params.userId === mockedOwnerParticipant.id) {
             return mockSuccessfulHttpResponse<ParticipantsData>({
-              result: [mockedOwnerRespondent],
+              result: [mockedOwnerParticipant],
               count: 1,
             });
           }
@@ -380,20 +380,20 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
 
     test('Full account participants cannot self-report', async () => {
       const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
-        result: [mockedRespondent, mockedRespondent2, mockedOwnerRespondent],
+        result: [mockedFullParticipant, mockedFullParticipant2, mockedOwnerParticipant],
         count: 3,
       });
 
       const successfulGetAppletManagersMock = mockSuccessfulHttpResponse<ManagersData>({
         result: [
           {
-            id: mockedOwnerRespondent.id,
+            id: mockedOwnerParticipant.id,
             firstName: mockedUserData.firstName,
             lastName: mockedUserData.lastName,
-            email: mockedOwnerRespondent.email,
+            email: mockedOwnerParticipant.email,
             roles: [Roles.Owner],
             lastSeen: new Date().toDateString(),
-            isPinned: mockedOwnerRespondent.isPinned,
+            isPinned: mockedOwnerParticipant.isPinned,
             applets: [
               {
                 id: mockedApplet.id,
@@ -423,9 +423,9 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
         [getAppletActivitiesUrl]: successfulGetAppletActivitiesMock,
         [getAppletSubjectActivitiesUrl]: successfulGetAppletSubjectActivitiesMock,
         [getWorkspaceRespondentsUrl]: (params) => {
-          if (params.userId === mockedOwnerRespondent.id) {
+          if (params.userId === mockedOwnerParticipant.id) {
             return mockSuccessfulHttpResponse<ParticipantsData>({
-              result: [mockedOwnerRespondent],
+              result: [mockedOwnerParticipant],
               count: 1,
             });
           }
@@ -461,7 +461,9 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
       fireEvent.mouseDown(inputElement);
 
       const fullAccountParticipantOption = getByTestId(
-        `${sourceSubjectDropdownTestId(testId)}-option-${mockedRespondent.details[0].subjectId}`,
+        `${sourceSubjectDropdownTestId(testId)}-option-${
+          mockedFullParticipant.details[0].subjectId
+        }`,
       );
 
       fireEvent.click(fullAccountParticipantOption);
@@ -473,20 +475,20 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
 
     test('Full account participants are not present in the inputting dropdown', async () => {
       const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
-        result: [mockedRespondent, mockedRespondent2, mockedOwnerRespondent],
+        result: [mockedFullParticipant, mockedFullParticipant2, mockedOwnerParticipant],
         count: 3,
       });
 
       const successfulGetAppletManagersMock = mockSuccessfulHttpResponse<ManagersData>({
         result: [
           {
-            id: mockedOwnerRespondent.id,
+            id: mockedOwnerParticipant.id,
             firstName: mockedUserData.firstName,
             lastName: mockedUserData.lastName,
-            email: mockedOwnerRespondent.email,
+            email: mockedOwnerParticipant.email,
             roles: [Roles.Owner],
             lastSeen: new Date().toDateString(),
-            isPinned: mockedOwnerRespondent.isPinned,
+            isPinned: mockedOwnerParticipant.isPinned,
             applets: [
               {
                 id: mockedApplet.id,
@@ -516,9 +518,9 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
         [getAppletActivitiesUrl]: successfulGetAppletActivitiesMock,
         [getAppletSubjectActivitiesUrl]: successfulGetAppletSubjectActivitiesMock,
         [getWorkspaceRespondentsUrl]: (params) => {
-          if (params.userId === mockedOwnerRespondent.id) {
+          if (params.userId === mockedOwnerParticipant.id) {
             return mockSuccessfulHttpResponse<ParticipantsData>({
-              result: [mockedOwnerRespondent],
+              result: [mockedOwnerParticipant],
               count: 1,
             });
           }
@@ -550,7 +552,7 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
         [MixpanelProps.Via]: 'Applet - Participants - Activities',
       });
 
-      await selectParticipant(testId, 'source', mockedOwnerRespondent.details[0].subjectId);
+      await selectParticipant(testId, 'source', mockedOwnerParticipant.details[0].subjectId);
 
       expectMixpanelTrack({ action: MixpanelEventType.ProvidingResponsesDropdownOpened });
       expectMixpanelTrack({
@@ -587,8 +589,8 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
           option.getAttribute('data-testid')?.replace(dropdownOptionTestIdRegex, '') || '',
       );
 
-      expect(optionsText).not.toContain(mockedRespondent.details[0].subjectId);
-      expect(optionsText).not.toContain(mockedRespondent2.details[0].subjectId);
+      expect(optionsText).not.toContain(mockedFullParticipant.details[0].subjectId);
+      expect(optionsText).not.toContain(mockedFullParticipant2.details[0].subjectId);
     });
 
     describe('featureFlags.enableParticipantMultiInformant = true', () => {
@@ -603,20 +605,20 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
 
       test('should pre-populate only participant in Take Now modal', async () => {
         const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
-          result: [mockedRespondent, mockedRespondent2, mockedOwnerRespondent],
+          result: [mockedFullParticipant, mockedFullParticipant2, mockedOwnerParticipant],
           count: 3,
         });
 
         const successfulGetAppletManagersMock = mockSuccessfulHttpResponse<ManagersData>({
           result: [
             {
-              id: mockedOwnerRespondent.id,
+              id: mockedOwnerParticipant.id,
               firstName: mockedUserData.firstName,
               lastName: mockedUserData.lastName,
-              email: mockedOwnerRespondent.email,
+              email: mockedOwnerParticipant.email,
               roles: [Roles.Owner],
               lastSeen: new Date().toDateString(),
-              isPinned: mockedOwnerRespondent.isPinned,
+              isPinned: mockedOwnerParticipant.isPinned,
               applets: [
                 {
                   id: mockedApplet.id,
@@ -646,9 +648,9 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
           [getAppletActivitiesUrl]: successfulGetAppletActivitiesMock,
           [getAppletSubjectActivitiesUrl]: successfulGetAppletSubjectActivitiesMock,
           [getWorkspaceRespondentsUrl]: (params) => {
-            if (params.userId === mockedOwnerRespondent.id) {
+            if (params.userId === mockedOwnerParticipant.id) {
               return mockSuccessfulHttpResponse<ParticipantsData>({
-                result: [mockedOwnerRespondent],
+                result: [mockedOwnerParticipant],
                 count: 1,
               });
             }
@@ -693,20 +695,20 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
 
       test('Full account participants can self-report', async () => {
         const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
-          result: [mockedRespondent, mockedRespondent2, mockedOwnerRespondent],
+          result: [mockedFullParticipant, mockedFullParticipant2, mockedOwnerParticipant],
           count: 3,
         });
 
         const successfulGetAppletManagersMock = mockSuccessfulHttpResponse<ManagersData>({
           result: [
             {
-              id: mockedOwnerRespondent.id,
+              id: mockedOwnerParticipant.id,
               firstName: mockedUserData.firstName,
               lastName: mockedUserData.lastName,
-              email: mockedOwnerRespondent.email,
+              email: mockedOwnerParticipant.email,
               roles: [Roles.Owner],
               lastSeen: new Date().toDateString(),
-              isPinned: mockedOwnerRespondent.isPinned,
+              isPinned: mockedOwnerParticipant.isPinned,
               applets: [
                 {
                   id: mockedApplet.id,
@@ -736,9 +738,9 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
           [getAppletActivitiesUrl]: successfulGetAppletActivitiesMock,
           [getAppletSubjectActivitiesUrl]: successfulGetAppletSubjectActivitiesMock,
           [getWorkspaceRespondentsUrl]: (params) => {
-            if (params.userId === mockedOwnerRespondent.id) {
+            if (params.userId === mockedOwnerParticipant.id) {
               return mockSuccessfulHttpResponse<ParticipantsData>({
-                result: [mockedOwnerRespondent],
+                result: [mockedOwnerParticipant],
                 count: 1,
               });
             }
@@ -765,7 +767,7 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
 
         await openTakeNowModal(testId);
 
-        selectParticipant(testId, 'source', mockedRespondent.details[0].subjectId);
+        selectParticipant(testId, 'source', mockedFullParticipant.details[0].subjectId);
 
         expectMixpanelTrack({ action: MixpanelEventType.ProvidingResponsesDropdownOpened });
         expectMixpanelTrack({
@@ -780,20 +782,20 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
 
       test('Full account participants are present in the inputting dropdown', async () => {
         const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
-          result: [mockedRespondent, mockedRespondent2, mockedOwnerRespondent],
+          result: [mockedFullParticipant, mockedFullParticipant2, mockedOwnerParticipant],
           count: 3,
         });
 
         const successfulGetAppletManagersMock = mockSuccessfulHttpResponse<ManagersData>({
           result: [
             {
-              id: mockedOwnerRespondent.id,
+              id: mockedOwnerParticipant.id,
               firstName: mockedUserData.firstName,
               lastName: mockedUserData.lastName,
-              email: mockedOwnerRespondent.email,
+              email: mockedOwnerParticipant.email,
               roles: [Roles.Owner],
               lastSeen: new Date().toDateString(),
-              isPinned: mockedOwnerRespondent.isPinned,
+              isPinned: mockedOwnerParticipant.isPinned,
               applets: [
                 {
                   id: mockedApplet.id,
@@ -823,9 +825,9 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
           [getAppletActivitiesUrl]: successfulGetAppletActivitiesMock,
           [getAppletSubjectActivitiesUrl]: successfulGetAppletSubjectActivitiesMock,
           [getWorkspaceRespondentsUrl]: (params) => {
-            if (params.userId === mockedOwnerRespondent.id) {
+            if (params.userId === mockedOwnerParticipant.id) {
               return mockSuccessfulHttpResponse<ParticipantsData>({
-                result: [mockedOwnerRespondent],
+                result: [mockedOwnerParticipant],
                 count: 1,
               });
             }
@@ -852,7 +854,7 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
 
         await openTakeNowModal(testId);
 
-        await selectParticipant(testId, 'source', mockedOwnerRespondent.details[0].subjectId);
+        await selectParticipant(testId, 'source', mockedOwnerParticipant.details[0].subjectId);
 
         expectMixpanelTrack({ action: MixpanelEventType.ProvidingResponsesDropdownOpened });
         expectMixpanelTrack({
@@ -889,8 +891,8 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
             option.getAttribute('data-testid')?.replace(dropdownOptionTestIdRegex, '') || '',
         );
 
-        expect(optionsText).toContain(mockedRespondent.details[0].subjectId);
-        expect(optionsText).toContain(mockedRespondent2.details[0].subjectId);
+        expect(optionsText).toContain(mockedFullParticipant.details[0].subjectId);
+        expect(optionsText).toContain(mockedFullParticipant2.details[0].subjectId);
       });
     });
   });

--- a/src/modules/Dashboard/features/Participant/Assignments/AssignmentsTab/AssignmentsTab.hooks.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/AssignmentsTab/AssignmentsTab.hooks.tsx
@@ -31,7 +31,7 @@ import { DataExportPopup } from 'modules/Dashboard/features/Respondents/Popups';
 import { useTakeNowModal } from 'modules/Dashboard/components/TakeNowModal/TakeNowModal';
 import { ActivityAssignDrawer, ActivityUnassignDrawer } from 'modules/Dashboard/components';
 import { EditablePerformanceTasks } from 'modules/Builder/features/Activities/Activities.const';
-import { RespondentDetails } from 'modules/Dashboard/types';
+import { SubjectDetails } from 'modules/Dashboard/types';
 
 import { UseAssignmentsTabProps } from './AssignmentsTab.types';
 
@@ -182,7 +182,7 @@ export const useAssignmentsTab = ({
   );
 
   const onClickAssign = useCallback(
-    (activityOrFlow?: ParticipantActivityOrFlow, targetSubjectArg?: RespondentDetails) => {
+    (activityOrFlow?: ParticipantActivityOrFlow, targetSubjectArg?: SubjectDetails) => {
       if (activityOrFlow) setSelectedActivityOrFlow(activityOrFlow);
       setSelectedTargetSubjectId(targetSubjectArg?.id ?? targetSubject?.id);
       setShowActivityAssign(true);

--- a/src/modules/Dashboard/features/Participant/Assignments/AssignmentsTab/AssignmentsTab.types.ts
+++ b/src/modules/Dashboard/features/Participant/Assignments/AssignmentsTab/AssignmentsTab.types.ts
@@ -1,6 +1,6 @@
 import { PropsWithChildren } from 'react';
 
-import { RespondentDetails } from 'modules/Dashboard/types';
+import { SubjectDetails } from 'modules/Dashboard/types';
 
 export type AssignmentsTabProps = PropsWithChildren<{
   isLoadingMetadata: boolean;
@@ -10,8 +10,8 @@ export type AssignmentsTabProps = PropsWithChildren<{
 
 export type UseAssignmentsTabProps = {
   appletId?: string;
-  targetSubject?: RespondentDetails;
-  respondentSubject?: RespondentDetails;
+  targetSubject?: SubjectDetails;
+  respondentSubject?: SubjectDetails;
   handleRefetch?: () => void;
   dataTestId: string;
 };

--- a/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ByParticipant.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ByParticipant.tsx
@@ -12,7 +12,7 @@ import {
 } from 'api';
 import { users } from 'redux/modules';
 import { ActionsMenu, Spinner, Tooltip } from 'shared/components';
-import { RespondentDetails } from 'modules/Dashboard/types';
+import { SubjectDetails } from 'modules/Dashboard/types';
 import { StyledFlexTopCenter } from 'shared/styles';
 import { DateFormats } from 'shared/consts';
 
@@ -101,7 +101,7 @@ const ByParticipant = () => {
 
   const handleClickNavigateToData = (
     activityOrFlow: ParticipantActivityOrFlow,
-    targetSubject: RespondentDetails,
+    targetSubject: SubjectDetails,
   ) => {
     if (!respondentSubject) return;
 

--- a/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ExpandedView/ExpandedView.types.ts
+++ b/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ExpandedView/ExpandedView.types.ts
@@ -1,5 +1,5 @@
 import { ParticipantActivityOrFlow, TargetSubjectsByRespondent } from 'api';
-import { RespondentDetails } from 'modules/Dashboard/types';
+import { SubjectDetails } from 'modules/Dashboard/types';
 import { MenuItem } from 'shared/components';
 
 export type ExpandedViewProps = {
@@ -7,11 +7,11 @@ export type ExpandedViewProps = {
   targetSubjects?: TargetSubjectsByRespondent;
   getActionsMenu: (
     activityOrFlow: ParticipantActivityOrFlow,
-    targetSubjectArg?: RespondentDetails,
+    targetSubjectArg?: SubjectDetails,
   ) => MenuItem<unknown>[];
   onClickViewData: (
     activityOrFlow: ParticipantActivityOrFlow,
-    targetSubject: RespondentDetails,
+    targetSubject: SubjectDetails,
   ) => void;
   'data-test-id': string;
 };

--- a/src/modules/Dashboard/features/Participant/Schedule/Schedule.tsx
+++ b/src/modules/Dashboard/features/Participant/Schedule/Schedule.tsx
@@ -10,7 +10,7 @@ import { applets, users } from 'modules/Dashboard/state';
 import { Spinner } from 'shared/components';
 import { theme, variables } from 'shared/styles';
 import { useAppDispatch } from 'redux/store';
-import { Respondent } from 'modules/Dashboard/types';
+import { Participant } from 'modules/Dashboard/types';
 import { usePermissions } from 'shared/hooks';
 import { checkIfHasAccessToSchedule } from 'modules/Dashboard/features/Applet/Schedule/Schedule.utils';
 import { ScheduleProvider } from 'modules/Dashboard/features/Applet/Schedule/ScheduleProvider';
@@ -40,7 +40,7 @@ export const ParticipantSchedule = () => {
     () =>
       respondentsData?.find(({ secretIds }) =>
         subjectData ? secretIds.includes(subjectData?.secretUserId) : false,
-      ) ?? ({} as Respondent),
+      ) ?? ({} as Participant),
     [respondentsData, subjectData],
   );
 

--- a/src/modules/Dashboard/features/Participants/Participants.test.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.test.tsx
@@ -9,8 +9,8 @@ import {
   mockedAppletId,
   mockedCurrentWorkspace,
   mockedOwnerId,
-  mockedFullParticipant,
-  mockedFullParticipantId,
+  mockedFullParticipant1,
+  mockedFullParticipantId1,
   mockedFullSubjectId1,
 } from 'shared/mock';
 import { Roles } from 'shared/consts';
@@ -76,7 +76,7 @@ const mockedResponses = {
 const getMockedGetWithParticipants = (respondentProps?: Partial<Participant>) => ({
   status: ApiResponseCodes.SuccessfulResponse,
   data: {
-    result: [{ ...mockedFullParticipant, ...respondentProps }],
+    result: [{ ...mockedFullParticipant1, ...respondentProps }],
     count: 1,
   },
 });
@@ -201,7 +201,7 @@ describe('Participants component tests', () => {
     await waitFor(() => {
       expect(mockAxios.post).nthCalledWith(
         1,
-        `/workspaces/${mockedOwnerId}/respondents/${mockedFullParticipantId}/pin`,
+        `/workspaces/${mockedOwnerId}/respondents/${mockedFullParticipantId1}/pin`,
         {},
         { signal: undefined },
       );

--- a/src/modules/Dashboard/features/Participants/Participants.test.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.test.tsx
@@ -20,7 +20,7 @@ import { ApiResponseCodes } from 'api';
 import { mockGetRequestResponses, mockSuccessfulHttpResponse } from 'shared/utils/axios-mocks';
 import * as MixpanelFunc from 'shared/utils/mixpanel';
 import { MixpanelEventType, MixpanelProps } from 'shared/utils/mixpanel';
-import { Respondent, RespondentStatus } from 'modules/Dashboard/types';
+import { Participant, ParticipantStatus } from 'modules/Dashboard/types';
 
 import { Participants } from './Participants';
 
@@ -73,7 +73,7 @@ const mockedResponses = {
   [RESPONDENTS_ENDPOINT]: mockSuccessfulHttpResponse({ result: [] }),
 };
 
-const getMockedGetWithParticipants = (respondentProps?: Partial<Respondent>) => ({
+const getMockedGetWithParticipants = (respondentProps?: Partial<Participant>) => ({
   status: ApiResponseCodes.SuccessfulResponse,
   data: {
     result: [{ ...mockedRespondent, ...respondentProps }],
@@ -177,7 +177,7 @@ describe('Participants component tests', () => {
   test('participant row should not link to participant details page for pending participants', async () => {
     mockGetRequestResponses({
       ...mockedResponses,
-      [RESPONDENTS_ENDPOINT]: getMockedGetWithParticipants({ status: RespondentStatus.Pending }),
+      [RESPONDENTS_ENDPOINT]: getMockedGetWithParticipants({ status: ParticipantStatus.Pending }),
     });
     renderWithProviders(<Participants />, { preloadedState, route, routePath });
     const firstParticipantSecretIdCell = await waitFor(() =>

--- a/src/modules/Dashboard/features/Participants/Participants.test.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.test.tsx
@@ -9,9 +9,9 @@ import {
   mockedAppletId,
   mockedCurrentWorkspace,
   mockedOwnerId,
-  mockedRespondent,
-  mockedRespondentId,
-  mockedSubjectId1,
+  mockedFullParticipant,
+  mockedFullParticipantId,
+  mockedFullSubjectId1,
 } from 'shared/mock';
 import { Roles } from 'shared/consts';
 import { initialStateData } from 'shared/state';
@@ -76,7 +76,7 @@ const mockedResponses = {
 const getMockedGetWithParticipants = (respondentProps?: Partial<Participant>) => ({
   status: ApiResponseCodes.SuccessfulResponse,
   data: {
-    result: [{ ...mockedRespondent, ...respondentProps }],
+    result: [{ ...mockedFullParticipant, ...respondentProps }],
     count: 1,
   },
 });
@@ -169,7 +169,7 @@ describe('Participants component tests', () => {
     expect(mockedUseNavigate).toHaveBeenCalledWith(
       generatePath(page.appletParticipantDetails, {
         appletId: mockedAppletId,
-        subjectId: mockedSubjectId1,
+        subjectId: mockedFullSubjectId1,
       }),
     );
   });
@@ -201,7 +201,7 @@ describe('Participants component tests', () => {
     await waitFor(() => {
       expect(mockAxios.post).nthCalledWith(
         1,
-        `/workspaces/${mockedOwnerId}/respondents/${mockedRespondentId}/pin`,
+        `/workspaces/${mockedOwnerId}/respondents/${mockedFullParticipantId}/pin`,
         {},
         { signal: undefined },
       );

--- a/src/modules/Dashboard/features/Participants/Participants.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.tsx
@@ -25,7 +25,7 @@ import {
 } from 'shared/utils';
 import { DEFAULT_ROWS_PER_PAGE, Roles } from 'shared/consts';
 import { StyledBody, StyledFlexWrap, StyledMaybeEmpty } from 'shared/styles';
-import { Respondent, RespondentStatus } from 'modules/Dashboard/types';
+import { Participant, ParticipantStatus } from 'modules/Dashboard/types';
 import { AddParticipantPopup, UpgradeAccountPopup } from 'modules/Dashboard/features/Applet/Popups';
 import {
   ActivityAssignDrawer,
@@ -313,7 +313,7 @@ export const Participants = () => {
     shouldRefetch && handleReload();
   };
 
-  const formatRow = (user: Respondent): Row => {
+  const formatRow = (user: Participant): Row => {
     const {
       secretIds,
       nicknames,
@@ -333,11 +333,11 @@ export const Participants = () => {
     const tag = detail.subjectTag;
     const respondentOrSubjectId = respondentId ?? detail.subjectId;
     const accountType = {
-      [RespondentStatus.Invited]: t('full'),
-      [RespondentStatus.NotInvited]: t('limited'),
-      [RespondentStatus.Pending]: t('pendingInvite'),
+      [ParticipantStatus.Invited]: t('full'),
+      [ParticipantStatus.NotInvited]: t('limited'),
+      [ParticipantStatus.Pending]: t('pendingInvite'),
     }[status];
-    const isPending = status === RespondentStatus.Pending;
+    const isPending = status === ParticipantStatus.Pending;
 
     const onClick = isPending
       ? undefined
@@ -434,7 +434,7 @@ export const Participants = () => {
     };
   };
 
-  const filterRespondentApplets = (user: Respondent) => {
+  const filterRespondentApplets = (user: Participant) => {
     const { details } = user;
     const filteredApplets: FilteredApplets = {
       scheduling: [],

--- a/src/modules/Dashboard/features/Participants/Participants.types.ts
+++ b/src/modules/Dashboard/features/Participants/Participants.types.ts
@@ -1,4 +1,4 @@
-import { Respondent, RespondentDetail, RespondentStatus } from 'modules/Dashboard/types';
+import { Participant, ParticipantDetail, ParticipantStatus } from 'modules/Dashboard/types';
 import { MenuActionProps } from 'shared/components';
 import { ParticipantTag, Roles } from 'shared/consts';
 import { Encryption } from 'shared/utils';
@@ -44,14 +44,14 @@ export enum FilteredAppletsKey {
   Viewable = 'viewable',
 }
 
-export type FilteredApplets = Record<FilteredAppletsKey, RespondentDetail[]>;
+export type FilteredApplets = Record<FilteredAppletsKey, ParticipantDetail[]>;
 
 export type FilteredParticipants = {
   [key: string]: FilteredApplets;
 };
 
 export type ParticipantsData = {
-  result: Respondent[];
+  result: Participant[];
   count: number;
   orderingFields?: string[];
 };
@@ -70,7 +70,7 @@ export type GetParticipantActionsProps = {
   subjectCreatedAt: string | null;
   tag?: ParticipantTag | null;
   appletId?: string;
-  status: RespondentStatus;
+  status: ParticipantStatus;
   dataTestId: string;
   canAssignActivity?: boolean;
   roles?: Roles[];

--- a/src/modules/Dashboard/features/Participants/Participants.utils.test.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.utils.test.tsx
@@ -1,5 +1,5 @@
 import { MenuItemType, Svg } from 'shared/components';
-import { mockedAppletId, mockedRespondentId } from 'shared/mock';
+import { mockedAppletId, mockedFullParticipantId } from 'shared/mock';
 import { variables } from 'shared/styles';
 import { ParticipantDetail, ParticipantStatus } from 'modules/Dashboard/types';
 import { ParticipantTag, Roles } from 'shared/consts';
@@ -66,8 +66,8 @@ describe('Participants utils tests', () => {
         copyInvitationLink: jest.fn(),
       },
       filteredApplets,
-      respondentId: mockedRespondentId,
-      respondentOrSubjectId: mockedRespondentId,
+      respondentId: mockedFullParticipantId,
+      respondentOrSubjectId: mockedFullParticipantId,
       appletId: mockedAppletId,
       email: mockedEmail,
       secretId: 'test secret id',
@@ -83,9 +83,9 @@ describe('Participants utils tests', () => {
     };
 
     const expectedContext: ParticipantActionProps = {
-      respondentId: mockedRespondentId,
+      respondentId: mockedFullParticipantId,
       email: mockedEmail,
-      respondentOrSubjectId: mockedRespondentId,
+      respondentOrSubjectId: mockedFullParticipantId,
       secretId: commonGetActionsProps.secretId,
       nickname: commonGetActionsProps.nickname,
       tag: commonGetActionsProps.tag,

--- a/src/modules/Dashboard/features/Participants/Participants.utils.test.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.utils.test.tsx
@@ -1,5 +1,5 @@
 import { MenuItemType, Svg } from 'shared/components';
-import { mockedAppletId, mockedFullParticipantId } from 'shared/mock';
+import { mockedAppletId, mockedFullParticipantId1 } from 'shared/mock';
 import { variables } from 'shared/styles';
 import { ParticipantDetail, ParticipantStatus } from 'modules/Dashboard/types';
 import { ParticipantTag, Roles } from 'shared/consts';
@@ -66,8 +66,8 @@ describe('Participants utils tests', () => {
         copyInvitationLink: jest.fn(),
       },
       filteredApplets,
-      respondentId: mockedFullParticipantId,
-      respondentOrSubjectId: mockedFullParticipantId,
+      respondentId: mockedFullParticipantId1,
+      respondentOrSubjectId: mockedFullParticipantId1,
       appletId: mockedAppletId,
       email: mockedEmail,
       secretId: 'test secret id',
@@ -83,9 +83,9 @@ describe('Participants utils tests', () => {
     };
 
     const expectedContext: ParticipantActionProps = {
-      respondentId: mockedFullParticipantId,
+      respondentId: mockedFullParticipantId1,
       email: mockedEmail,
-      respondentOrSubjectId: mockedFullParticipantId,
+      respondentOrSubjectId: mockedFullParticipantId1,
       secretId: commonGetActionsProps.secretId,
       nickname: commonGetActionsProps.nickname,
       tag: commonGetActionsProps.tag,

--- a/src/modules/Dashboard/features/Participants/Participants.utils.test.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.utils.test.tsx
@@ -1,7 +1,7 @@
 import { MenuItemType, Svg } from 'shared/components';
 import { mockedAppletId, mockedRespondentId } from 'shared/mock';
 import { variables } from 'shared/styles';
-import { RespondentDetail, RespondentStatus } from 'modules/Dashboard/types';
+import { ParticipantDetail, ParticipantStatus } from 'modules/Dashboard/types';
 import { ParticipantTag, Roles } from 'shared/consts';
 import { Invitation } from 'shared/types';
 
@@ -16,7 +16,7 @@ describe('Participants utils tests', () => {
   describe('getParticipantActions function', () => {
     const dataTestId = 'test-id';
 
-    const applets: RespondentDetail[] = [
+    const applets: ParticipantDetail[] = [
       {
         appletId: 'fbc90304-3fc9-4a71-a85f-aa7944278107',
         appletDisplayName: 'Applet 1',
@@ -78,7 +78,7 @@ describe('Participants utils tests', () => {
       firstName: 'Jane',
       lastName: 'Doe',
       subjectCreatedAt: '2021-10-01T00:00:00.000Z',
-      status: RespondentStatus.Invited,
+      status: ParticipantStatus.Invited,
       dataTestId,
     };
 
@@ -217,7 +217,7 @@ describe('Participants utils tests', () => {
       };
       const actions = getParticipantActions({
         ...commonGetActionsProps,
-        status: RespondentStatus.Invited,
+        status: ParticipantStatus.Invited,
         dataTestId,
         roles: [Roles.Manager],
         invitation: approvedInvitation,
@@ -249,7 +249,7 @@ describe('Participants utils tests', () => {
       const actions = getParticipantActions({
         ...commonGetActionsProps,
         email: null,
-        status: RespondentStatus.NotInvited,
+        status: ParticipantStatus.NotInvited,
         dataTestId,
         roles: [Roles.Manager],
       });
@@ -294,7 +294,7 @@ describe('Participants utils tests', () => {
       };
       const actions = getParticipantActions({
         ...commonGetActionsProps,
-        status: RespondentStatus.Pending,
+        status: ParticipantStatus.Pending,
         dataTestId,
         invitation: pendingInvitation,
         roles: [Roles.Manager],

--- a/src/modules/Dashboard/features/Participants/Participants.utils.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.utils.tsx
@@ -11,7 +11,7 @@ import {
   StyledSmallAppletImgPlaceholder,
   variables,
 } from 'shared/styles';
-import { RespondentDetail, RespondentStatus } from 'modules/Dashboard/types';
+import { ParticipantDetail, ParticipantStatus } from 'modules/Dashboard/types';
 import { HeadCell } from 'shared/types';
 import i18n from 'i18n';
 import { MenuItem, MenuItemType } from 'shared/components';
@@ -98,8 +98,8 @@ export const getParticipantActions = ({
     invitation,
   };
   const canManageParticipants = checkIfCanManageParticipants(roles);
-  const isUpgradeable = status === RespondentStatus.NotInvited;
-  const isPending = status === RespondentStatus.Pending;
+  const isUpgradeable = status === ParticipantStatus.NotInvited;
+  const isPending = status === ParticipantStatus.Pending;
   const isEditable = canManageParticipants && !!filteredApplets?.editable.length;
   const isViewable = !!filteredApplets?.viewable.length;
   const showEdit = !!appletId && isEditable && !isPending;
@@ -150,12 +150,12 @@ export const getParticipantActions = ({
       action: copyEmailAddress,
       title: t('copyEmailAddress'),
       context,
-      isDisplayed: !!emailAddress && status !== RespondentStatus.Invited,
+      isDisplayed: !!emailAddress && status !== ParticipantStatus.Invited,
       'data-testid': `${dataTestId}-copy-email`,
     },
     {
       type: MenuItemType.Divider,
-      isDisplayed: !!emailAddress && status !== RespondentStatus.Invited,
+      isDisplayed: !!emailAddress && status !== ParticipantStatus.Invited,
     },
     {
       icon: <Svg id="format-link" width={24} height={24} />,
@@ -214,7 +214,7 @@ export const getParticipantActions = ({
 };
 
 export const getAppletsSmallTableRows = (
-  respondentAccesses: RespondentDetail[],
+  respondentAccesses: ParticipantDetail[],
   setChosenAppletData: Dispatch<SetStateAction<ChosenAppletData | null>>,
   respondentId: string,
   ownerId: string,

--- a/src/modules/Dashboard/features/RespondentData/RespondentData.hooks.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentData.hooks.test.tsx
@@ -1,4 +1,4 @@
-import { mockedAppletId, mockedRespondentId } from 'shared/mock';
+import { mockedAppletId, mockedFullParticipantId } from 'shared/mock';
 import { renderHookWithProviders } from 'shared/utils/renderHookWithProviders';
 import { getPreloadedState } from 'shared/tests/getPreloadedState';
 import * as reduxHooks from 'redux/store/hooks';
@@ -18,7 +18,7 @@ describe('Respondent Data hooks', () => {
     beforeEach(() => {
       mockedUseParams.mockReturnValue({
         appletId: mockedAppletId,
-        subjectId: mockedRespondentId,
+        subjectId: mockedFullParticipantId,
       });
     });
 
@@ -32,7 +32,7 @@ describe('Respondent Data hooks', () => {
             id: 'respondent-data-summary',
             icon: expect.any(Object),
             activeIcon: expect.any(Object),
-            path: `/dashboard/${mockedAppletId}/participants/${mockedRespondentId}/dataviz/summary`,
+            path: `/dashboard/${mockedAppletId}/participants/${mockedFullParticipantId}/dataviz/summary`,
             'data-testid': 'respondents-summary-tab-summary',
           },
           {
@@ -40,7 +40,7 @@ describe('Respondent Data hooks', () => {
             id: 'respondent-data-responses',
             icon: expect.any(Object),
             activeIcon: expect.any(Object),
-            path: `/dashboard/${mockedAppletId}/participants/${mockedRespondentId}/dataviz/responses`,
+            path: `/dashboard/${mockedAppletId}/participants/${mockedFullParticipantId}/dataviz/responses`,
             'data-testid': 'respondents-summary-tab-review',
           },
         ],

--- a/src/modules/Dashboard/features/RespondentData/RespondentData.hooks.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentData.hooks.test.tsx
@@ -1,4 +1,4 @@
-import { mockedAppletId, mockedFullParticipantId } from 'shared/mock';
+import { mockedAppletId, mockedFullSubjectId1 } from 'shared/mock';
 import { renderHookWithProviders } from 'shared/utils/renderHookWithProviders';
 import { getPreloadedState } from 'shared/tests/getPreloadedState';
 import * as reduxHooks from 'redux/store/hooks';
@@ -18,7 +18,7 @@ describe('Respondent Data hooks', () => {
     beforeEach(() => {
       mockedUseParams.mockReturnValue({
         appletId: mockedAppletId,
-        subjectId: mockedFullParticipantId,
+        subjectId: mockedFullSubjectId1,
       });
     });
 
@@ -32,7 +32,7 @@ describe('Respondent Data hooks', () => {
             id: 'respondent-data-summary',
             icon: expect.any(Object),
             activeIcon: expect.any(Object),
-            path: `/dashboard/${mockedAppletId}/participants/${mockedFullParticipantId}/dataviz/summary`,
+            path: `/dashboard/${mockedAppletId}/participants/${mockedFullSubjectId1}/dataviz/summary`,
             'data-testid': 'respondents-summary-tab-summary',
           },
           {
@@ -40,7 +40,7 @@ describe('Respondent Data hooks', () => {
             id: 'respondent-data-responses',
             icon: expect.any(Object),
             activeIcon: expect.any(Object),
-            path: `/dashboard/${mockedAppletId}/participants/${mockedFullParticipantId}/dataviz/responses`,
+            path: `/dashboard/${mockedAppletId}/participants/${mockedFullSubjectId1}/dataviz/responses`,
             'data-testid': 'respondents-summary-tab-review',
           },
         ],

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataHeader/RespondentDataHeader.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataHeader/RespondentDataHeader.test.tsx
@@ -12,7 +12,7 @@ import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 import { Roles } from 'shared/consts';
 import { getPreloadedState } from 'shared/tests/getPreloadedState';
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
-import { RespondentDetails } from 'modules/Dashboard/types';
+import { SubjectDetails } from 'modules/Dashboard/types';
 import * as MixpanelFunc from 'shared/utils/mixpanel';
 import { MixpanelEventType, MixpanelProps } from 'shared/utils/mixpanel';
 
@@ -35,7 +35,7 @@ jest.mock('shared/hooks/useFeatureFlags', () => ({
 
 const mockUseFeatureFlags = jest.mocked(useFeatureFlags);
 
-const mockedSubject: RespondentDetails = {
+const mockedSubject: SubjectDetails = {
   nickname: mockedRespondent.nicknames[0],
   secretUserId: mockedRespondent.secretIds[0],
   userId: mockedRespondentId,

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataHeader/RespondentDataHeader.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataHeader/RespondentDataHeader.test.tsx
@@ -3,9 +3,9 @@ import { fireEvent, screen } from '@testing-library/react';
 import {
   mockedApplet,
   mockedAppletData,
-  mockedFullParticipant,
+  mockedFullParticipant1,
   mockedAppletId,
-  mockedFullParticipantId,
+  mockedFullParticipantId1,
   mockedActivityId,
   mockedFullSubjectId1,
 } from 'shared/mock';
@@ -37,10 +37,10 @@ jest.mock('shared/hooks/useFeatureFlags', () => ({
 const mockUseFeatureFlags = jest.mocked(useFeatureFlags);
 
 const mockedSubject: SubjectDetails = {
-  nickname: mockedFullParticipant.nicknames[0],
-  secretUserId: mockedFullParticipant.secretIds[0],
-  userId: mockedFullParticipantId,
-  ...mockedFullParticipant,
+  nickname: mockedFullParticipant1.nicknames[0],
+  secretUserId: mockedFullParticipant1.secretIds[0],
+  userId: mockedFullParticipantId1,
+  ...mockedFullParticipant1,
   id: mockedFullSubjectId1,
   firstName: 'John',
   lastName: 'Doe',

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataHeader/RespondentDataHeader.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataHeader/RespondentDataHeader.test.tsx
@@ -7,6 +7,7 @@ import {
   mockedAppletId,
   mockedFullParticipantId,
   mockedActivityId,
+  mockedFullSubjectId1,
 } from 'shared/mock';
 import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 import { Roles } from 'shared/consts';
@@ -40,7 +41,7 @@ const mockedSubject: SubjectDetails = {
   secretUserId: mockedFullParticipant.secretIds[0],
   userId: mockedFullParticipantId,
   ...mockedFullParticipant,
-  id: mockedFullParticipantId,
+  id: mockedFullSubjectId1,
   firstName: 'John',
   lastName: 'Doe',
 };

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataHeader/RespondentDataHeader.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataHeader/RespondentDataHeader.test.tsx
@@ -3,9 +3,9 @@ import { fireEvent, screen } from '@testing-library/react';
 import {
   mockedApplet,
   mockedAppletData,
-  mockedRespondent,
+  mockedFullParticipant,
   mockedAppletId,
-  mockedRespondentId,
+  mockedFullParticipantId,
   mockedActivityId,
 } from 'shared/mock';
 import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
@@ -36,11 +36,11 @@ jest.mock('shared/hooks/useFeatureFlags', () => ({
 const mockUseFeatureFlags = jest.mocked(useFeatureFlags);
 
 const mockedSubject: SubjectDetails = {
-  nickname: mockedRespondent.nicknames[0],
-  secretUserId: mockedRespondent.secretIds[0],
-  userId: mockedRespondentId,
-  ...mockedRespondent,
-  id: mockedRespondentId,
+  nickname: mockedFullParticipant.nicknames[0],
+  secretUserId: mockedFullParticipant.secretIds[0],
+  userId: mockedFullParticipantId,
+  ...mockedFullParticipant,
+  id: mockedFullParticipantId,
   firstName: 'John',
   lastName: 'Doe',
 };

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataHeader/RespondentDataHeader.types.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataHeader/RespondentDataHeader.types.ts
@@ -1,10 +1,10 @@
 import { HydratedActivityFlow } from 'modules/Dashboard/types/Dashboard.types';
-import { RespondentDetails } from 'modules/Dashboard/types';
+import { SubjectDetails } from 'modules/Dashboard/types';
 import { Activity, SingleApplet } from 'redux/modules';
 
 export interface RespondentDataHeaderProps {
   applet: SingleApplet;
-  subject: RespondentDetails;
+  subject: SubjectDetails;
   activityOrFlow?: Activity | HydratedActivityFlow;
   dataTestid: string;
 }

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/FeedbackAssessment/FeedbackAssessment.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/FeedbackAssessment/FeedbackAssessment.test.tsx
@@ -9,7 +9,7 @@ import {
   mockedApplet,
   mockedAppletId,
   mockedCurrentWorkspace,
-  mockedFullParticipantId,
+  mockedFullSubjectId1,
 } from 'shared/mock';
 import { Roles } from 'shared/consts';
 import { Item, initialStateData } from 'shared/state';
@@ -24,7 +24,7 @@ import { FeedbackForm } from '../Feedback.types';
 import { FeedbackAssessment } from './FeedbackAssessment';
 import { FeedbackAssessmentProps } from './FeedbackAssessment.types';
 
-const route = `/dashboard/${mockedAppletId}/participants/${mockedFullParticipantId}/dataviz/responses?selectedDate=2023-11-27&answerId=0a7bcd14-24a3-48ed-8d6b-b059a6541ae4`;
+const route = `/dashboard/${mockedAppletId}/participants/${mockedFullSubjectId1}/dataviz/responses?selectedDate=2023-11-27&answerId=0a7bcd14-24a3-48ed-8d6b-b059a6541ae4`;
 const routePath = page.appletParticipantDataReview;
 const preloadedState = {
   workspaces: {

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/FeedbackAssessment/FeedbackAssessment.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/FeedbackAssessment/FeedbackAssessment.test.tsx
@@ -9,7 +9,7 @@ import {
   mockedApplet,
   mockedAppletId,
   mockedCurrentWorkspace,
-  mockedRespondentId,
+  mockedFullParticipantId,
 } from 'shared/mock';
 import { Roles } from 'shared/consts';
 import { Item, initialStateData } from 'shared/state';
@@ -24,7 +24,7 @@ import { FeedbackForm } from '../Feedback.types';
 import { FeedbackAssessment } from './FeedbackAssessment';
 import { FeedbackAssessmentProps } from './FeedbackAssessment.types';
 
-const route = `/dashboard/${mockedAppletId}/participants/${mockedRespondentId}/dataviz/responses?selectedDate=2023-11-27&answerId=0a7bcd14-24a3-48ed-8d6b-b059a6541ae4`;
+const route = `/dashboard/${mockedAppletId}/participants/${mockedFullParticipantId}/dataviz/responses?selectedDate=2023-11-27&answerId=0a7bcd14-24a3-48ed-8d6b-b059a6541ae4`;
 const routePath = page.appletParticipantDataReview;
 const preloadedState = {
   workspaces: {

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/FeedbackNotes/FeedbackNotes.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/FeedbackNotes/FeedbackNotes.test.tsx
@@ -10,7 +10,7 @@ import {
   mockedApplet,
   mockedAppletId,
   mockedCurrentWorkspace,
-  mockedRespondent,
+  mockedFullParticipant,
 } from 'shared/mock';
 import { Roles } from 'shared/consts';
 import { initialStateData } from 'shared/state';
@@ -26,8 +26,8 @@ const noteTestId = 'respondents-summary-feedback-notes-note';
 const newNoteValue = 'New note has been added';
 const mockedAnswerId = 'some-answer-id';
 const mockedSubmitId = 'some-submit-id';
-const routeWithAnswerId = `/dashboard/${mockedAppletId}/participants/${mockedRespondent}/dataviz/responses?selectedDate=2023-11-27&answerId=${mockedAnswerId}`;
-const routeWithSubmitId = `/dashboard/${mockedAppletId}/participants/${mockedRespondent}/dataviz/responses?selectedDate=2023-11-27&submitId=${mockedSubmitId}`;
+const routeWithAnswerId = `/dashboard/${mockedAppletId}/participants/${mockedFullParticipant}/dataviz/responses?selectedDate=2023-11-27&answerId=${mockedAnswerId}`;
+const routeWithSubmitId = `/dashboard/${mockedAppletId}/participants/${mockedFullParticipant}/dataviz/responses?selectedDate=2023-11-27&submitId=${mockedSubmitId}`;
 const routePath = page.appletParticipantDataReview;
 const firstUserId = 'user-id-1';
 const preloadedState = {

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/FeedbackNotes/FeedbackNotes.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/FeedbackNotes/FeedbackNotes.test.tsx
@@ -10,7 +10,7 @@ import {
   mockedApplet,
   mockedAppletId,
   mockedCurrentWorkspace,
-  mockedFullParticipant,
+  mockedFullSubjectId1,
 } from 'shared/mock';
 import { Roles } from 'shared/consts';
 import { initialStateData } from 'shared/state';
@@ -26,8 +26,8 @@ const noteTestId = 'respondents-summary-feedback-notes-note';
 const newNoteValue = 'New note has been added';
 const mockedAnswerId = 'some-answer-id';
 const mockedSubmitId = 'some-submit-id';
-const routeWithAnswerId = `/dashboard/${mockedAppletId}/participants/${mockedFullParticipant}/dataviz/responses?selectedDate=2023-11-27&answerId=${mockedAnswerId}`;
-const routeWithSubmitId = `/dashboard/${mockedAppletId}/participants/${mockedFullParticipant}/dataviz/responses?selectedDate=2023-11-27&submitId=${mockedSubmitId}`;
+const routeWithAnswerId = `/dashboard/${mockedAppletId}/participants/${mockedFullSubjectId1}/dataviz/responses?selectedDate=2023-11-27&answerId=${mockedAnswerId}`;
+const routeWithSubmitId = `/dashboard/${mockedAppletId}/participants/${mockedFullSubjectId1}/dataviz/responses?selectedDate=2023-11-27&submitId=${mockedSubmitId}`;
 const routePath = page.appletParticipantDataReview;
 const firstUserId = 'user-id-1';
 const preloadedState = {

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/FeedbackReviews/FeedbackReviews.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/FeedbackReviews/FeedbackReviews.test.tsx
@@ -9,7 +9,7 @@ import {
   mockedApplet,
   mockedAppletId,
   mockedCurrentWorkspace,
-  mockedRespondent,
+  mockedFullParticipant,
 } from 'shared/mock';
 import { Roles } from 'shared/consts';
 import { initialStateData, Item } from 'shared/state';
@@ -25,7 +25,7 @@ import { FeedbackForm } from '../Feedback.types';
 import { getDefaultFormValues } from '../utils/getDefaultValues/getDefaultValues';
 
 const mockedAnswerId = '0a7bcd14-24a3-48ed-8d6b-b059a6541ae4';
-const route = `/dashboard/${mockedAppletId}/participants/${mockedRespondent}/dataviz/responses?selectedDate=2023-11-27&answerId=${mockedAnswerId}`;
+const route = `/dashboard/${mockedAppletId}/participants/${mockedFullParticipant}/dataviz/responses?selectedDate=2023-11-27&answerId=${mockedAnswerId}`;
 const routePath = page.appletParticipantDataReview;
 const preloadedState = {
   workspaces: {

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/FeedbackReviews/FeedbackReviews.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/Feedback/FeedbackReviews/FeedbackReviews.test.tsx
@@ -9,7 +9,7 @@ import {
   mockedApplet,
   mockedAppletId,
   mockedCurrentWorkspace,
-  mockedFullParticipant,
+  mockedFullSubjectId1,
 } from 'shared/mock';
 import { Roles } from 'shared/consts';
 import { initialStateData, Item } from 'shared/state';
@@ -25,7 +25,7 @@ import { FeedbackForm } from '../Feedback.types';
 import { getDefaultFormValues } from '../utils/getDefaultValues/getDefaultValues';
 
 const mockedAnswerId = '0a7bcd14-24a3-48ed-8d6b-b059a6541ae4';
-const route = `/dashboard/${mockedAppletId}/participants/${mockedFullParticipant}/dataviz/responses?selectedDate=2023-11-27&answerId=${mockedAnswerId}`;
+const route = `/dashboard/${mockedAppletId}/participants/${mockedFullSubjectId1}/dataviz/responses?selectedDate=2023-11-27&answerId=${mockedAnswerId}`;
 const routePath = page.appletParticipantDataReview;
 const preloadedState = {
   workspaces: {

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.test.tsx
@@ -11,7 +11,7 @@ import {
   mockedCurrentWorkspace,
   mockedFullParticipant,
   mockedFullParticipant2,
-  mockedFullParticipantId,
+  mockedFullSubjectId1,
 } from 'shared/mock';
 import { DateFormats, Roles, JEST_TEST_TIMEOUT, MAX_LIMIT, ParticipantTag } from 'shared/consts';
 import { initialStateData } from 'shared/state';
@@ -23,9 +23,9 @@ import { RespondentDataReview } from './RespondentDataReview';
 const date = new Date('2023-12-27');
 const dataTestid = 'respondents-review';
 
-const route1 = `/dashboard/${mockedAppletId}/participants/${mockedFullParticipantId}/dataviz/responses?selectedDate=2023-12-27`;
-const route2 = `/dashboard/${mockedAppletId}/participants/${mockedFullParticipantId}/dataviz/responses?selectedDate=2023-12-15&answerId=answer-id-2-2&isFeedbackVisible=true`;
-const routeWithoutSelectedDate = `/dashboard/${mockedAppletId}/participants/${mockedFullParticipantId}/dataviz/responses`;
+const route1 = `/dashboard/${mockedAppletId}/participants/${mockedFullSubjectId1}/dataviz/responses?selectedDate=2023-12-27`;
+const route2 = `/dashboard/${mockedAppletId}/participants/${mockedFullSubjectId1}/dataviz/responses?selectedDate=2023-12-15&answerId=answer-id-2-2&isFeedbackVisible=true`;
+const routeWithoutSelectedDate = `/dashboard/${mockedAppletId}/participants/${mockedFullSubjectId1}/dataviz/responses`;
 const routePath = page.appletParticipantDataReview;
 const preloadedState = {
   workspaces: {
@@ -63,10 +63,10 @@ const preloadedState = {
         result: {
           id: '1',
           nickname: 'Mocked Respondent',
-          secretUserId: mockedFullParticipantId,
+          secretUserId: mockedFullSubjectId1,
           lastSeen: '2023-12-15T23:29:36.150182',
           tag: 'Child' as ParticipantTag,
-          userId: mockedFullParticipantId,
+          userId: mockedFullSubjectId1,
           firstName: 'John',
           lastName: 'Doe',
         },
@@ -358,7 +358,7 @@ describe('RespondentDataReview', () => {
             params: {
               createdDate: format(date, DateFormats.YearMonthDay),
               limit: MAX_LIMIT,
-              targetSubjectId: mockedFullParticipantId,
+              targetSubjectId: mockedFullSubjectId1,
             },
             signal: undefined,
           },
@@ -371,7 +371,7 @@ describe('RespondentDataReview', () => {
             params: {
               createdDate: format(date, DateFormats.YearMonthDay),
               limit: MAX_LIMIT,
-              targetSubjectId: mockedFullParticipantId,
+              targetSubjectId: mockedFullSubjectId1,
             },
             signal: undefined,
           },
@@ -382,7 +382,7 @@ describe('RespondentDataReview', () => {
           `/answers/applet/${mockedAppletId}/dates`,
           {
             params: {
-              targetSubjectId: mockedFullParticipantId,
+              targetSubjectId: mockedFullSubjectId1,
               fromDate: startOfMonth(date).getTime().toString(),
               toDate: endOfMonth(date).getTime().toString(),
             },
@@ -458,7 +458,7 @@ describe('RespondentDataReview', () => {
             params: {
               createdDate: format(selectedDate, DateFormats.YearMonthDay),
               limit: MAX_LIMIT,
-              targetSubjectId: mockedFullParticipantId,
+              targetSubjectId: mockedFullSubjectId1,
             },
             signal: undefined,
           },
@@ -471,7 +471,7 @@ describe('RespondentDataReview', () => {
             params: {
               createdDate: format(selectedDate, DateFormats.YearMonthDay),
               limit: MAX_LIMIT,
-              targetSubjectId: mockedFullParticipantId,
+              targetSubjectId: mockedFullSubjectId1,
             },
             signal: undefined,
           },
@@ -598,7 +598,7 @@ describe('RespondentDataReview', () => {
             params: {
               createdDate: '2023-12-15',
               limit: MAX_LIMIT,
-              targetSubjectId: mockedFullParticipantId,
+              targetSubjectId: mockedFullSubjectId1,
             },
             signal: undefined,
           },
@@ -611,7 +611,7 @@ describe('RespondentDataReview', () => {
             params: {
               createdDate: '2023-12-15',
               limit: MAX_LIMIT,
-              targetSubjectId: mockedFullParticipantId,
+              targetSubjectId: mockedFullSubjectId1,
             },
             signal: undefined,
           },
@@ -622,7 +622,7 @@ describe('RespondentDataReview', () => {
           `/answers/applet/${mockedAppletId}/dates`,
           {
             params: {
-              targetSubjectId: mockedFullParticipantId,
+              targetSubjectId: mockedFullSubjectId1,
               fromDate: startOfMonth(date).getTime().toString(),
               toDate: endOfMonth(date).getTime().toString(),
             },
@@ -676,7 +676,7 @@ describe('RespondentDataReview', () => {
           params: {
             createdDate: format(new Date('2023-12-15'), DateFormats.YearMonthDay),
             limit: MAX_LIMIT,
-            targetSubjectId: mockedFullParticipantId,
+            targetSubjectId: mockedFullSubjectId1,
           },
           signal: undefined,
         },
@@ -689,7 +689,7 @@ describe('RespondentDataReview', () => {
           params: {
             createdDate: format(new Date('2023-12-15'), DateFormats.YearMonthDay),
             limit: MAX_LIMIT,
-            targetSubjectId: mockedFullParticipantId,
+            targetSubjectId: mockedFullSubjectId1,
           },
           signal: undefined,
         },

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.test.tsx
@@ -9,7 +9,7 @@ import {
   mockedApplet,
   mockedAppletId,
   mockedCurrentWorkspace,
-  mockedFullParticipant,
+  mockedFullParticipant1,
   mockedFullParticipant2,
   mockedFullSubjectId1,
 } from 'shared/mock';
@@ -53,7 +53,7 @@ const preloadedState = {
     allRespondents: {
       ...initialStateData,
       data: {
-        result: [mockedFullParticipant, mockedFullParticipant2],
+        result: [mockedFullParticipant1, mockedFullParticipant2],
         count: 2,
       },
     },

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.test.tsx
@@ -9,9 +9,9 @@ import {
   mockedApplet,
   mockedAppletId,
   mockedCurrentWorkspace,
-  mockedRespondent,
-  mockedRespondent2,
-  mockedRespondentId,
+  mockedFullParticipant,
+  mockedFullParticipant2,
+  mockedFullParticipantId,
 } from 'shared/mock';
 import { DateFormats, Roles, JEST_TEST_TIMEOUT, MAX_LIMIT, ParticipantTag } from 'shared/consts';
 import { initialStateData } from 'shared/state';
@@ -23,9 +23,9 @@ import { RespondentDataReview } from './RespondentDataReview';
 const date = new Date('2023-12-27');
 const dataTestid = 'respondents-review';
 
-const route1 = `/dashboard/${mockedAppletId}/participants/${mockedRespondentId}/dataviz/responses?selectedDate=2023-12-27`;
-const route2 = `/dashboard/${mockedAppletId}/participants/${mockedRespondentId}/dataviz/responses?selectedDate=2023-12-15&answerId=answer-id-2-2&isFeedbackVisible=true`;
-const routeWithoutSelectedDate = `/dashboard/${mockedAppletId}/participants/${mockedRespondentId}/dataviz/responses`;
+const route1 = `/dashboard/${mockedAppletId}/participants/${mockedFullParticipantId}/dataviz/responses?selectedDate=2023-12-27`;
+const route2 = `/dashboard/${mockedAppletId}/participants/${mockedFullParticipantId}/dataviz/responses?selectedDate=2023-12-15&answerId=answer-id-2-2&isFeedbackVisible=true`;
+const routeWithoutSelectedDate = `/dashboard/${mockedAppletId}/participants/${mockedFullParticipantId}/dataviz/responses`;
 const routePath = page.appletParticipantDataReview;
 const preloadedState = {
   workspaces: {
@@ -53,7 +53,7 @@ const preloadedState = {
     allRespondents: {
       ...initialStateData,
       data: {
-        result: [mockedRespondent, mockedRespondent2],
+        result: [mockedFullParticipant, mockedFullParticipant2],
         count: 2,
       },
     },
@@ -63,10 +63,10 @@ const preloadedState = {
         result: {
           id: '1',
           nickname: 'Mocked Respondent',
-          secretUserId: mockedRespondentId,
+          secretUserId: mockedFullParticipantId,
           lastSeen: '2023-12-15T23:29:36.150182',
           tag: 'Child' as ParticipantTag,
-          userId: mockedRespondentId,
+          userId: mockedFullParticipantId,
           firstName: 'John',
           lastName: 'Doe',
         },
@@ -358,7 +358,7 @@ describe('RespondentDataReview', () => {
             params: {
               createdDate: format(date, DateFormats.YearMonthDay),
               limit: MAX_LIMIT,
-              targetSubjectId: mockedRespondentId,
+              targetSubjectId: mockedFullParticipantId,
             },
             signal: undefined,
           },
@@ -371,7 +371,7 @@ describe('RespondentDataReview', () => {
             params: {
               createdDate: format(date, DateFormats.YearMonthDay),
               limit: MAX_LIMIT,
-              targetSubjectId: mockedRespondentId,
+              targetSubjectId: mockedFullParticipantId,
             },
             signal: undefined,
           },
@@ -382,7 +382,7 @@ describe('RespondentDataReview', () => {
           `/answers/applet/${mockedAppletId}/dates`,
           {
             params: {
-              targetSubjectId: mockedRespondentId,
+              targetSubjectId: mockedFullParticipantId,
               fromDate: startOfMonth(date).getTime().toString(),
               toDate: endOfMonth(date).getTime().toString(),
             },
@@ -458,7 +458,7 @@ describe('RespondentDataReview', () => {
             params: {
               createdDate: format(selectedDate, DateFormats.YearMonthDay),
               limit: MAX_LIMIT,
-              targetSubjectId: mockedRespondentId,
+              targetSubjectId: mockedFullParticipantId,
             },
             signal: undefined,
           },
@@ -471,7 +471,7 @@ describe('RespondentDataReview', () => {
             params: {
               createdDate: format(selectedDate, DateFormats.YearMonthDay),
               limit: MAX_LIMIT,
-              targetSubjectId: mockedRespondentId,
+              targetSubjectId: mockedFullParticipantId,
             },
             signal: undefined,
           },
@@ -598,7 +598,7 @@ describe('RespondentDataReview', () => {
             params: {
               createdDate: '2023-12-15',
               limit: MAX_LIMIT,
-              targetSubjectId: mockedRespondentId,
+              targetSubjectId: mockedFullParticipantId,
             },
             signal: undefined,
           },
@@ -611,7 +611,7 @@ describe('RespondentDataReview', () => {
             params: {
               createdDate: '2023-12-15',
               limit: MAX_LIMIT,
-              targetSubjectId: mockedRespondentId,
+              targetSubjectId: mockedFullParticipantId,
             },
             signal: undefined,
           },
@@ -622,7 +622,7 @@ describe('RespondentDataReview', () => {
           `/answers/applet/${mockedAppletId}/dates`,
           {
             params: {
-              targetSubjectId: mockedRespondentId,
+              targetSubjectId: mockedFullParticipantId,
               fromDate: startOfMonth(date).getTime().toString(),
               toDate: endOfMonth(date).getTime().toString(),
             },
@@ -676,7 +676,7 @@ describe('RespondentDataReview', () => {
           params: {
             createdDate: format(new Date('2023-12-15'), DateFormats.YearMonthDay),
             limit: MAX_LIMIT,
-            targetSubjectId: mockedRespondentId,
+            targetSubjectId: mockedFullParticipantId,
           },
           signal: undefined,
         },
@@ -689,7 +689,7 @@ describe('RespondentDataReview', () => {
           params: {
             createdDate: format(new Date('2023-12-15'), DateFormats.YearMonthDay),
             limit: MAX_LIMIT,
-            targetSubjectId: mockedRespondentId,
+            targetSubjectId: mockedFullParticipantId,
           },
           signal: undefined,
         },

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.types.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.types.ts
@@ -1,8 +1,8 @@
-import { RespondentDetails } from 'modules/Dashboard/types';
+import { SubjectDetails } from 'modules/Dashboard/types';
 
 import { ResponsesSummary } from '../RespondentDataReview.types';
 
 export type ResponsesSummaryProps = ResponsesSummary & {
   'data-testid': string;
-  sourceSubject?: RespondentDetails;
+  sourceSubject?: SubjectDetails;
 };

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewMenu/ReviewMenu.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewMenu/ReviewMenu.test.tsx
@@ -8,9 +8,9 @@ import {
   mockedApplet,
   mockedAppletId,
   mockedCurrentWorkspace,
-  mockedRespondent,
-  mockedRespondent2,
-  mockedRespondentId,
+  mockedFullParticipant,
+  mockedFullParticipant2,
+  mockedFullParticipantId,
 } from 'shared/mock';
 import { ParticipantTag, Roles } from 'shared/consts';
 import { initialStateData } from 'shared/state';
@@ -20,7 +20,7 @@ import { ReviewMenu } from './ReviewMenu';
 import { ReviewMenuProps } from './ReviewMenu.types';
 
 const mockedAnswerId = '0a7bcd14-24a3-48ed-8d6b-b059a6541ae4';
-const route = `/dashboard/${mockedAppletId}/participants/${mockedRespondentId}/dataviz/responses?selectedDate=2023-12-05&answerId=${mockedAnswerId}`;
+const route = `/dashboard/${mockedAppletId}/participants/${mockedFullParticipantId}/dataviz/responses?selectedDate=2023-12-05&answerId=${mockedAnswerId}`;
 const routePath = page.appletParticipantDataReview;
 const preloadedState = {
   workspaces: {
@@ -42,7 +42,7 @@ const preloadedState = {
     allRespondents: {
       ...initialStateData,
       data: {
-        result: [mockedRespondent, mockedRespondent2],
+        result: [mockedFullParticipant, mockedFullParticipant2],
         count: 2,
       },
     },

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewMenu/ReviewMenu.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewMenu/ReviewMenu.test.tsx
@@ -8,7 +8,7 @@ import {
   mockedApplet,
   mockedAppletId,
   mockedCurrentWorkspace,
-  mockedFullParticipant,
+  mockedFullParticipant1,
   mockedFullParticipant2,
   mockedFullSubjectId1,
 } from 'shared/mock';
@@ -42,7 +42,7 @@ const preloadedState = {
     allRespondents: {
       ...initialStateData,
       data: {
-        result: [mockedFullParticipant, mockedFullParticipant2],
+        result: [mockedFullParticipant1, mockedFullParticipant2],
         count: 2,
       },
     },

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewMenu/ReviewMenu.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewMenu/ReviewMenu.test.tsx
@@ -10,7 +10,7 @@ import {
   mockedCurrentWorkspace,
   mockedFullParticipant,
   mockedFullParticipant2,
-  mockedFullParticipantId,
+  mockedFullSubjectId1,
 } from 'shared/mock';
 import { ParticipantTag, Roles } from 'shared/consts';
 import { initialStateData } from 'shared/state';
@@ -20,7 +20,7 @@ import { ReviewMenu } from './ReviewMenu';
 import { ReviewMenuProps } from './ReviewMenu.types';
 
 const mockedAnswerId = '0a7bcd14-24a3-48ed-8d6b-b059a6541ae4';
-const route = `/dashboard/${mockedAppletId}/participants/${mockedFullParticipantId}/dataviz/responses?selectedDate=2023-12-05&answerId=${mockedAnswerId}`;
+const route = `/dashboard/${mockedAppletId}/participants/${mockedFullSubjectId1}/dataviz/responses?selectedDate=2023-12-05&answerId=${mockedAnswerId}`;
 const routePath = page.appletParticipantDataReview;
 const preloadedState = {
   workspaces: {

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewMenu/ReviewMenu.types.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewMenu/ReviewMenu.types.ts
@@ -1,7 +1,7 @@
 import { Control } from 'react-hook-form';
 
 import { AnswerDate, ReviewEntity } from 'modules/Dashboard/api';
-import { RespondentDetails } from 'modules/Dashboard/types/Dashboard.types';
+import { SubjectDetails } from 'modules/Dashboard/types/Dashboard.types';
 
 import { RespondentsDataFormValues } from '../../RespondentData.types';
 import { OnSelectActivityOrFlow, OnSelectAnswer } from '../RespondentDataReview.types';
@@ -18,7 +18,7 @@ export type ReviewMenuProps = {
   onDateChange: (date?: Date | null) => void;
   isDatePickerLoading: boolean;
   onSelectAnswer: OnSelectAnswer;
-  lastActivityCompleted?: RespondentDetails['lastSeen'];
+  lastActivityCompleted?: SubjectDetails['lastSeen'];
   isActivitiesFlowsLoading: boolean;
   onSelectActivity: OnSelectActivityOrFlow;
   onSelectFlow: OnSelectActivityOrFlow;

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewMenu/ReviewMenuItem/ReviewMenuItem.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewMenu/ReviewMenuItem/ReviewMenuItem.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import * as reactRouterDom from 'react-router-dom';
 
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
-import { mockedAppletId, mockedFullParticipantId } from 'shared/mock';
+import { mockedAppletId, mockedFullSubjectId1 } from 'shared/mock';
 import { page } from 'resources';
 import { variables } from 'shared/styles';
 
@@ -11,8 +11,8 @@ import { ReviewMenuItem } from './ReviewMenuItem';
 import { ReviewMenuItemProps } from './ReviewMenuItem.types';
 
 const preselectedAnswerId = 'answer-id-3';
-const routeWithAnswerId = `/dashboard/${mockedAppletId}/participants/${mockedFullParticipantId}/dataviz/responses?answerId=${preselectedAnswerId}`;
-const routeWithoutAnswerId = `/dashboard/${mockedAppletId}/participants/${mockedFullParticipantId}/dataviz/responses`;
+const routeWithAnswerId = `/dashboard/${mockedAppletId}/participants/${mockedFullSubjectId1}/dataviz/responses?answerId=${preselectedAnswerId}`;
+const routeWithoutAnswerId = `/dashboard/${mockedAppletId}/participants/${mockedFullSubjectId1}/dataviz/responses`;
 const routePath = page.appletParticipantDataReview;
 const preselectedAnswer = {
   createdAt: '2023-12-15T22:20:30.150182',

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewMenu/ReviewMenuItem/ReviewMenuItem.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewMenu/ReviewMenuItem/ReviewMenuItem.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import * as reactRouterDom from 'react-router-dom';
 
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
-import { mockedAppletId, mockedRespondentId } from 'shared/mock';
+import { mockedAppletId, mockedFullParticipantId } from 'shared/mock';
 import { page } from 'resources';
 import { variables } from 'shared/styles';
 
@@ -11,8 +11,8 @@ import { ReviewMenuItem } from './ReviewMenuItem';
 import { ReviewMenuItemProps } from './ReviewMenuItem.types';
 
 const preselectedAnswerId = 'answer-id-3';
-const routeWithAnswerId = `/dashboard/${mockedAppletId}/participants/${mockedRespondentId}/dataviz/responses?answerId=${preselectedAnswerId}`;
-const routeWithoutAnswerId = `/dashboard/${mockedAppletId}/participants/${mockedRespondentId}/dataviz/responses`;
+const routeWithAnswerId = `/dashboard/${mockedAppletId}/participants/${mockedFullParticipantId}/dataviz/responses?answerId=${preselectedAnswerId}`;
+const routeWithoutAnswerId = `/dashboard/${mockedAppletId}/participants/${mockedFullParticipantId}/dataviz/responses`;
 const routePath = page.appletParticipantDataReview;
 const preselectedAnswer = {
   createdAt: '2023-12-15T22:20:30.150182',

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Charts/ScatterChart/ChartTooltip/ChartTooltip.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Charts/ScatterChart/ChartTooltip/ChartTooltip.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { PreloadedState } from '@reduxjs/toolkit';
 
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
-import { mockedApplet, mockedAppletId, mockedFullParticipantId } from 'shared/mock';
+import { mockedApplet, mockedAppletId, mockedFullSubjectId1 } from 'shared/mock';
 import { page } from 'resources';
 import { ReportContext } from 'modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Report.context';
 import { RootState } from 'redux/store';
@@ -12,7 +12,7 @@ import { initialStateData } from 'shared/state';
 import { ChartTooltip } from './ChartTooltip';
 import { ChartTooltipProps, ScatterTooltipRowData } from './ChartTooltip.types';
 
-const route = `/dashboard/${mockedAppletId}/participants/${mockedFullParticipantId}/dataviz/summary`;
+const route = `/dashboard/${mockedAppletId}/participants/${mockedFullSubjectId1}/dataviz/summary`;
 const routePath = page.appletParticipantDataSummary;
 
 const dataTestid = 'scatter-chart';
@@ -94,7 +94,7 @@ const testPositiveFlowWithNavigate = async (text: string, search: string) => {
   await userEvent.click(reviewButton);
 
   expect(mockedNavigate).toBeCalledWith({
-    pathname: `/dashboard/${mockedAppletId}/participants/${mockedFullParticipantId}/dataviz/responses`,
+    pathname: `/dashboard/${mockedAppletId}/participants/${mockedFullSubjectId1}/dataviz/responses`,
     search,
   });
 };
@@ -115,7 +115,7 @@ describe('ChartTooltip', () => {
     await viewResponseButtonClick();
 
     expect(mockedNavigate).toBeCalledWith({
-      pathname: `/dashboard/${mockedAppletId}/participants/${mockedFullParticipantId}/dataviz/responses`,
+      pathname: `/dashboard/${mockedAppletId}/participants/${mockedFullSubjectId1}/dataviz/responses`,
       search: `selectedDate=2023-12-20&answerId=${answerId}&isFeedbackVisible=false`,
     });
   });
@@ -128,7 +128,7 @@ describe('ChartTooltip', () => {
     await viewResponseButtonClick();
 
     expect(mockedNavigate).toBeCalledWith({
-      pathname: `/dashboard/${mockedAppletId}/participants/${mockedFullParticipantId}/dataviz/responses`,
+      pathname: `/dashboard/${mockedAppletId}/participants/${mockedFullSubjectId1}/dataviz/responses`,
       search: `selectedDate=2023-12-20&submitId=${flowSubmitId}&isFeedbackVisible=false`,
     });
   });

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Charts/ScatterChart/ChartTooltip/ChartTooltip.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Charts/ScatterChart/ChartTooltip/ChartTooltip.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { PreloadedState } from '@reduxjs/toolkit';
 
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
-import { mockedApplet, mockedAppletId, mockedRespondentId } from 'shared/mock';
+import { mockedApplet, mockedAppletId, mockedFullParticipantId } from 'shared/mock';
 import { page } from 'resources';
 import { ReportContext } from 'modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Report.context';
 import { RootState } from 'redux/store';
@@ -12,7 +12,7 @@ import { initialStateData } from 'shared/state';
 import { ChartTooltip } from './ChartTooltip';
 import { ChartTooltipProps, ScatterTooltipRowData } from './ChartTooltip.types';
 
-const route = `/dashboard/${mockedAppletId}/participants/${mockedRespondentId}/dataviz/summary`;
+const route = `/dashboard/${mockedAppletId}/participants/${mockedFullParticipantId}/dataviz/summary`;
 const routePath = page.appletParticipantDataSummary;
 
 const dataTestid = 'scatter-chart';
@@ -94,7 +94,7 @@ const testPositiveFlowWithNavigate = async (text: string, search: string) => {
   await userEvent.click(reviewButton);
 
   expect(mockedNavigate).toBeCalledWith({
-    pathname: `/dashboard/${mockedAppletId}/participants/${mockedRespondentId}/dataviz/responses`,
+    pathname: `/dashboard/${mockedAppletId}/participants/${mockedFullParticipantId}/dataviz/responses`,
     search,
   });
 };
@@ -115,7 +115,7 @@ describe('ChartTooltip', () => {
     await viewResponseButtonClick();
 
     expect(mockedNavigate).toBeCalledWith({
-      pathname: `/dashboard/${mockedAppletId}/participants/${mockedRespondentId}/dataviz/responses`,
+      pathname: `/dashboard/${mockedAppletId}/participants/${mockedFullParticipantId}/dataviz/responses`,
       search: `selectedDate=2023-12-20&answerId=${answerId}&isFeedbackVisible=false`,
     });
   });
@@ -128,7 +128,7 @@ describe('ChartTooltip', () => {
     await viewResponseButtonClick();
 
     expect(mockedNavigate).toBeCalledWith({
-      pathname: `/dashboard/${mockedAppletId}/participants/${mockedRespondentId}/dataviz/responses`,
+      pathname: `/dashboard/${mockedAppletId}/participants/${mockedFullParticipantId}/dataviz/responses`,
       search: `selectedDate=2023-12-20&submitId=${flowSubmitId}&isFeedbackVisible=false`,
     });
   });

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/DownloadReport/DownloadReport.hooks.test.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/DownloadReport/DownloadReport.hooks.test.ts
@@ -3,7 +3,7 @@ import mockAxios from 'jest-mock-axios';
 import download from 'downloadjs';
 
 import { renderHookWithProviders } from 'shared/utils/renderHookWithProviders';
-import { mockedAppletId, mockedFullParticipantId } from 'shared/mock';
+import { mockedAppletId, mockedFullSubjectId1 } from 'shared/mock';
 
 import { useDownloadReport } from './DownloadReport.hooks';
 
@@ -77,7 +77,7 @@ const testDownloadReport = async (result: { current: unknown }, isFlow: boolean)
     expect(mockAxios.post).toBeCalledWith(
       `/answers/applet/${mockedAppletId}/${
         isFlow ? `flows/${flowId}` : `activities/${activityId}`
-      }/subjects/${mockedFullParticipantId}/latest_report`,
+      }/subjects/${mockedFullSubjectId1}/latest_report`,
       {},
       { responseType: 'arraybuffer', signal: undefined },
     );
@@ -93,7 +93,7 @@ describe('useDownloadReport', () => {
   beforeEach(() => {
     mockedUseParams.mockReturnValue({
       appletId: mockedAppletId,
-      subjectId: mockedFullParticipantId,
+      subjectId: mockedFullSubjectId1,
     });
   });
   afterEach(() => {

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/DownloadReport/DownloadReport.hooks.test.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/DownloadReport/DownloadReport.hooks.test.ts
@@ -3,7 +3,7 @@ import mockAxios from 'jest-mock-axios';
 import download from 'downloadjs';
 
 import { renderHookWithProviders } from 'shared/utils/renderHookWithProviders';
-import { mockedAppletId, mockedRespondentId } from 'shared/mock';
+import { mockedAppletId, mockedFullParticipantId } from 'shared/mock';
 
 import { useDownloadReport } from './DownloadReport.hooks';
 
@@ -77,7 +77,7 @@ const testDownloadReport = async (result: { current: unknown }, isFlow: boolean)
     expect(mockAxios.post).toBeCalledWith(
       `/answers/applet/${mockedAppletId}/${
         isFlow ? `flows/${flowId}` : `activities/${activityId}`
-      }/subjects/${mockedRespondentId}/latest_report`,
+      }/subjects/${mockedFullParticipantId}/latest_report`,
       {},
       { responseType: 'arraybuffer', signal: undefined },
     );
@@ -93,7 +93,7 @@ describe('useDownloadReport', () => {
   beforeEach(() => {
     mockedUseParams.mockReturnValue({
       appletId: mockedAppletId,
-      subjectId: mockedRespondentId,
+      subjectId: mockedFullParticipantId,
     });
   });
   afterEach(() => {

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Report.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Report.test.tsx
@@ -4,7 +4,7 @@ import * as reactHookForm from 'react-hook-form';
 
 import { page } from 'resources';
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
-import { mockedApplet, mockedAppletId, mockedSubjectId1 } from 'shared/mock';
+import { mockedApplet, mockedAppletId, mockedFullSubjectId1 } from 'shared/mock';
 import { initialStateData } from 'redux/modules';
 
 import { Report } from './Report';
@@ -36,7 +36,7 @@ const preloadedState = {
   },
 };
 
-const route = `/dashboard/${mockedAppletId}/participants/${mockedSubjectId1}/dataviz/summary`;
+const route = `/dashboard/${mockedAppletId}/participants/${mockedFullSubjectId1}/dataviz/summary`;
 const routePath = page.appletParticipantDataSummary;
 
 const mockedActivity = {

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ReportFilters/ReportFilters.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ReportFilters/ReportFilters.test.tsx
@@ -8,7 +8,7 @@ import * as reactHookForm from 'react-hook-form';
 
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
 import { page } from 'resources';
-import { mockedAppletId, mockedRespondentId } from 'shared/mock';
+import { mockedAppletId, mockedFullParticipantId } from 'shared/mock';
 import { MAX_LIMIT } from 'shared/consts';
 import { RespondentsDataFormValues } from 'modules/Dashboard/features/RespondentData/RespondentData.types';
 import { defaultRespondentDataFormValues } from 'modules/Dashboard/features/RespondentData/RespondentData.const';
@@ -33,7 +33,7 @@ const versions = [
 ];
 
 const dataTestid = 'respondents-summary-filters';
-const route = `/dashboard/${mockedAppletId}/participants/${mockedRespondentId}/dataviz/summary`;
+const route = `/dashboard/${mockedAppletId}/participants/${mockedFullParticipantId}/dataviz/summary`;
 const routePath = page.appletParticipantDataSummary;
 const mockedActivity = {
   id: 'd65e8a64-a023-4830-9c84-7433c4b96440',
@@ -78,7 +78,10 @@ jest.mock('react-router-dom', () => ({
 
 describe('ReportFilters', () => {
   beforeEach(() => {
-    mockedUseParams.mockReturnValue({ appletId: mockedAppletId, subjectId: mockedRespondentId });
+    mockedUseParams.mockReturnValue({
+      appletId: mockedAppletId,
+      subjectId: mockedFullParticipantId,
+    });
   });
 
   test('renders date pickers and time pickers', async () => {
@@ -191,7 +194,7 @@ describe('ReportFilters', () => {
           params: {
             emptyIdentifiers: true,
             fromDatetime: '2024-01-04T00:00:00',
-            targetSubjectId: mockedRespondentId,
+            targetSubjectId: mockedFullParticipantId,
             toDatetime: '2024-01-10T23:59:00',
             versions: '1.0.0,1.0.1',
             limit: MAX_LIMIT,
@@ -225,7 +228,7 @@ describe('ReportFilters', () => {
           params: {
             emptyIdentifiers: true,
             fromDatetime: '2024-01-04T00:00:00',
-            targetSubjectId: mockedRespondentId,
+            targetSubjectId: mockedFullParticipantId,
             toDatetime: '2024-01-10T23:59:00',
             versions: '1.0.0,1.0.1',
             limit: MAX_LIMIT,

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ReportFilters/ReportFilters.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ReportFilters/ReportFilters.test.tsx
@@ -8,7 +8,7 @@ import * as reactHookForm from 'react-hook-form';
 
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
 import { page } from 'resources';
-import { mockedAppletId, mockedFullParticipantId } from 'shared/mock';
+import { mockedAppletId, mockedFullSubjectId1 } from 'shared/mock';
 import { MAX_LIMIT } from 'shared/consts';
 import { RespondentsDataFormValues } from 'modules/Dashboard/features/RespondentData/RespondentData.types';
 import { defaultRespondentDataFormValues } from 'modules/Dashboard/features/RespondentData/RespondentData.const';
@@ -33,7 +33,7 @@ const versions = [
 ];
 
 const dataTestid = 'respondents-summary-filters';
-const route = `/dashboard/${mockedAppletId}/participants/${mockedFullParticipantId}/dataviz/summary`;
+const route = `/dashboard/${mockedAppletId}/participants/${mockedFullSubjectId1}/dataviz/summary`;
 const routePath = page.appletParticipantDataSummary;
 const mockedActivity = {
   id: 'd65e8a64-a023-4830-9c84-7433c4b96440',
@@ -80,7 +80,7 @@ describe('ReportFilters', () => {
   beforeEach(() => {
     mockedUseParams.mockReturnValue({
       appletId: mockedAppletId,
-      subjectId: mockedFullParticipantId,
+      subjectId: mockedFullSubjectId1,
     });
   });
 
@@ -194,7 +194,7 @@ describe('ReportFilters', () => {
           params: {
             emptyIdentifiers: true,
             fromDatetime: '2024-01-04T00:00:00',
-            targetSubjectId: mockedFullParticipantId,
+            targetSubjectId: mockedFullSubjectId1,
             toDatetime: '2024-01-10T23:59:00',
             versions: '1.0.0,1.0.1',
             limit: MAX_LIMIT,
@@ -228,7 +228,7 @@ describe('ReportFilters', () => {
           params: {
             emptyIdentifiers: true,
             fromDatetime: '2024-01-04T00:00:00',
-            targetSubjectId: mockedFullParticipantId,
+            targetSubjectId: mockedFullSubjectId1,
             toDatetime: '2024-01-10T23:59:00',
             versions: '1.0.0,1.0.1',
             limit: MAX_LIMIT,

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/ReportMenu/StickyHeader/StickyHeader.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/ReportMenu/StickyHeader/StickyHeader.test.tsx
@@ -5,7 +5,7 @@ import { Box } from '@mui/material';
 
 import { getPreloadedState } from 'shared/tests/getPreloadedState';
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
-import { mockedRespondentId } from 'shared/mock';
+import { mockedFullParticipantId } from 'shared/mock';
 import { initialStateData } from 'shared/state';
 
 import { StickyHeader } from './StickyHeader';
@@ -23,7 +23,7 @@ const preloadedState = {
       data: {
         result: {
           nickname: 'Mocked Respondent',
-          secretUserId: mockedRespondentId,
+          secretUserId: mockedFullParticipantId,
           lastSeen: '2023-12-11T08:40:41.424000',
         },
       },

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/ReportMenu/StickyHeader/StickyHeader.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/ReportMenu/StickyHeader/StickyHeader.test.tsx
@@ -5,7 +5,7 @@ import { Box } from '@mui/material';
 
 import { getPreloadedState } from 'shared/tests/getPreloadedState';
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
-import { mockedFullParticipantId } from 'shared/mock';
+import { mockedFullParticipantDetail } from 'shared/mock';
 import { initialStateData } from 'shared/state';
 
 import { StickyHeader } from './StickyHeader';
@@ -22,8 +22,8 @@ const preloadedState = {
       ...initialStateData,
       data: {
         result: {
-          nickname: 'Mocked Respondent',
-          secretUserId: mockedFullParticipantId,
+          nickname: mockedFullParticipantDetail.respondentNickname,
+          secretUserId: mockedFullParticipantDetail.respondentSecretId,
           lastSeen: '2023-12-11T08:40:41.424000',
         },
       },
@@ -52,7 +52,7 @@ describe('StickyHeader', () => {
     );
 
     const description = getByText(
-      'Subject: b60a142d-2b7f-4328-841c-dbhjhj4afcf1c7 (Mocked Respondent)',
+      `Subject: ${mockedFullParticipantDetail.respondentSecretId} (${mockedFullParticipantDetail.respondentNickname})`,
     );
     expect(description).toBeInTheDocument();
     expect(description).toHaveStyle({ position: 'relative', padding: 0 });

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/ReportMenu/StickyHeader/StickyHeader.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/ReportMenu/StickyHeader/StickyHeader.test.tsx
@@ -5,7 +5,7 @@ import { Box } from '@mui/material';
 
 import { getPreloadedState } from 'shared/tests/getPreloadedState';
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
-import { mockedFullParticipantDetail } from 'shared/mock';
+import { mockedFullParticipant1 } from 'shared/mock';
 import { initialStateData } from 'shared/state';
 
 import { StickyHeader } from './StickyHeader';
@@ -22,8 +22,8 @@ const preloadedState = {
       ...initialStateData,
       data: {
         result: {
-          nickname: mockedFullParticipantDetail.respondentNickname,
-          secretUserId: mockedFullParticipantDetail.respondentSecretId,
+          nickname: mockedFullParticipant1.details[0].respondentNickname,
+          secretUserId: mockedFullParticipant1.details[0].respondentSecretId,
           lastSeen: '2023-12-11T08:40:41.424000',
         },
       },
@@ -52,7 +52,7 @@ describe('StickyHeader', () => {
     );
 
     const description = getByText(
-      `Subject: ${mockedFullParticipantDetail.respondentSecretId} (${mockedFullParticipantDetail.respondentNickname})`,
+      `Subject: ${mockedFullParticipant1.details[0].respondentSecretId} (${mockedFullParticipant1.details[0].respondentNickname})`,
     );
     expect(description).toBeInTheDocument();
     expect(description).toHaveStyle({ position: 'relative', padding: 0 });

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/RespondentDataSummary.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/RespondentDataSummary.test.tsx
@@ -5,7 +5,7 @@ import { endOfDay, startOfDay, subDays } from 'date-fns';
 
 import { page } from 'resources';
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
-import { mockedAppletId, mockedSubjectId1 } from 'shared/mock';
+import { mockedAppletId, mockedFullSubjectId1 } from 'shared/mock';
 import { MAX_LIMIT } from 'shared/consts';
 
 import * as useDatavizSummaryRequestsHook from './hooks/useDatavizSummaryRequests/useDatavizSummaryRequests';
@@ -14,7 +14,7 @@ import { RespondentDataSummary } from './RespondentDataSummary';
 import { RespondentDataContext } from '../RespondentDataContext/RespondentDataContext.context';
 import { RespondentDataContextType } from '../RespondentDataContext/RespondentDataContext.types';
 
-const route = `/dashboard/${mockedAppletId}/participants/${mockedSubjectId1}/dataviz/summary`;
+const route = `/dashboard/${mockedAppletId}/participants/${mockedFullSubjectId1}/dataviz/summary`;
 const routePath = page.appletParticipantDataSummary;
 const mockedSetValue = jest.fn();
 
@@ -70,7 +70,7 @@ jest.mock('modules/Dashboard/hooks', () => ({
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
-  useParams: () => ({ subjectId: mockedSubjectId1, appletId: mockedAppletId }),
+  useParams: () => ({ subjectId: mockedFullSubjectId1, appletId: mockedAppletId }),
 }));
 
 jest.mock('./ReportMenu', () => ({
@@ -184,7 +184,7 @@ describe('RespondentDataSummary component', () => {
         {
           params: {
             limit: MAX_LIMIT,
-            targetSubjectId: mockedSubjectId1,
+            targetSubjectId: mockedFullSubjectId1,
           },
           signal: undefined,
         },
@@ -195,7 +195,7 @@ describe('RespondentDataSummary component', () => {
         {
           params: {
             limit: MAX_LIMIT,
-            targetSubjectId: mockedSubjectId1,
+            targetSubjectId: mockedFullSubjectId1,
           },
           signal: undefined,
         },

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/hooks/useDatavizSummaryRequests/useDatavizSummaryRequests.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/hooks/useDatavizSummaryRequests/useDatavizSummaryRequests.test.tsx
@@ -1,7 +1,7 @@
 import mockAxios from 'jest-mock-axios';
 import { renderHook } from '@testing-library/react';
 
-import { mockedActivityId, mockedAppletId, mockedFullParticipantId } from 'shared/mock';
+import { mockedActivityId, mockedAppletId, mockedFullSubjectId1 } from 'shared/mock';
 
 import * as useDecryptedIdentifiersHook from '../useDecryptedIdentifiers';
 import { useDatavizSummaryRequests } from './useDatavizSummaryRequests';
@@ -79,7 +79,7 @@ describe('useDatavizSummaryRequests', () => {
   beforeEach(() => {
     mockedUseParams.mockReturnValue({
       appletId: mockedAppletId,
-      subjectId: mockedFullParticipantId,
+      subjectId: mockedFullSubjectId1,
     });
     const mockedGetDecryptedIdentifiers = jest.spyOn(
       useDecryptedIdentifiersHook,

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/hooks/useDatavizSummaryRequests/useDatavizSummaryRequests.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/hooks/useDatavizSummaryRequests/useDatavizSummaryRequests.test.tsx
@@ -1,7 +1,7 @@
 import mockAxios from 'jest-mock-axios';
 import { renderHook } from '@testing-library/react';
 
-import { mockedActivityId, mockedAppletId, mockedRespondentId } from 'shared/mock';
+import { mockedActivityId, mockedAppletId, mockedFullParticipantId } from 'shared/mock';
 
 import * as useDecryptedIdentifiersHook from '../useDecryptedIdentifiers';
 import { useDatavizSummaryRequests } from './useDatavizSummaryRequests';
@@ -79,7 +79,7 @@ describe('useDatavizSummaryRequests', () => {
   beforeEach(() => {
     mockedUseParams.mockReturnValue({
       appletId: mockedAppletId,
-      subjectId: mockedRespondentId,
+      subjectId: mockedFullParticipantId,
     });
     const mockedGetDecryptedIdentifiers = jest.spyOn(
       useDecryptedIdentifiersHook,

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/hooks/useRespondentAnswers/useRespondentAnswers.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/hooks/useRespondentAnswers/useRespondentAnswers.test.tsx
@@ -2,7 +2,7 @@ import { renderHook, waitFor } from '@testing-library/react';
 import mockAxios from 'jest-mock-axios';
 import { endOfDay, startOfDay, subDays } from 'date-fns';
 
-import { mockedActivityId, mockedAppletId, mockedFullParticipantId } from 'shared/mock';
+import { mockedActivityId, mockedAppletId, mockedFullSubjectId1 } from 'shared/mock';
 import * as dashboardHooks from 'modules/Dashboard/hooks';
 import { ActivityOrFlow } from 'modules/Dashboard/features/RespondentData/RespondentData.types';
 import { RespondentDataContext } from 'modules/Dashboard/features/RespondentData/RespondentDataContext/RespondentDataContext.context';
@@ -102,7 +102,7 @@ const testIdentifierDatesChange = async () => {
           emptyIdentifiers: false,
           fromDatetime: '2024-04-06T09:00:00',
           identifiers: 'encrypted_ident_1,encrypted_ident_2,encrypted_ident_2_1',
-          targetSubjectId: mockedFullParticipantId,
+          targetSubjectId: mockedFullSubjectId1,
           toDatetime: '2024-04-12T17:00:00',
           versions: 'v3',
           limit: MAX_LIMIT,
@@ -264,7 +264,7 @@ describe('useRespondentAnswers', () => {
   beforeEach(() => {
     mockedUseParams.mockReturnValue({
       appletId: mockedAppletId,
-      subjectId: mockedFullParticipantId,
+      subjectId: mockedFullSubjectId1,
     });
   });
 
@@ -296,7 +296,7 @@ describe('useRespondentAnswers', () => {
             emptyIdentifiers: true,
             fromDatetime: '2024-01-12T09:00:00',
             identifiers: undefined,
-            targetSubjectId: mockedFullParticipantId,
+            targetSubjectId: mockedFullSubjectId1,
             toDatetime: '2024-01-15T17:00:00',
             versions: 'v3',
             limit: MAX_LIMIT,
@@ -338,7 +338,7 @@ describe('useRespondentAnswers', () => {
             emptyIdentifiers: true,
             fromDatetime: '2024-01-12T09:00:00',
             identifiers: undefined,
-            targetSubjectId: mockedFullParticipantId,
+            targetSubjectId: mockedFullSubjectId1,
             toDatetime: '2024-01-15T17:00:00',
             versions: 'v3',
             limit: MAX_LIMIT,
@@ -428,7 +428,7 @@ describe('useRespondentAnswers', () => {
             emptyIdentifiers: true,
             fromDatetime: '2024-01-12T09:00:00',
             identifiers: undefined,
-            targetSubjectId: mockedFullParticipantId,
+            targetSubjectId: mockedFullSubjectId1,
             toDatetime: '2024-01-18T17:00:00',
             versions: 'v3',
             limit: MAX_LIMIT,

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/hooks/useRespondentAnswers/useRespondentAnswers.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/hooks/useRespondentAnswers/useRespondentAnswers.test.tsx
@@ -2,7 +2,7 @@ import { renderHook, waitFor } from '@testing-library/react';
 import mockAxios from 'jest-mock-axios';
 import { endOfDay, startOfDay, subDays } from 'date-fns';
 
-import { mockedActivityId, mockedAppletId, mockedRespondentId } from 'shared/mock';
+import { mockedActivityId, mockedAppletId, mockedFullParticipantId } from 'shared/mock';
 import * as dashboardHooks from 'modules/Dashboard/hooks';
 import { ActivityOrFlow } from 'modules/Dashboard/features/RespondentData/RespondentData.types';
 import { RespondentDataContext } from 'modules/Dashboard/features/RespondentData/RespondentDataContext/RespondentDataContext.context';
@@ -102,7 +102,7 @@ const testIdentifierDatesChange = async () => {
           emptyIdentifiers: false,
           fromDatetime: '2024-04-06T09:00:00',
           identifiers: 'encrypted_ident_1,encrypted_ident_2,encrypted_ident_2_1',
-          targetSubjectId: mockedRespondentId,
+          targetSubjectId: mockedFullParticipantId,
           toDatetime: '2024-04-12T17:00:00',
           versions: 'v3',
           limit: MAX_LIMIT,
@@ -264,7 +264,7 @@ describe('useRespondentAnswers', () => {
   beforeEach(() => {
     mockedUseParams.mockReturnValue({
       appletId: mockedAppletId,
-      subjectId: mockedRespondentId,
+      subjectId: mockedFullParticipantId,
     });
   });
 
@@ -296,7 +296,7 @@ describe('useRespondentAnswers', () => {
             emptyIdentifiers: true,
             fromDatetime: '2024-01-12T09:00:00',
             identifiers: undefined,
-            targetSubjectId: mockedRespondentId,
+            targetSubjectId: mockedFullParticipantId,
             toDatetime: '2024-01-15T17:00:00',
             versions: 'v3',
             limit: MAX_LIMIT,
@@ -338,7 +338,7 @@ describe('useRespondentAnswers', () => {
             emptyIdentifiers: true,
             fromDatetime: '2024-01-12T09:00:00',
             identifiers: undefined,
-            targetSubjectId: mockedRespondentId,
+            targetSubjectId: mockedFullParticipantId,
             toDatetime: '2024-01-15T17:00:00',
             versions: 'v3',
             limit: MAX_LIMIT,
@@ -428,7 +428,7 @@ describe('useRespondentAnswers', () => {
             emptyIdentifiers: true,
             fromDatetime: '2024-01-12T09:00:00',
             identifiers: undefined,
-            targetSubjectId: mockedRespondentId,
+            targetSubjectId: mockedFullParticipantId,
             toDatetime: '2024-01-18T17:00:00',
             versions: 'v3',
             limit: MAX_LIMIT,

--- a/src/modules/Dashboard/features/Respondents/Popups/RemoveRespondentPopup/RemoveRespondentPopup.test.tsx
+++ b/src/modules/Dashboard/features/Respondents/Popups/RemoveRespondentPopup/RemoveRespondentPopup.test.tsx
@@ -2,7 +2,7 @@ import { waitFor, screen, fireEvent } from '@testing-library/react';
 import mockAxios from 'jest-mock-axios';
 
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
-import { mockedAppletId, mockedSubjectId1 } from 'shared/mock';
+import { mockedAppletId, mockedFullSubjectId1 } from 'shared/mock';
 import { page } from 'resources';
 
 import { RemoveRespondentPopup } from '.';
@@ -16,7 +16,7 @@ const chosenAppletData = {
   respondentNickname: 'respondentNickname',
   ownerId: '1',
   appletDisplayName: 'ApplletName',
-  subjectId: mockedSubjectId1,
+  subjectId: mockedFullSubjectId1,
 };
 
 const onCloseMock = jest.fn();

--- a/src/modules/Dashboard/features/Respondents/Popups/ScheduleSetupPopup/ScheduleSetupPopup.test.tsx
+++ b/src/modules/Dashboard/features/Respondents/Popups/ScheduleSetupPopup/ScheduleSetupPopup.test.tsx
@@ -5,9 +5,9 @@ import { renderWithProviders } from 'shared/utils/renderWithProviders';
 import {
   mockedAppletId,
   mockedOwnerId,
-  mockedRespondentDetails,
-  mockedRespondentId,
-  mockedSubjectId1,
+  mockedFullParticipantDetail,
+  mockedFullParticipantId,
+  mockedFullSubjectId1,
 } from 'shared/mock';
 
 import { ScheduleSetupPopup } from './ScheduleSetupPopup';
@@ -15,10 +15,10 @@ import { ScheduleSetupPopup } from './ScheduleSetupPopup';
 const setPopupVisibleMock = jest.fn();
 const setChosenAppletDataMock = jest.fn();
 const chosenAppletDataMock = {
-  ...mockedRespondentDetails,
-  respondentId: mockedRespondentId,
+  ...mockedFullParticipantDetail,
+  respondentId: mockedFullParticipantId,
   ownerId: mockedOwnerId,
-  subjectId: mockedSubjectId1,
+  subjectId: mockedFullSubjectId1,
 };
 
 const tableRowsMock = [
@@ -71,13 +71,13 @@ describe('ScheduleSetupPopup', () => {
 
     expect(mockAxios.post).toHaveBeenNthCalledWith(
       1,
-      `/applets/${mockedAppletId}/events/individual/${mockedRespondentId}`,
+      `/applets/${mockedAppletId}/events/individual/${mockedFullParticipantId}`,
       {},
       { signal: undefined },
     );
     await waitFor(() =>
       expect(mockedUseNavigate).toBeCalledWith(
-        `/dashboard/${mockedAppletId}/participants/${mockedSubjectId1}/schedule`,
+        `/dashboard/${mockedAppletId}/participants/${mockedFullSubjectId1}/schedule`,
       ),
     );
   });
@@ -100,7 +100,7 @@ describe('ScheduleSetupPopup', () => {
 
     expect(setChosenAppletDataMock).toBeCalledWith(chosenAppletDataMock);
     expect(mockedUseNavigate).toBeCalledWith(
-      `/dashboard/${mockedAppletId}/participants/${mockedSubjectId1}/schedule`,
+      `/dashboard/${mockedAppletId}/participants/${mockedFullSubjectId1}/schedule`,
     );
   });
 });

--- a/src/modules/Dashboard/features/Respondents/Popups/ScheduleSetupPopup/ScheduleSetupPopup.test.tsx
+++ b/src/modules/Dashboard/features/Respondents/Popups/ScheduleSetupPopup/ScheduleSetupPopup.test.tsx
@@ -5,9 +5,9 @@ import { renderWithProviders } from 'shared/utils/renderWithProviders';
 import {
   mockedAppletId,
   mockedOwnerId,
-  mockedFullParticipantDetail,
-  mockedFullParticipantId,
+  mockedFullParticipantId1,
   mockedFullSubjectId1,
+  mockedFullParticipant1,
 } from 'shared/mock';
 
 import { ScheduleSetupPopup } from './ScheduleSetupPopup';
@@ -15,8 +15,8 @@ import { ScheduleSetupPopup } from './ScheduleSetupPopup';
 const setPopupVisibleMock = jest.fn();
 const setChosenAppletDataMock = jest.fn();
 const chosenAppletDataMock = {
-  ...mockedFullParticipantDetail,
-  respondentId: mockedFullParticipantId,
+  ...mockedFullParticipant1.details[0],
+  respondentId: mockedFullParticipantId1,
   ownerId: mockedOwnerId,
   subjectId: mockedFullSubjectId1,
 };
@@ -71,7 +71,7 @@ describe('ScheduleSetupPopup', () => {
 
     expect(mockAxios.post).toHaveBeenNthCalledWith(
       1,
-      `/applets/${mockedAppletId}/events/individual/${mockedFullParticipantId}`,
+      `/applets/${mockedAppletId}/events/individual/${mockedFullParticipantId1}`,
       {},
       { signal: undefined },
     );

--- a/src/modules/Dashboard/features/Respondents/Popups/SendInvitationPopup/SendInvitationPopup.test.tsx
+++ b/src/modules/Dashboard/features/Respondents/Popups/SendInvitationPopup/SendInvitationPopup.test.tsx
@@ -4,7 +4,7 @@ import mockAxios from 'jest-mock-axios';
 import * as routerDom from 'react-router-dom';
 
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
-import { mockedAppletId, mockedSubjectId1 } from 'shared/mock';
+import { mockedAppletId, mockedFullSubjectId1 } from 'shared/mock';
 
 import { SendInvitationPopup } from './SendInvitationPopup';
 import { dataTestId } from './SendInvitationPopup.const';
@@ -22,7 +22,7 @@ const mockedChosenAppletData = {
   respondentId: mockedRespondentId,
   respondentNickname: 'respondentNickname',
   ownerId: '1',
-  subjectId: mockedSubjectId1,
+  subjectId: mockedFullSubjectId1,
 };
 const commonPopupProps = {
   popupVisible: true,
@@ -54,7 +54,7 @@ describe('SendInvitationPopup', () => {
       expect(mockAxios.post).toHaveBeenNthCalledWith(
         1,
         `/invitations/${mockedAppletId}/subject`,
-        { email: mockedEmail, subjectId: mockedSubjectId1 },
+        { email: mockedEmail, subjectId: mockedFullSubjectId1 },
         { signal: undefined },
       );
     });
@@ -75,7 +75,7 @@ describe('SendInvitationPopup', () => {
       expect(mockAxios.post).toHaveBeenNthCalledWith(
         1,
         `/invitations/${mockedAppletId}/subject`,
-        { email: mockedEmail, subjectId: mockedSubjectId1 },
+        { email: mockedEmail, subjectId: mockedFullSubjectId1 },
         { signal: undefined },
       );
     });

--- a/src/modules/Dashboard/features/Respondents/Popups/ViewParticipantPopup/ViewParticipantPopup.test.tsx
+++ b/src/modules/Dashboard/features/Respondents/Popups/ViewParticipantPopup/ViewParticipantPopup.test.tsx
@@ -3,10 +3,10 @@ import { generatePath, useNavigate } from 'react-router-dom';
 
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
 import {
-  mockedRespondentDetails,
-  mockedRespondentId,
+  mockedFullParticipantDetail,
+  mockedFullParticipantId,
   mockedOwnerId,
-  mockedSubjectId1,
+  mockedFullSubjectId1,
   mockedAppletId,
 } from 'shared/mock';
 import { page } from 'resources';
@@ -25,10 +25,10 @@ const mockedGeneratePath = jest.mocked(generatePath);
 const setChosenAppletDataMock = jest.fn();
 const setPopupVisibleMock = jest.fn();
 const chosenAppletDataMock = {
-  ...mockedRespondentDetails,
-  respondentId: mockedRespondentId,
+  ...mockedFullParticipantDetail,
+  respondentId: mockedFullParticipantId,
   ownerId: mockedOwnerId,
-  subjectId: mockedSubjectId1,
+  subjectId: mockedFullSubjectId1,
 };
 const tableRowsMock = [
   {
@@ -91,7 +91,7 @@ describe('ViewParticipantPopup', () => {
 
     expect(mockedGeneratePath).toBeCalledWith(page.appletParticipantDetails, {
       appletId: mockedAppletId,
-      subjectId: mockedSubjectId1,
+      subjectId: mockedFullSubjectId1,
     });
     expect(navigateMock).toBeCalledTimes(1);
   });

--- a/src/modules/Dashboard/features/Respondents/Popups/ViewParticipantPopup/ViewParticipantPopup.test.tsx
+++ b/src/modules/Dashboard/features/Respondents/Popups/ViewParticipantPopup/ViewParticipantPopup.test.tsx
@@ -3,11 +3,11 @@ import { generatePath, useNavigate } from 'react-router-dom';
 
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
 import {
-  mockedFullParticipantDetail,
-  mockedFullParticipantId,
+  mockedFullParticipantId1,
   mockedOwnerId,
   mockedFullSubjectId1,
   mockedAppletId,
+  mockedFullParticipant1,
 } from 'shared/mock';
 import { page } from 'resources';
 
@@ -25,8 +25,8 @@ const mockedGeneratePath = jest.mocked(generatePath);
 const setChosenAppletDataMock = jest.fn();
 const setPopupVisibleMock = jest.fn();
 const chosenAppletDataMock = {
-  ...mockedFullParticipantDetail,
-  respondentId: mockedFullParticipantId,
+  ...mockedFullParticipant1.details[0],
+  respondentId: mockedFullParticipantId1,
   ownerId: mockedOwnerId,
   subjectId: mockedFullSubjectId1,
 };

--- a/src/modules/Dashboard/features/Respondents/Respondents.test.tsx
+++ b/src/modules/Dashboard/features/Respondents/Respondents.test.tsx
@@ -7,8 +7,8 @@ import {
   mockedAppletId,
   mockedCurrentWorkspace,
   mockedOwnerId,
-  mockedFullParticipantId,
-  mockedFullParticipant,
+  mockedFullParticipantId1,
+  mockedFullParticipant1,
 } from 'shared/mock';
 import { Roles } from 'shared/consts';
 import { initialStateData } from 'shared/state';
@@ -47,8 +47,8 @@ const getMockedGetWithRespondents = (isAnonymousRespondent = false) => ({
   status: ApiResponseCodes.SuccessfulResponse,
   data: {
     result: isAnonymousRespondent
-      ? [{ ...mockedFullParticipant, isAnonymousRespondent: true }]
-      : [mockedFullParticipant],
+      ? [{ ...mockedFullParticipant1, isAnonymousRespondent: true }]
+      : [mockedFullParticipant1],
     count: 1,
   },
 });
@@ -116,7 +116,7 @@ describe('Respondents component tests', () => {
     await waitFor(() => {
       expect(mockAxios.post).nthCalledWith(
         1,
-        `/workspaces/${mockedOwnerId}/respondents/${mockedFullParticipantId}/pin`,
+        `/workspaces/${mockedOwnerId}/respondents/${mockedFullParticipantId1}/pin`,
         {},
         { signal: undefined },
       );

--- a/src/modules/Dashboard/features/Respondents/Respondents.test.tsx
+++ b/src/modules/Dashboard/features/Respondents/Respondents.test.tsx
@@ -7,8 +7,8 @@ import {
   mockedAppletId,
   mockedCurrentWorkspace,
   mockedOwnerId,
-  mockedRespondentId,
-  mockedRespondent,
+  mockedFullParticipantId,
+  mockedFullParticipant,
 } from 'shared/mock';
 import { Roles } from 'shared/consts';
 import { initialStateData } from 'shared/state';
@@ -47,8 +47,8 @@ const getMockedGetWithRespondents = (isAnonymousRespondent = false) => ({
   status: ApiResponseCodes.SuccessfulResponse,
   data: {
     result: isAnonymousRespondent
-      ? [{ ...mockedRespondent, isAnonymousRespondent: true }]
-      : [mockedRespondent],
+      ? [{ ...mockedFullParticipant, isAnonymousRespondent: true }]
+      : [mockedFullParticipant],
     count: 1,
   },
 });
@@ -116,7 +116,7 @@ describe('Respondents component tests', () => {
     await waitFor(() => {
       expect(mockAxios.post).nthCalledWith(
         1,
-        `/workspaces/${mockedOwnerId}/respondents/${mockedRespondentId}/pin`,
+        `/workspaces/${mockedOwnerId}/respondents/${mockedFullParticipantId}/pin`,
         {},
         { signal: undefined },
       );

--- a/src/modules/Dashboard/features/Respondents/Respondents.tsx
+++ b/src/modules/Dashboard/features/Respondents/Respondents.tsx
@@ -35,7 +35,7 @@ import {
 } from 'shared/utils';
 import { DEFAULT_ROWS_PER_PAGE, Roles } from 'shared/consts';
 import { StyledBody } from 'shared/styles';
-import { Respondent, RespondentStatus } from 'modules/Dashboard/types';
+import { Participant, ParticipantStatus } from 'modules/Dashboard/types';
 
 import {
   RespondentsTableHeader,
@@ -293,7 +293,7 @@ export const Respondents = () => {
     shouldReFetch && handleReload();
   };
 
-  const formatRow = (user: Respondent): Row => {
+  const formatRow = (user: Participant): Row => {
     const {
       secretIds,
       nicknames,
@@ -312,11 +312,11 @@ export const Respondents = () => {
     const stringSecretIds = joinWihComma(secretIds, true);
     const respondentOrSubjectId = respondentId ?? details[0].subjectId;
     const accountType = {
-      [RespondentStatus.Invited]: t('full'),
-      [RespondentStatus.NotInvited]: t('limited'),
-      [RespondentStatus.Pending]: t('pendingInvite'),
+      [ParticipantStatus.Invited]: t('full'),
+      [ParticipantStatus.NotInvited]: t('limited'),
+      [ParticipantStatus.Pending]: t('pendingInvite'),
     }[status];
-    const isPending = status === RespondentStatus.Pending;
+    const isPending = status === ParticipantStatus.Pending;
 
     return {
       id: {
@@ -372,9 +372,9 @@ export const Respondents = () => {
               respondentOrSubjectId,
               appletId,
               email,
-              isInviteEnabled: status === RespondentStatus.NotInvited,
+              isInviteEnabled: status === ParticipantStatus.NotInvited,
               isViewCalendarEnabled:
-                !!respondentId && status === RespondentStatus.Invited && !isAnonymousRespondent,
+                !!respondentId && status === ParticipantStatus.Invited && !isAnonymousRespondent,
             })}
             data-testid="dashboard-respondents-table-actions"
           />
@@ -384,7 +384,7 @@ export const Respondents = () => {
     };
   };
 
-  const filterRespondentApplets = (user: Respondent) => {
+  const filterRespondentApplets = (user: Participant) => {
     const { details } = user;
     const filteredApplets: FilteredApplets = {
       scheduling: [],

--- a/src/modules/Dashboard/features/Respondents/Respondents.types.ts
+++ b/src/modules/Dashboard/features/Respondents/Respondents.types.ts
@@ -1,4 +1,4 @@
-import { Respondent, RespondentDetail } from 'modules/Dashboard/types';
+import { Participant, ParticipantDetail } from 'modules/Dashboard/types';
 import { Encryption } from 'shared/utils';
 import { MenuActionProps } from 'shared/components';
 import { ParticipantTag } from 'shared/consts';
@@ -38,14 +38,14 @@ export enum FilteredAppletsKey {
   Viewable = 'viewable',
 }
 
-export type FilteredApplets = Record<FilteredAppletsKey, RespondentDetail[]>;
+export type FilteredApplets = Record<FilteredAppletsKey, ParticipantDetail[]>;
 
 export type FilteredRespondents = {
   [key: string]: FilteredApplets;
 };
 
 export type RespondentsData = {
-  result: Respondent[];
+  result: Participant[];
   count: number;
   orderingFields: string[];
 };

--- a/src/modules/Dashboard/features/Respondents/Respondents.utils.test.tsx
+++ b/src/modules/Dashboard/features/Respondents/Respondents.utils.test.tsx
@@ -1,5 +1,5 @@
 import { Svg } from 'shared/components';
-import { mockedAppletId, mockedRespondentId } from 'shared/mock';
+import { mockedAppletId, mockedFullParticipantId } from 'shared/mock';
 import { variables } from 'shared/styles';
 import { ParticipantTag } from 'shared/consts';
 
@@ -53,8 +53,8 @@ const commonGetActionsProps = {
     sendInvitation: jest.fn(),
   },
   filteredApplets,
-  respondentId: mockedRespondentId,
-  respondentOrSubjectId: mockedRespondentId,
+  respondentId: mockedFullParticipantId,
+  respondentOrSubjectId: mockedFullParticipantId,
   appletId: mockedAppletId,
   email: mockedEmail,
 };
@@ -74,9 +74,9 @@ describe('Respondents utils tests', () => {
           action: expect.any(Function),
           title: 'View Individual Calendar',
           context: {
-            respondentId: mockedRespondentId,
+            respondentId: mockedFullParticipantId,
             email: mockedEmail,
-            respondentOrSubjectId: mockedRespondentId,
+            respondentOrSubjectId: mockedFullParticipantId,
           },
           isDisplayed: true,
           'data-testid': 'dashboard-respondents-view-calendar',
@@ -86,9 +86,9 @@ describe('Respondents utils tests', () => {
           action: expect.any(Function),
           title: 'View Data',
           context: {
-            respondentId: mockedRespondentId,
+            respondentId: mockedFullParticipantId,
             email: mockedEmail,
-            respondentOrSubjectId: mockedRespondentId,
+            respondentOrSubjectId: mockedFullParticipantId,
           },
           isDisplayed: true,
           'data-testid': 'dashboard-respondents-view-data',
@@ -98,9 +98,9 @@ describe('Respondents utils tests', () => {
           action: expect.any(Function),
           title: 'Export Data',
           context: {
-            respondentId: mockedRespondentId,
+            respondentId: mockedFullParticipantId,
             email: mockedEmail,
-            respondentOrSubjectId: mockedRespondentId,
+            respondentOrSubjectId: mockedFullParticipantId,
           },
           isDisplayed: true,
           'data-testid': 'dashboard-respondents-export-data',
@@ -110,9 +110,9 @@ describe('Respondents utils tests', () => {
           action: expect.any(Function),
           title: 'Edit Respondent',
           context: {
-            respondentId: mockedRespondentId,
+            respondentId: mockedFullParticipantId,
             email: mockedEmail,
-            respondentOrSubjectId: mockedRespondentId,
+            respondentOrSubjectId: mockedFullParticipantId,
           },
           isDisplayed: true,
           'data-testid': 'dashboard-respondents-edit',
@@ -122,9 +122,9 @@ describe('Respondents utils tests', () => {
           action: expect.any(Function),
           title: 'Send Invitation',
           context: {
-            respondentId: mockedRespondentId,
+            respondentId: mockedFullParticipantId,
             email: mockedEmail,
-            respondentOrSubjectId: mockedRespondentId,
+            respondentOrSubjectId: mockedFullParticipantId,
           },
           isDisplayed: true,
           'data-testid': 'dashboard-respondents-invite',
@@ -134,9 +134,9 @@ describe('Respondents utils tests', () => {
           action: expect.any(Function),
           title: 'Remove from Applet',
           context: {
-            respondentId: mockedRespondentId,
+            respondentId: mockedFullParticipantId,
             email: mockedEmail,
-            respondentOrSubjectId: mockedRespondentId,
+            respondentOrSubjectId: mockedFullParticipantId,
           },
           isDisplayed: true,
           customItemColor: variables.palette.dark_error_container,

--- a/src/modules/Dashboard/features/Respondents/Respondents.utils.test.tsx
+++ b/src/modules/Dashboard/features/Respondents/Respondents.utils.test.tsx
@@ -1,5 +1,5 @@
 import { Svg } from 'shared/components';
-import { mockedAppletId, mockedFullParticipantId } from 'shared/mock';
+import { mockedAppletId, mockedFullParticipantId1 } from 'shared/mock';
 import { variables } from 'shared/styles';
 import { ParticipantTag } from 'shared/consts';
 
@@ -53,8 +53,8 @@ const commonGetActionsProps = {
     sendInvitation: jest.fn(),
   },
   filteredApplets,
-  respondentId: mockedFullParticipantId,
-  respondentOrSubjectId: mockedFullParticipantId,
+  respondentId: mockedFullParticipantId1,
+  respondentOrSubjectId: mockedFullParticipantId1,
   appletId: mockedAppletId,
   email: mockedEmail,
 };
@@ -74,9 +74,9 @@ describe('Respondents utils tests', () => {
           action: expect.any(Function),
           title: 'View Individual Calendar',
           context: {
-            respondentId: mockedFullParticipantId,
+            respondentId: mockedFullParticipantId1,
             email: mockedEmail,
-            respondentOrSubjectId: mockedFullParticipantId,
+            respondentOrSubjectId: mockedFullParticipantId1,
           },
           isDisplayed: true,
           'data-testid': 'dashboard-respondents-view-calendar',
@@ -86,9 +86,9 @@ describe('Respondents utils tests', () => {
           action: expect.any(Function),
           title: 'View Data',
           context: {
-            respondentId: mockedFullParticipantId,
+            respondentId: mockedFullParticipantId1,
             email: mockedEmail,
-            respondentOrSubjectId: mockedFullParticipantId,
+            respondentOrSubjectId: mockedFullParticipantId1,
           },
           isDisplayed: true,
           'data-testid': 'dashboard-respondents-view-data',
@@ -98,9 +98,9 @@ describe('Respondents utils tests', () => {
           action: expect.any(Function),
           title: 'Export Data',
           context: {
-            respondentId: mockedFullParticipantId,
+            respondentId: mockedFullParticipantId1,
             email: mockedEmail,
-            respondentOrSubjectId: mockedFullParticipantId,
+            respondentOrSubjectId: mockedFullParticipantId1,
           },
           isDisplayed: true,
           'data-testid': 'dashboard-respondents-export-data',
@@ -110,9 +110,9 @@ describe('Respondents utils tests', () => {
           action: expect.any(Function),
           title: 'Edit Respondent',
           context: {
-            respondentId: mockedFullParticipantId,
+            respondentId: mockedFullParticipantId1,
             email: mockedEmail,
-            respondentOrSubjectId: mockedFullParticipantId,
+            respondentOrSubjectId: mockedFullParticipantId1,
           },
           isDisplayed: true,
           'data-testid': 'dashboard-respondents-edit',
@@ -122,9 +122,9 @@ describe('Respondents utils tests', () => {
           action: expect.any(Function),
           title: 'Send Invitation',
           context: {
-            respondentId: mockedFullParticipantId,
+            respondentId: mockedFullParticipantId1,
             email: mockedEmail,
-            respondentOrSubjectId: mockedFullParticipantId,
+            respondentOrSubjectId: mockedFullParticipantId1,
           },
           isDisplayed: true,
           'data-testid': 'dashboard-respondents-invite',
@@ -134,9 +134,9 @@ describe('Respondents utils tests', () => {
           action: expect.any(Function),
           title: 'Remove from Applet',
           context: {
-            respondentId: mockedFullParticipantId,
+            respondentId: mockedFullParticipantId1,
             email: mockedEmail,
-            respondentOrSubjectId: mockedFullParticipantId,
+            respondentOrSubjectId: mockedFullParticipantId1,
           },
           isDisplayed: true,
           customItemColor: variables.palette.dark_error_container,

--- a/src/modules/Dashboard/features/Respondents/Respondents.utils.tsx
+++ b/src/modules/Dashboard/features/Respondents/Respondents.utils.tsx
@@ -10,7 +10,7 @@ import {
   StyledFlexTopCenter,
   variables,
 } from 'shared/styles';
-import { RespondentDetail } from 'modules/Dashboard/types';
+import { ParticipantDetail } from 'modules/Dashboard/types';
 import { HeadCell } from 'shared/types';
 import i18n from 'i18n';
 
@@ -86,7 +86,7 @@ export const getRespondentActions = ({
 ];
 
 export const getAppletsSmallTableRows = (
-  respondentAccesses: RespondentDetail[],
+  respondentAccesses: ParticipantDetail[],
   setChosenAppletData: Dispatch<SetStateAction<ChosenAppletData | null>>,
   respondentId: string,
   ownerId: string,

--- a/src/modules/Dashboard/pages/ParticipantDetails/ParticipantDetails.test.tsx
+++ b/src/modules/Dashboard/pages/ParticipantDetails/ParticipantDetails.test.tsx
@@ -3,14 +3,14 @@ import { generatePath, useNavigate } from 'react-router-dom';
 import { screen, waitFor } from '@testing-library/react';
 
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
-import { mockedAppletId, mockedApplet, mockedFullParticipantId } from 'shared/mock';
+import { mockedAppletId, mockedApplet, mockedFullSubjectId1 } from 'shared/mock';
 import { getPreloadedState } from 'shared/tests/getPreloadedState';
 import { page } from 'resources';
 import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 
 import ParticipantDetails from './ParticipantDetails';
 
-const route = `/dashboard/${mockedAppletId}/participants/${mockedFullParticipantId}`;
+const route = `/dashboard/${mockedAppletId}/participants/${mockedFullSubjectId1}`;
 const routePath = page.appletParticipantDetails;
 
 const mockedAppletResult = {

--- a/src/modules/Dashboard/pages/ParticipantDetails/ParticipantDetails.test.tsx
+++ b/src/modules/Dashboard/pages/ParticipantDetails/ParticipantDetails.test.tsx
@@ -3,14 +3,14 @@ import { generatePath, useNavigate } from 'react-router-dom';
 import { screen, waitFor } from '@testing-library/react';
 
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
-import { mockedAppletId, mockedApplet, mockedRespondentId } from 'shared/mock';
+import { mockedAppletId, mockedApplet, mockedFullParticipantId } from 'shared/mock';
 import { getPreloadedState } from 'shared/tests/getPreloadedState';
 import { page } from 'resources';
 import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 
 import ParticipantDetails from './ParticipantDetails';
 
-const route = `/dashboard/${mockedAppletId}/participants/${mockedRespondentId}`;
+const route = `/dashboard/${mockedAppletId}/participants/${mockedFullParticipantId}`;
 const routePath = page.appletParticipantDetails;
 
 const mockedAppletResult = {

--- a/src/modules/Dashboard/state/Users/Users.schema.ts
+++ b/src/modules/Dashboard/state/Users/Users.schema.ts
@@ -1,8 +1,8 @@
 import { BaseSchema } from 'shared/state/Base';
-import { Respondent, RespondentDetails } from 'modules/Dashboard/types';
+import { Respondent, SubjectDetails } from 'modules/Dashboard/types';
 
 export type UsersSchema = {
   allRespondents: BaseSchema<{ result: Respondent[]; count: number } | null>;
-  respondentDetails: BaseSchema<{ result: RespondentDetails } | null>;
-  subjectDetails: BaseSchema<{ result: RespondentDetails } | null>;
+  respondentDetails: BaseSchema<{ result: SubjectDetails } | null>;
+  subjectDetails: BaseSchema<{ result: SubjectDetails } | null>;
 };

--- a/src/modules/Dashboard/state/Users/Users.schema.ts
+++ b/src/modules/Dashboard/state/Users/Users.schema.ts
@@ -1,8 +1,8 @@
 import { BaseSchema } from 'shared/state/Base';
-import { Respondent, SubjectDetails } from 'modules/Dashboard/types';
+import { Participant, SubjectDetails } from 'modules/Dashboard/types';
 
 export type UsersSchema = {
-  allRespondents: BaseSchema<{ result: Respondent[]; count: number } | null>;
+  allRespondents: BaseSchema<{ result: Participant[]; count: number } | null>;
   respondentDetails: BaseSchema<{ result: SubjectDetails } | null>;
   subjectDetails: BaseSchema<{ result: SubjectDetails } | null>;
 };

--- a/src/modules/Dashboard/types/Dashboard.types.ts
+++ b/src/modules/Dashboard/types/Dashboard.types.ts
@@ -30,7 +30,7 @@ export type Manager = {
   invitationKey: string | null;
 };
 
-export type RespondentDetail = {
+export type ParticipantDetail = {
   appletId: string;
   appletDisplayName: string;
   appletImage?: string;
@@ -51,23 +51,23 @@ export type RespondentDetail = {
   invitation: Invitation | null;
 };
 
-export enum RespondentStatus {
+export enum ParticipantStatus {
   Invited = 'invited',
   NotInvited = 'not_invited',
   Pending = 'pending',
 }
 
-export type Respondent = {
+export type Participant = {
   id: string | null;
   nicknames: string[];
   role: Roles;
   secretIds: string[];
   lastSeen: string;
   isPinned?: boolean;
-  details: RespondentDetail[];
+  details: ParticipantDetail[];
   isAnonymousRespondent: boolean;
   email: string | null;
-  status: RespondentStatus;
+  status: ParticipantStatus;
 };
 
 export type SubjectDetails = {

--- a/src/modules/Dashboard/types/Dashboard.types.ts
+++ b/src/modules/Dashboard/types/Dashboard.types.ts
@@ -70,7 +70,7 @@ export type Respondent = {
   status: RespondentStatus;
 };
 
-export type RespondentDetails = {
+export type SubjectDetails = {
   id: string;
   nickname: string;
   secretUserId: string;

--- a/src/shared/layouts/BaseLayout/components/TopBar/Notifications/Notification/Notification.test.tsx
+++ b/src/shared/layouts/BaseLayout/components/TopBar/Notifications/Notification/Notification.test.tsx
@@ -3,7 +3,7 @@
 import { screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { mockedAlert, mockedSubjectId1 } from 'shared/mock';
+import { mockedAlert, mockedFullSubjectId1 } from 'shared/mock';
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
 import * as useEncryptionStorageFunc from 'shared/hooks/useEncryptionStorage';
 
@@ -98,7 +98,7 @@ describe('Notification', () => {
     await userEvent.click(button);
 
     expect(mockedUseNavigate).toBeCalledWith(
-      `/dashboard/2e46fa32-ea7c-4a76-b49b-1c97d795bb9a/participants/${mockedSubjectId1}`,
+      `/dashboard/2e46fa32-ea7c-4a76-b49b-1c97d795bb9a/participants/${mockedFullSubjectId1}`,
     );
   });
 
@@ -125,7 +125,7 @@ describe('Notification', () => {
     await userEvent.click(button);
 
     expect(mockedUseNavigate).toBeCalledWith(
-      `/dashboard/2e46fa32-ea7c-4a76-b49b-1c97d795bb9a/participants/${mockedSubjectId1}`,
+      `/dashboard/2e46fa32-ea7c-4a76-b49b-1c97d795bb9a/participants/${mockedFullSubjectId1}`,
     );
   });
 });

--- a/src/shared/mock.ts
+++ b/src/shared/mock.ts
@@ -61,7 +61,7 @@ export const mockedOwnerSubject = {
   nickname: `${mockedUserData.firstName} ${mockedUserData.lastName}`,
   lastSeen: null,
   tag: 'Team' as ParticipantTag,
-  userId: null,
+  userId: mockedUserData.id,
   firstName: mockedUserData.firstName,
   lastName: mockedUserData.lastName,
 };

--- a/src/shared/mock.ts
+++ b/src/shared/mock.ts
@@ -4,7 +4,12 @@ import { v4 as uuidv4 } from 'uuid';
 import { Applet } from 'api';
 import { page } from 'resources';
 import { ItemFormValues, ItemFormValuesCommonType } from 'modules/Builder/types';
-import { Manager, Respondent, RespondentDetail, RespondentStatus } from 'modules/Dashboard/types';
+import {
+  Manager,
+  Participant,
+  ParticipantDetail,
+  ParticipantStatus,
+} from 'modules/Dashboard/types';
 import { AssessmentActivityItem } from 'modules/Dashboard/features/RespondentData/RespondentDataReview';
 
 import {
@@ -93,7 +98,7 @@ export const mockedOwnerRespondent = {
       invitation: null,
     },
   ],
-  status: RespondentStatus.Invited,
+  status: ParticipantStatus.Invited,
   email: mockedUserData.email,
 };
 
@@ -149,7 +154,7 @@ export const mockedCurrentWorkspace = {
 };
 export const mockedRespondentId = 'b60a142d-2b7f-4328-841c-dbhjhj4afcf1c7';
 export const mockedSubjectId1 = 'subject-id-987';
-export const mockedRespondentDetails: RespondentDetail = {
+export const mockedRespondentDetails: ParticipantDetail = {
   appletId: mockedAppletId,
   appletDisplayName: 'Mocked Applet',
   appletImage: '',
@@ -165,7 +170,7 @@ export const mockedRespondentDetails: RespondentDetail = {
   subjectCreatedAt: '2023-09-26T12:11:46.162083',
   invitation: null,
 };
-export const mockedRespondent: Respondent = {
+export const mockedRespondent: Participant = {
   id: mockedRespondentId,
   nicknames: ['Mocked Respondent'],
   secretIds: ['mockedSecretId'],
@@ -174,13 +179,13 @@ export const mockedRespondent: Respondent = {
   isPinned: false,
   role: Roles.Respondent,
   details: [mockedRespondentDetails],
-  status: RespondentStatus.Invited,
+  status: ParticipantStatus.Invited,
   email: 'resp1@mail.com',
 };
 
 export const mockedRespondentId2 = 'b60a142d-2b7f-4328-841c-ddsdddj4afcf1c7';
 export const mockedSubjectId2 = 'subject-id-123';
-export const mockedRespondent2: Respondent = {
+export const mockedRespondent2: Participant = {
   id: mockedRespondentId2,
   nicknames: ['Test Respondent'],
   secretIds: ['testSecretId'],
@@ -188,7 +193,7 @@ export const mockedRespondent2: Respondent = {
   lastSeen: new Date().toDateString(),
   isPinned: false,
   role: Roles.Respondent,
-  status: RespondentStatus.Invited,
+  status: ParticipantStatus.Invited,
   email: 'resp2@mail.com',
   details: [
     {
@@ -219,7 +224,7 @@ export const mockedLimitedRespondent = {
   lastSeen: new Date().toDateString(),
   isPinned: false,
   role: Roles.Respondent,
-  status: RespondentStatus.NotInvited,
+  status: ParticipantStatus.NotInvited,
   email: null,
   subjects: [mockedLimitedSubjectId],
   details: [

--- a/src/shared/mock.ts
+++ b/src/shared/mock.ts
@@ -71,7 +71,7 @@ export const mockedOwnerSubject = {
   lastName: mockedUserData.lastName,
 };
 
-export const mockedOwnerRespondent = {
+export const mockedOwnerParticipant = {
   id: mockedUserData.id,
   nicknames: [mockedOwnerSubject.nickname],
   secretIds: [mockedOwnerSubject.secretUserId],
@@ -152,9 +152,9 @@ export const mockedCurrentWorkspace = {
     workspaceName: 'name',
   },
 };
-export const mockedRespondentId = 'b60a142d-2b7f-4328-841c-dbhjhj4afcf1c7';
-export const mockedSubjectId1 = 'subject-id-987';
-export const mockedRespondentDetails: ParticipantDetail = {
+export const mockedFullParticipantId = 'b60a142d-2b7f-4328-841c-dbhjhj4afcf1c7';
+export const mockedFullSubjectId1 = 'subject-id-987';
+export const mockedFullParticipantDetail: ParticipantDetail = {
   appletId: mockedAppletId,
   appletDisplayName: 'Mocked Applet',
   appletImage: '',
@@ -163,30 +163,30 @@ export const mockedRespondentDetails: ParticipantDetail = {
   respondentSecretId: 'mockedSecretId',
   hasIndividualSchedule: false,
   encryption: mockedEncryption,
-  subjectId: mockedSubjectId1,
+  subjectId: mockedFullSubjectId1,
   subjectTag: 'Child' as ParticipantTag,
   subjectFirstName: 'John',
   subjectLastName: 'Doe',
   subjectCreatedAt: '2023-09-26T12:11:46.162083',
   invitation: null,
 };
-export const mockedRespondent: Participant = {
-  id: mockedRespondentId,
+export const mockedFullParticipant: Participant = {
+  id: mockedFullParticipantId,
   nicknames: ['Mocked Respondent'],
   secretIds: ['mockedSecretId'],
   isAnonymousRespondent: false,
   lastSeen: new Date().toDateString(),
   isPinned: false,
   role: Roles.Respondent,
-  details: [mockedRespondentDetails],
+  details: [mockedFullParticipantDetail],
   status: ParticipantStatus.Invited,
   email: 'resp1@mail.com',
 };
 
-export const mockedRespondentId2 = 'b60a142d-2b7f-4328-841c-ddsdddj4afcf1c7';
-export const mockedSubjectId2 = 'subject-id-123';
-export const mockedRespondent2: Participant = {
-  id: mockedRespondentId2,
+export const mockedFullParticipantId2 = 'b60a142d-2b7f-4328-841c-ddsdddj4afcf1c7';
+export const mockedFullSubjectId2 = 'subject-id-123';
+export const mockedFullParticipant2: Participant = {
+  id: mockedFullParticipantId2,
   nicknames: ['Test Respondent'],
   secretIds: ['testSecretId'],
   isAnonymousRespondent: false,
@@ -205,7 +205,7 @@ export const mockedRespondent2: Participant = {
       respondentSecretId: 'testSecretId',
       hasIndividualSchedule: false,
       encryption: mockedEncryption,
-      subjectId: mockedSubjectId2,
+      subjectId: mockedFullSubjectId2,
       subjectTag: 'Child' as ParticipantTag,
       subjectFirstName: 'John',
       subjectLastName: 'Doe',
@@ -216,7 +216,7 @@ export const mockedRespondent2: Participant = {
 };
 
 export const mockedLimitedSubjectId = 'limited-subject-id-123';
-export const mockedLimitedRespondent = {
+export const mockedLimitedParticipant: Participant = {
   id: null,
   nicknames: ['Limited 1'],
   secretIds: ['limited-1'],
@@ -226,7 +226,6 @@ export const mockedLimitedRespondent = {
   role: Roles.Respondent,
   status: ParticipantStatus.NotInvited,
   email: null,
-  subjects: [mockedLimitedSubjectId],
   details: [
     {
       appletId: mockedAppletId,
@@ -514,7 +513,7 @@ export const mockedManager: Manager = {
         {
           accessId: '17ba7d95-f766-42ae-9ce6-2f8fcc3l24a',
           role: Roles.Reviewer,
-          reviewerSubjects: [mockedSubjectId1],
+          reviewerSubjects: [mockedFullSubjectId1],
         },
       ],
       encryption: mockedEncryption,
@@ -3109,7 +3108,7 @@ export const mockedAlert = {
   image:
     'https://media-dev.cmiml.net/mindlogger/391962851007982489/4490a3c1-904b-441c-87a9-4683fe2983fa/1.jpg',
   workspace: 'Test ML',
-  subjectId: mockedSubjectId1,
+  subjectId: mockedFullSubjectId1,
 };
 
 export const mockedAppletSummaryData = [

--- a/src/shared/mock.ts
+++ b/src/shared/mock.ts
@@ -4,12 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { Applet } from 'api';
 import { page } from 'resources';
 import { ItemFormValues, ItemFormValuesCommonType } from 'modules/Builder/types';
-import {
-  Manager,
-  Participant,
-  ParticipantDetail,
-  ParticipantStatus,
-} from 'modules/Dashboard/types';
+import { Manager, Participant, ParticipantStatus } from 'modules/Dashboard/types';
 import { AssessmentActivityItem } from 'modules/Dashboard/features/RespondentData/RespondentDataReview';
 
 import {
@@ -152,33 +147,34 @@ export const mockedCurrentWorkspace = {
     workspaceName: 'name',
   },
 };
-export const mockedFullParticipantId = 'b60a142d-2b7f-4328-841c-dbhjhj4afcf1c7';
+export const mockedFullParticipantId1 = 'b60a142d-2b7f-4328-841c-dbhjhj4afcf1c7';
 export const mockedFullSubjectId1 = 'subject-id-987';
-export const mockedFullParticipantDetail: ParticipantDetail = {
-  appletId: mockedAppletId,
-  appletDisplayName: 'Mocked Applet',
-  appletImage: '',
-  accessId: 'aebf08ab-c781-4229-a625-271838ebdff4',
-  respondentNickname: 'Mocked Respondent',
-  respondentSecretId: 'mockedSecretId',
-  hasIndividualSchedule: false,
-  encryption: mockedEncryption,
-  subjectId: mockedFullSubjectId1,
-  subjectTag: 'Child' as ParticipantTag,
-  subjectFirstName: 'John',
-  subjectLastName: 'Doe',
-  subjectCreatedAt: '2023-09-26T12:11:46.162083',
-  invitation: null,
-};
-export const mockedFullParticipant: Participant = {
-  id: mockedFullParticipantId,
+export const mockedFullParticipant1: Participant = {
+  id: mockedFullParticipantId1,
   nicknames: ['Mocked Respondent'],
   secretIds: ['mockedSecretId'],
   isAnonymousRespondent: false,
   lastSeen: new Date().toDateString(),
   isPinned: false,
   role: Roles.Respondent,
-  details: [mockedFullParticipantDetail],
+  details: [
+    {
+      appletId: mockedAppletId,
+      appletDisplayName: 'Mocked Applet',
+      appletImage: '',
+      accessId: 'aebf08ab-c781-4229-a625-271838ebdff4',
+      respondentNickname: 'Mocked Respondent',
+      respondentSecretId: 'mockedSecretId',
+      hasIndividualSchedule: false,
+      encryption: mockedEncryption,
+      subjectId: mockedFullSubjectId1,
+      subjectTag: 'Child' as ParticipantTag,
+      subjectFirstName: 'John',
+      subjectLastName: 'Doe',
+      subjectCreatedAt: '2023-09-26T12:11:46.162083',
+      invitation: null,
+    },
+  ],
   status: ParticipantStatus.Invited,
   email: 'resp1@mail.com',
 };


### PR DESCRIPTION
### 📝 Description

I've been finding it annoying dealing with mock variables named as if they are describing "respondents" when they're actually describing participants more generally. Similar confusion arises with some of the type names; for example, `RespondentDetails` representing the details of a subject entity on the BE (and not necessarily haven't anything to do with the subject having a "respondent" role).

So I thought that during a period when there isn't much parallel activity happening in this repo and low risk of conflicts, I opted to do some renaming of these symbols:

[`dashboard.types.ts`](https://github.com/ChildMindInstitute/mindlogger-admin/pull/1998/files#diff-2958a24fb2a8c137ee0b146c134c80bc32eb48af38b89fff44b397ca348ce424):

- rename type `Respondent` ⇒ `Participant`
- rename type `RespondentDetail` ⇒ `ParticipantDetail`
- rename enum `RespondentStatus` ⇒ `ParticipantStatus`
- rename type `RespondentDetails` ⇒ `SubjectDetails`
  - This one I thought it made more sense to use "Subject" since it's a type that's so commonly used to represent a "subject" entity structure returned from the BE; open to feedback though

[`mock.ts`](https://github.com/ChildMindInstitute/mindlogger-admin/pull/1998/files#diff-68be31d3aa680bf1e385d1094572c72dca1fe4a995fbc22a2b042bf9d2e6b5d5):

- rename mock variables `*Respondent*` ⇒ `*Participant*`
- make mocked participant data more descriptive where possible
- align naming/structure of `mockedFull*1` and `mockedFull*2` mock accounts

Several Dataviz-related tests:
- use `mockedFullSubject1` rather than `mockedFullParticipantId` where used incorrectly (didn't actually impact actual tests passing, but good practice and makes understanding API calls and tests easier for new devs; thanks @sultanofcardio!)

There is no Jira ticket explicitly associated with this change, I opted to do it as a side effect of writing PDP unit tests and trying to make the code make more sense.

### 🪤 Peer Testing

TSC should compile correctly and unit tests should pass, so no manual testing should be needed.
