### PR TITLE
fix: Adds text and message as possible flow sequences (M2-8286)

### DIFF
--- a/src/modules/Builder/features/ActivityItemsFlow_old/ActivityItemsFlow.test.tsx
+++ b/src/modules/Builder/features/ActivityItemsFlow_old/ActivityItemsFlow.test.tsx
@@ -74,6 +74,13 @@ const mockedOrderedConditionNameItems = [
   mockedMultiActivityItem,
   mockedSliderActivityItem,
 ];
+const mockedOrderedFlowSequenceNameItems = [
+  mockedSingleActivityItem,
+  mockedMultiActivityItem,
+  mockedTextActivityItem,
+  mockedSliderActivityItem,
+  mockedMessageActivityItem,
+];
 
 const renderActivityItemsFlow = (formData) => {
   const ref = createRef();
@@ -260,11 +267,11 @@ describe('Activity Items Flow', () => {
     expect(itemDropdown).toBeVisible();
 
     const items = itemDropdown.querySelectorAll('li');
-    expect(items).toHaveLength(3);
+    expect(items).toHaveLength(mockedOrderedFlowSequenceNameItems.length);
 
     items.forEach((item, index) => {
-      expect(item).toHaveAttribute('data-value', mockedOrderedConditionNameItems[index].id);
-      expect(item).toHaveTextContent(mockedOrderedConditionNameItems[index].name);
+      expect(item).toHaveAttribute('data-value', mockedOrderedFlowSequenceNameItems[index].id);
+      expect(item).toHaveTextContent(mockedOrderedFlowSequenceNameItems[index].name);
     });
   });
 

--- a/src/modules/Builder/features/ActivityItemsFlow_old/ItemFlow/SummaryRow/SummaryRow.utils.test.tsx
+++ b/src/modules/Builder/features/ActivityItemsFlow_old/ItemFlow/SummaryRow/SummaryRow.utils.test.tsx
@@ -1,4 +1,5 @@
 import { ItemResponseType } from 'shared/consts';
+import { StyledMdPreview } from 'modules/Builder/components/ItemFlowSelectController/StyledMdPreview/StyledMdPreview.styles';
 
 import { getItemsOptions, getItemsInUsage } from './SummaryRow.utils';
 
@@ -221,6 +222,20 @@ describe('SummaryRow.utils', () => {
         tooltip:
           "This item is already selected in another Conditional card's summary row. If multiple conditions are necessary, use the same Conditional card with ALL or ANY conditions.",
         value: 'item-3',
+        tooltipPlacement: 'right',
+      },
+      {
+        disabled: false,
+        labelKey: 't1',
+        value: 'item-4',
+        tooltip: <StyledMdPreview modelValue="item-4" />,
+        tooltipPlacement: 'right',
+      },
+      {
+        disabled: false,
+        labelKey: 'Message',
+        value: 'item-17',
+        tooltip: <StyledMdPreview modelValue="item-17" />,
         tooltipPlacement: 'right',
       },
     ];

--- a/src/modules/Builder/features/ActivityItemsFlow_old/ItemFlow/SummaryRow/SummaryRow.utils.tsx
+++ b/src/modules/Builder/features/ActivityItemsFlow_old/ItemFlow/SummaryRow/SummaryRow.utils.tsx
@@ -20,6 +20,14 @@ export const getMatchOptions = () => [
   },
 ];
 
+const allowedResponseTypes = [
+  ItemResponseType.Slider,
+  ItemResponseType.SingleSelection,
+  ItemResponseType.MultipleSelection,
+  ItemResponseType.Text,
+  ItemResponseType.Message,
+];
+
 export const getItemsOptions = ({ items, itemsInUsage, conditions }: GetItemsOptionsProps) => {
   const itemsObject = getObjectFromList(items, undefined, true);
   const conditionItemsInUsageSet = new Set(conditions.map((condition) => condition.itemName));
@@ -28,11 +36,7 @@ export const getItemsOptions = ({ items, itemsInUsage, conditions }: GetItemsOpt
   );
 
   return items?.reduce((optionList: { value: string; labelKey: string }[], item, index) => {
-    if (
-      item.responseType !== ItemResponseType.Slider &&
-      item.responseType !== ItemResponseType.SingleSelection &&
-      item.responseType !== ItemResponseType.MultipleSelection
-    ) {
+    if (!allowedResponseTypes.includes(item.responseType)) {
       return optionList;
     }
 


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added
- [x] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-8286](https://mindlogger.atlassian.net/browse/M2-8286)

- As per discussion with the team, including also the possibility of choosing the sequence of the item flow to Text and Message items


### 🪤 Peer Testing

- Make sure the feature flag enableItemFlowExtendedItems is off.

- Log into the admin platform, create an applet and activity

- Include different types of items in the activity

- Create a new Flow for the activity

- Populate the trigger (1st box)

Expected outcome: Check whether the last box is populated with items other than legacy logic (Slider, Multiple Selection,  Single Selection, Text or Message )

### ✏️ Notes

- Based on the ticket https://mindlogger.atlassian.net/browse/M2-8248 status - Amplify should now be able to use DEV values, so it's possible to test this change on Amplify, changing the values on LD Dev.
