### PR TITLE
fix: Update InputSchedulePopup tests for dynamic dates

### DIFF
--- a/src/modules/Dashboard/features/Applet/Schedule/ImportSchedulePopup/ImportSchedulePopup.utils.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/ImportSchedulePopup/ImportSchedulePopup.utils.test.tsx
@@ -18,6 +18,8 @@ import {
 import { ImportScheduleErrors } from './ImportSchedulePopup.types';
 import { dateValidationRegex } from './ImportSchedule.const';
 
+const currentYear = new Date().getFullYear();
+
 describe('getInvalidActivitiesError', () => {
   const errorText1 =
     'Activity does not exist in Applet TestApplet. Please enter a valid Activity name and reupload the file.';
@@ -306,7 +308,6 @@ describe('prepareImportPayload', () => {
   const mockRespondentId = 'respondentId';
   test('returns prepared import payload with valid data', () => {
     const result = prepareImportPayload(mockUploadedEvents, mockAppletData, mockRespondentId);
-    const getCurrentYear = new Date().getFullYear();
 
     expect(result).toEqual([
       {
@@ -345,7 +346,7 @@ describe('prepareImportPayload', () => {
           type: 'ALWAYS',
           selectedDate: undefined,
           startDate: '2024-02-13',
-          endDate: `${getCurrentYear()}-12-31`,
+          endDate: `${currentYear}-12-31`,
         },
         activityId: undefined,
         flowId: undefined,
@@ -359,7 +360,7 @@ describe('prepareImportPayload', () => {
         timerType: 'NOT_SET',
         respondentId: 'respondentId',
         periodicity: {
-          endDate: `${getCurrentYear()}-12-31`,
+          endDate: `${currentYear}-12-31`,
           selectedDate: undefined,
           startDate: '2024-03-07',
           type: 'ALWAYS',

--- a/src/modules/Dashboard/features/Applet/Schedule/ImportSchedulePopup/ImportSchedulePopup.utils.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/ImportSchedulePopup/ImportSchedulePopup.utils.test.tsx
@@ -18,8 +18,6 @@ import {
 import { ImportScheduleErrors } from './ImportSchedulePopup.types';
 import { dateValidationRegex } from './ImportSchedule.const';
 
-const getCurrentYear = new Date().getFullYear();
-
 describe('getInvalidActivitiesError', () => {
   const errorText1 =
     'Activity does not exist in Applet TestApplet. Please enter a valid Activity name and reupload the file.';
@@ -308,6 +306,7 @@ describe('prepareImportPayload', () => {
   const mockRespondentId = 'respondentId';
   test('returns prepared import payload with valid data', () => {
     const result = prepareImportPayload(mockUploadedEvents, mockAppletData, mockRespondentId);
+    const getCurrentYear = new Date().getFullYear();
 
     expect(result).toEqual([
       {

--- a/src/modules/Dashboard/features/Applet/Schedule/ImportSchedulePopup/ImportSchedulePopup.utils.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/ImportSchedulePopup/ImportSchedulePopup.utils.test.tsx
@@ -18,6 +18,8 @@ import {
 import { ImportScheduleErrors } from './ImportSchedulePopup.types';
 import { dateValidationRegex } from './ImportSchedule.const';
 
+const getCurrentYear = new Date().getFullYear();
+
 describe('getInvalidActivitiesError', () => {
   const errorText1 =
     'Activity does not exist in Applet TestApplet. Please enter a valid Activity name and reupload the file.';
@@ -344,7 +346,7 @@ describe('prepareImportPayload', () => {
           type: 'ALWAYS',
           selectedDate: undefined,
           startDate: '2024-02-13',
-          endDate: '2024-12-31',
+          endDate: `${getCurrentYear()}-12-31`,
         },
         activityId: undefined,
         flowId: undefined,
@@ -358,7 +360,7 @@ describe('prepareImportPayload', () => {
         timerType: 'NOT_SET',
         respondentId: 'respondentId',
         periodicity: {
-          endDate: '2024-12-31',
+          endDate: `${getCurrentYear()}-12-31`,
           selectedDate: undefined,
           startDate: '2024-03-07',
           type: 'ALWAYS',


### PR DESCRIPTION
- [X] Tests for the changes have been 
- [ ] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

🔗 [Jira Ticket M2-8446](https://mindlogger.atlassian.net/browse/M2-8446)

A test for `InputSchedulePopup.utils.test.tsx` was incorrectly failing due to mock items having a hardcoded date, supposed to be pointing towards the last day of the year. Hardcoded date pointed towards 2024. A simple change in order to point to the current year was implemented.