### PR TITLE
fix: Reviewer/Coordinator shouldn't be offered to View Data of participants they aren't assigned to (M2-8359)

### DIFF
--- a/src/modules/Dashboard/api/api.types.ts
+++ b/src/modules/Dashboard/api/api.types.ts
@@ -731,6 +731,7 @@ export type TargetSubjectsByRespondent = Array<
     AppletId & {
       submissionCount: number;
       currentlyAssigned: boolean;
+      teamMemberCanViewData: boolean;
     }
 >;
 

--- a/src/modules/Dashboard/features/Participant/Assignments/AboutParticipant/AboutParticipant.test.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/AboutParticipant/AboutParticipant.test.tsx
@@ -24,6 +24,7 @@ import {
 } from 'shared/utils/axios-mocks';
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
 import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
+import { Roles } from 'shared/consts';
 
 import AboutParticipant from './AboutParticipant';
 
@@ -132,8 +133,8 @@ const testId = 'participant-details-about-participant';
 const route = `/dashboard/${mockedAppletId}/participants/${mockedOwnerSubject.id}`;
 const routePath = page.appletParticipantDetails;
 
-const preloadedState: PreloadedState<RootState> = {
-  ...getPreloadedState(),
+const preloadedState: (role?: Roles) => PreloadedState<RootState> = (role) => ({
+  ...getPreloadedState(role),
   users: {
     respondentDetails: mockSchema(null),
     allRespondents: mockSchema(null, {
@@ -143,10 +144,10 @@ const preloadedState: PreloadedState<RootState> = {
       result: mockedOwnerSubject,
     }),
   },
-};
+});
 
 const renderOptions = {
-  preloadedState,
+  preloadedState: preloadedState(),
   route,
   routePath,
 };
@@ -269,5 +270,18 @@ describe('Dashboard > Applet > Participant > Assignments > About Participant scr
     await userEvent.click(within(activitiesOrFlows[0]).getByText('View Data'));
 
     expect(screen.getByTestId('unlock-applet-data-popup')).toBeVisible();
+  });
+
+  it('should disable the view data button for coordinators', async () => {
+    renderWithProviders(<AboutParticipant />, {
+      ...renderOptions,
+      preloadedState: preloadedState(Roles.Coordinator),
+    });
+
+    const activitiesOrFlows = await screen.findAllByTestId(`${testId}-activity-list-item`);
+
+    const viewDataButton = within(activitiesOrFlows[0]).getByText('View Data');
+
+    expect(viewDataButton).toBeDisabled();
   });
 });

--- a/src/modules/Dashboard/features/Participant/Assignments/AboutParticipant/AboutParticipant.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/AboutParticipant/AboutParticipant.tsx
@@ -6,10 +6,11 @@ import { format } from 'date-fns';
 
 import { useAsync } from 'shared/hooks';
 import { getAppletTargetSubjectActivitiesApi, ParticipantActivityOrFlow } from 'api';
-import { users } from 'redux/modules';
-import { ActionsMenu, Spinner, Svg, Tooltip } from 'shared/components';
+import { users, workspaces } from 'redux/modules';
+import { ActionsMenu, OptionalTooltipWrapper, Spinner, Svg, Tooltip } from 'shared/components';
 import { StyledFlexTopCenter } from 'shared/styles';
 import { DateFormats } from 'shared/consts';
+import { hasPermissionToViewData } from 'modules/Dashboard/pages/RespondentData/RespondentData.utils';
 
 import { AssignmentsTab, useAssignmentsTab } from '../AssignmentsTab';
 import { ActivitiesList } from '../ActivitiesList';
@@ -25,6 +26,10 @@ const AboutParticipant = () => {
   const { useSubject, useSubjectStatus } = users;
   const isLoadingSubject = useSubjectStatus() !== 'success';
   const { result: targetSubject } = useSubject() ?? {};
+
+  const rolesData = workspaces.useRolesData();
+  const roles = appletId ? rolesData?.data?.[appletId] : undefined;
+  const canViewData = hasPermissionToViewData(roles);
 
   const {
     execute: fetchActivities,
@@ -126,17 +131,25 @@ const AboutParticipant = () => {
                   </StyledFlexTopCenter>
                 </Tooltip>
 
-                <Button
-                  variant="outlined"
-                  onClick={() => handleClickNavigateToData(activity)}
-                  sx={{ mr: 0.4 }}
-                  className="primary-button"
-                  disableRipple
-                  data-testid={`${dataTestId}-${index}-view-data`}
+                <OptionalTooltipWrapper
+                  tooltipTitle={!canViewData ? t('subjectDataUnavailable') : ''}
                 >
-                  <Svg id="chart" width="18" height="18" fill="currentColor" />
-                  {t('viewData')}
-                </Button>
+                  {/*https://mui.com/material-ui/react-tooltip/#disabled-elements*/}
+                  <span>
+                    <Button
+                      variant="outlined"
+                      onClick={() => handleClickNavigateToData(activity)}
+                      sx={{ mr: 0.4 }}
+                      className="primary-button"
+                      disableRipple
+                      data-testid={`${dataTestId}-${index}-view-data`}
+                      disabled={!canViewData}
+                    >
+                      <Svg id="chart" width="18" height="18" fill="currentColor" />
+                      {t('viewData')}
+                    </Button>
+                  </span>
+                </OptionalTooltipWrapper>
 
                 <ActionsMenu
                   anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}

--- a/src/modules/Dashboard/features/Participant/Assignments/AboutParticipant/AboutParticipant.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/AboutParticipant/AboutParticipant.tsx
@@ -156,7 +156,7 @@ const AboutParticipant = () => {
                   anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
                   transformOrigin={{ vertical: -6, horizontal: 'right' }}
                   buttonColor="secondary"
-                  menuItems={getActionsMenu(activity)}
+                  menuItems={getActionsMenu({ activityOrFlow: activity })}
                   data-testid={`${dataTestId}-${index}`}
                 />
               </ActivityListItem>

--- a/src/modules/Dashboard/features/Participant/Assignments/AboutParticipant/AboutParticipant.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/AboutParticipant/AboutParticipant.tsx
@@ -134,7 +134,7 @@ const AboutParticipant = () => {
                 <OptionalTooltipWrapper
                   tooltipTitle={!canViewData ? t('subjectDataUnavailable') : ''}
                 >
-                  {/*https://mui.com/material-ui/react-tooltip/#disabled-elements*/}
+                  {/* https://mui.com/material-ui/react-tooltip/#disabled-elements */}
                   <span>
                     <Button
                       variant="outlined"

--- a/src/modules/Dashboard/features/Participant/Assignments/AssignmentsTab/AssignmentsTab.hooks.test.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/AssignmentsTab/AssignmentsTab.hooks.test.tsx
@@ -158,7 +158,7 @@ const UseAssignmentsHookTest = ({
         </Button>
       )}
       <ActionsMenu
-        menuItems={getActionsMenu(activityOrFlow)}
+        menuItems={getActionsMenu({ activityOrFlow })}
         data-testid={`${testId}-activity-actions`}
       />
 

--- a/src/modules/Dashboard/features/Participant/Assignments/AssignmentsTab/AssignmentsTab.hooks.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/AssignmentsTab/AssignmentsTab.hooks.tsx
@@ -33,7 +33,7 @@ import { ActivityAssignDrawer, ActivityUnassignDrawer } from 'modules/Dashboard/
 import { EditablePerformanceTasks } from 'modules/Builder/features/Activities/Activities.const';
 import { SubjectDetails } from 'modules/Dashboard/types';
 
-import { UseAssignmentsTabProps } from './AssignmentsTab.types';
+import { GetActionsMenuParams, UseAssignmentsTabProps } from './AssignmentsTab.types';
 
 export const useAssignmentsTab = ({
   appletId,
@@ -215,7 +215,11 @@ export const useAssignmentsTab = ({
    * the current respondent).
    */
   const getActionsMenu = useCallback(
-    (activityOrFlow: ParticipantActivityOrFlow, targetSubjectArg = targetSubject) => {
+    ({
+      activityOrFlow,
+      targetSubject: targetSubjectArg = targetSubject,
+      teamMemberCanViewData = true,
+    }: GetActionsMenuParams) => {
       const { id, autoAssign, assignments, isFlow, performanceTaskType, status } = activityOrFlow;
 
       // TODO: Remove extra steps below after supportedPlatforms prop is returned by API
@@ -258,6 +262,9 @@ export const useAssignmentsTab = ({
       // this condition after M2-7906 has been completed.
       const isTakeNowDisplayed = canDoTakeNow && !!activities.length;
 
+      const isExportDisabled = !id || !teamMemberCanViewData;
+      const exportDisabledTooltip = !teamMemberCanViewData ? t('subjectDataUnavailable') : '';
+
       let assignTooltip: string | undefined;
       if (status === ActivityAssignmentStatus.Hidden) {
         assignTooltip = isFlow
@@ -288,7 +295,8 @@ export const useAssignmentsTab = ({
             setSelectedTargetSubjectId(targetSubjectArg?.id);
             setShowExportData(true);
           },
-          disabled: !id,
+          disabled: isExportDisabled,
+          tooltip: exportDisabledTooltip,
           icon: <Svg id="export" />,
           title: t('exportData'),
           isDisplayed: canAccessData && !!targetSubjectArg,

--- a/src/modules/Dashboard/features/Participant/Assignments/AssignmentsTab/AssignmentsTab.types.ts
+++ b/src/modules/Dashboard/features/Participant/Assignments/AssignmentsTab/AssignmentsTab.types.ts
@@ -1,6 +1,7 @@
 import { PropsWithChildren } from 'react';
 
 import { SubjectDetails } from 'modules/Dashboard/types';
+import { ParticipantActivityOrFlow } from 'modules/Dashboard/api';
 
 export type AssignmentsTabProps = PropsWithChildren<{
   isLoadingMetadata: boolean;
@@ -14,4 +15,10 @@ export type UseAssignmentsTabProps = {
   respondentSubject?: SubjectDetails;
   handleRefetch?: () => void;
   dataTestId: string;
+};
+
+export type GetActionsMenuParams = {
+  activityOrFlow: ParticipantActivityOrFlow;
+  targetSubject?: SubjectDetails;
+  teamMemberCanViewData?: boolean;
 };

--- a/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ByParticipant.test.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ByParticipant.test.tsx
@@ -24,6 +24,7 @@ import {
 } from 'shared/utils/axios-mocks';
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
 import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
+import { Roles } from 'shared/consts';
 
 import ByParticipant from './ByParticipant';
 
@@ -106,7 +107,11 @@ const successfulGetAppletRespondentSubjectActivitiesMock = mockSuccessfulHttpRes
 
 const successfulGetTargetSubjectsByRespondentMock = ({
   activityOrFlowId,
-}: Record<string, string>) => {
+  teamMemberCanViewData,
+}: Partial<{
+  activityOrFlowId: string;
+  teamMemberCanViewData: boolean;
+}>) => {
   const participantActivityOrFlow = mockParticipantActivitiesOrFlows.find(
     (a) => a.id === activityOrFlowId,
   );
@@ -120,6 +125,7 @@ const successfulGetTargetSubjectsByRespondentMock = ({
         ...mockedOwnerSubject,
         submissionCount: activityOrFlowMetadata?.respondentSubmissionsCount,
         currentlyAssigned: participantActivityOrFlow?.status === 'active',
+        teamMemberCanViewData: teamMemberCanViewData ?? true,
       },
     ],
     count: 1,
@@ -156,8 +162,8 @@ const testId = 'participant-details-by-participant';
 const route = `/dashboard/${mockedAppletId}/participants/${mockedOwnerSubject.id}`;
 const routePath = page.appletParticipantDetails;
 
-const preloadedState: PreloadedState<RootState> = {
-  ...getPreloadedState(),
+const preloadedState: (role?: Roles) => PreloadedState<RootState> = (role) => ({
+  ...getPreloadedState(role),
   users: {
     respondentDetails: mockSchema(null),
     allRespondents: mockSchema(null, {
@@ -167,12 +173,26 @@ const preloadedState: PreloadedState<RootState> = {
       result: mockedOwnerSubject,
     }),
   },
-};
+});
 
 const renderOptions = {
-  preloadedState,
+  preloadedState: preloadedState(),
   route,
   routePath,
+};
+
+const getRequestResponses = {
+  [GET_APPLET_URL]: successfulGetAppletMock,
+  [GET_APPLET_ACTIVITIES_URL]: successfulGetAppletActivitiesMock,
+  [GET_APPLET_ACTIVITIES_METADATA_URL]: successfulGetAppletActivitiesMetadataMock,
+  [GET_APPLET_RESPONDENT_SUBJECT_ACTIVITIES_URL]:
+    successfulGetAppletRespondentSubjectActivitiesMock,
+  [`${GET_TARGET_SUBJECTS_BY_RESPONDENT_URL}/${mockParticipantActivitiesOrFlows[0].id}`]:
+    successfulGetTargetSubjectsByRespondentMock({
+      activityOrFlowId: mockParticipantActivitiesOrFlows[0].id,
+    }),
+  [GET_WORKSPACE_RESPONDENTS_URL]: successfulGetWorkspaceRespondentsMock,
+  [GET_WORKSPACE_MANAGERS_URL]: successfulGetWorkspaceManagersMock,
 };
 
 jest.mock('shared/hooks/useFeatureFlags');
@@ -192,15 +212,7 @@ describe('Dashboard > Applet > Participant > Assignments > By Participant screen
       resetLDContext: jest.fn(),
     });
 
-    mockGetRequestResponses({
-      [GET_APPLET_URL]: successfulGetAppletMock,
-      [GET_APPLET_ACTIVITIES_URL]: successfulGetAppletActivitiesMock,
-      [GET_APPLET_ACTIVITIES_METADATA_URL]: successfulGetAppletActivitiesMetadataMock,
-      [GET_APPLET_RESPONDENT_SUBJECT_ACTIVITIES_URL]:
-        successfulGetAppletRespondentSubjectActivitiesMock,
-      [GET_WORKSPACE_RESPONDENTS_URL]: successfulGetWorkspaceRespondentsMock,
-      [GET_WORKSPACE_MANAGERS_URL]: successfulGetWorkspaceManagersMock,
-    });
+    mockGetRequestResponses(getRequestResponses);
   });
 
   afterEach(() => {
@@ -215,13 +227,9 @@ describe('Dashboard > Applet > Participant > Assignments > By Participant screen
 
   it('should render the empty state', async () => {
     mockGetRequestResponses({
-      [GET_APPLET_URL]: successfulGetAppletMock,
-      [GET_APPLET_ACTIVITIES_URL]: successfulGetAppletActivitiesMock,
-      [GET_APPLET_ACTIVITIES_METADATA_URL]: successfulGetAppletActivitiesMetadataMock,
+      ...getRequestResponses,
       [GET_APPLET_RESPONDENT_SUBJECT_ACTIVITIES_URL]:
         successfulEmptyGetAppletRespondentSubjectActivitiesMock,
-      [GET_WORKSPACE_RESPONDENTS_URL]: successfulGetWorkspaceRespondentsMock,
-      [GET_WORKSPACE_MANAGERS_URL]: successfulGetWorkspaceManagersMock,
     });
 
     renderWithProviders(<ByParticipant />, renderOptions);
@@ -280,22 +288,6 @@ describe('Dashboard > Applet > Participant > Assignments > By Participant screen
   });
 
   describe('expanded view', () => {
-    beforeEach(() => {
-      mockGetRequestResponses({
-        [GET_APPLET_URL]: successfulGetAppletMock,
-        [GET_APPLET_ACTIVITIES_URL]: successfulGetAppletActivitiesMock,
-        [GET_APPLET_ACTIVITIES_METADATA_URL]: successfulGetAppletActivitiesMetadataMock,
-        [GET_APPLET_RESPONDENT_SUBJECT_ACTIVITIES_URL]:
-          successfulGetAppletRespondentSubjectActivitiesMock,
-        [`${GET_TARGET_SUBJECTS_BY_RESPONDENT_URL}/${mockParticipantActivitiesOrFlows[0].id}`]:
-          successfulGetTargetSubjectsByRespondentMock({
-            activityOrFlowId: mockParticipantActivitiesOrFlows[0].id,
-          }),
-        [GET_WORKSPACE_RESPONDENTS_URL]: successfulGetWorkspaceRespondentsMock,
-        [GET_WORKSPACE_MANAGERS_URL]: successfulGetWorkspaceManagersMock,
-      });
-    });
-
     it('should be expanded when clicking activity/flow card', async () => {
       renderWithProviders(<ByParticipant />, renderOptions);
 
@@ -332,6 +324,28 @@ describe('Dashboard > Applet > Participant > Assignments > By Participant screen
       await userEvent.click(viewDataButton);
 
       expect(screen.getByTestId('unlock-applet-data-popup')).toBeVisible();
+    });
+
+    it('should disable the View Data button according to the API data', async () => {
+      mockGetRequestResponses({
+        ...getRequestResponses,
+        [`${GET_TARGET_SUBJECTS_BY_RESPONDENT_URL}/${mockParticipantActivitiesOrFlows[0].id}`]:
+          successfulGetTargetSubjectsByRespondentMock({
+            activityOrFlowId: mockParticipantActivitiesOrFlows[0].id,
+            teamMemberCanViewData: false,
+          }),
+      });
+
+      renderWithProviders(<ByParticipant />, renderOptions);
+
+      const activityOrFlow = (await screen.findAllByTestId(`${testId}-activity-list-item`))[0];
+
+      const toggleButton = within(activityOrFlow).getByLabelText('Toggle Subjects View');
+
+      await userEvent.click(toggleButton);
+
+      const viewDataButton = screen.getByTestId(`${testId}-0-expanded-view-subject-0-view-data`);
+      expect(viewDataButton).toBeDisabled();
     });
   });
 });

--- a/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ByParticipant.test.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ByParticipant.test.tsx
@@ -369,5 +369,57 @@ describe('Dashboard > Applet > Participant > Assignments > By Participant screen
       const viewDataButton = screen.getByTestId(`${testId}-0-expanded-view-subject-0-view-data`);
       expect(viewDataButton).toBeDisabled();
     });
+
+    it('should default the export data menu item to enabled when visible', async () => {
+      mockGetRequestResponses({
+        ...getRequestResponses,
+        [`${GET_TARGET_SUBJECTS_BY_RESPONDENT_URL}/${mockParticipantActivitiesOrFlows[0].id}`]:
+          successfulGetTargetSubjectsByRespondentMock({
+            activityOrFlowId: mockParticipantActivitiesOrFlows[0].id,
+            teamMemberCanViewData: undefined,
+          }),
+      });
+
+      renderWithProviders(<ByParticipant />, renderOptions);
+
+      const activityOrFlow = (await screen.findAllByTestId(`${testId}-activity-list-item`))[0];
+
+      const toggleButton = within(activityOrFlow).getByLabelText('Toggle Subjects View');
+
+      await userEvent.click(toggleButton);
+
+      const actionsMenuButton = screen.getByTestId(`${testId}-0-expanded-view-subject-0-dots`);
+      await userEvent.click(actionsMenuButton);
+
+      const exportDataMenuItem = screen.getByTestId(`${testId}-export`);
+
+      expect(exportDataMenuItem).toBeEnabled();
+    });
+
+    it('should disable the export data menu item according to API data', async () => {
+      mockGetRequestResponses({
+        ...getRequestResponses,
+        [`${GET_TARGET_SUBJECTS_BY_RESPONDENT_URL}/${mockParticipantActivitiesOrFlows[0].id}`]:
+          successfulGetTargetSubjectsByRespondentMock({
+            activityOrFlowId: mockParticipantActivitiesOrFlows[0].id,
+            teamMemberCanViewData: false,
+          }),
+      });
+
+      renderWithProviders(<ByParticipant />, renderOptions);
+
+      const activityOrFlow = (await screen.findAllByTestId(`${testId}-activity-list-item`))[0];
+
+      const toggleButton = within(activityOrFlow).getByLabelText('Toggle Subjects View');
+
+      await userEvent.click(toggleButton);
+
+      const actionsMenuButton = screen.getByTestId(`${testId}-0-expanded-view-subject-0-dots`);
+      await userEvent.click(actionsMenuButton);
+
+      const exportDataMenuItem = screen.getByTestId(`${testId}-export`);
+
+      expect(exportDataMenuItem).toBeEnabled();
+    });
   });
 });

--- a/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ByParticipant.test.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ByParticipant.test.tsx
@@ -326,6 +326,28 @@ describe('Dashboard > Applet > Participant > Assignments > By Participant screen
       expect(screen.getByTestId('unlock-applet-data-popup')).toBeVisible();
     });
 
+    it('should default the View Data button to enabled', async () => {
+      mockGetRequestResponses({
+        ...getRequestResponses,
+        [`${GET_TARGET_SUBJECTS_BY_RESPONDENT_URL}/${mockParticipantActivitiesOrFlows[0].id}`]:
+          successfulGetTargetSubjectsByRespondentMock({
+            activityOrFlowId: mockParticipantActivitiesOrFlows[0].id,
+            teamMemberCanViewData: undefined,
+          }),
+      });
+
+      renderWithProviders(<ByParticipant />, renderOptions);
+
+      const activityOrFlow = (await screen.findAllByTestId(`${testId}-activity-list-item`))[0];
+
+      const toggleButton = within(activityOrFlow).getByLabelText('Toggle Subjects View');
+
+      await userEvent.click(toggleButton);
+
+      const viewDataButton = screen.getByTestId(`${testId}-0-expanded-view-subject-0-view-data`);
+      expect(viewDataButton).toBeEnabled();
+    });
+
     it('should disable the View Data button according to the API data', async () => {
       mockGetRequestResponses({
         ...getRequestResponses,

--- a/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ByParticipant.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ByParticipant.tsx
@@ -215,7 +215,7 @@ const ByParticipant = () => {
                   anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
                   transformOrigin={{ vertical: -6, horizontal: 'right' }}
                   buttonColor="secondary"
-                  menuItems={getActionsMenu(activity)}
+                  menuItems={getActionsMenu({ activityOrFlow: activity })}
                   data-testid={`${dataTestId}-${index}`}
                 />
               </ActivityListItem>

--- a/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ExpandedView/ExpandedView.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ExpandedView/ExpandedView.tsx
@@ -22,7 +22,10 @@ export const ExpandedView = ({
   const rows: Row[] = useMemo(
     () =>
       targetSubjects.map(
-        ({ submissionCount, currentlyAssigned, teamMemberCanViewData, ...subject }, index) => ({
+        (
+          { submissionCount, currentlyAssigned, teamMemberCanViewData = true, ...subject },
+          index,
+        ) => ({
           id: {
             value: subject.id,
             content: () => <ParticipantSnippet {...subject} secretId={subject.secretUserId} />,

--- a/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ExpandedView/ExpandedView.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ExpandedView/ExpandedView.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import { Button } from '@mui/material';
 
 import { ParticipantSnippet } from 'modules/Dashboard/components';
-import { ActionsMenu, Row, Svg } from 'shared/components';
+import { ActionsMenu, OptionalTooltipWrapper, Row, Svg } from 'shared/components';
 import { StyledFlexTopCenter } from 'shared/styles';
 
 import { ExpandedViewProps } from './ExpandedView.types';
@@ -21,56 +21,66 @@ export const ExpandedView = ({
 
   const rows: Row[] = useMemo(
     () =>
-      targetSubjects.map(({ submissionCount, currentlyAssigned, ...subject }, index) => ({
-        id: {
-          value: subject.id,
-          content: () => <ParticipantSnippet {...subject} secretId={subject.secretUserId} />,
-        },
-        submissionCount: {
-          value: String(submissionCount),
-          content: () => String(submissionCount),
-        },
-        currentlyAssigned: {
-          value: String(currentlyAssigned),
-          content: () => (currentlyAssigned ? t('yes') : t('no')),
-        },
-        actions: {
-          value: '',
-          content: () => {
-            // Filter assignments attached to this activity/flow by target subject before
-            // passing to `getActionsMenu()` so that the Unassign action only prompts user to
-            // unassign for the specific target subject.
-            const filteredActivityOrFlow = {
-              ...activityOrFlow,
-              assignments: activityOrFlow.assignments.filter(
-                ({ targetSubject }) => targetSubject.id === subject.id,
-              ),
-            };
-
-            return (
-              <StyledFlexTopCenter sx={{ gap: 0.8 }}>
-                <Button
-                  variant="outlined"
-                  onClick={() => onClickViewData(activityOrFlow, subject)}
-                  sx={{ mr: 0.4 }}
-                  data-testid={`${dataTestId}-subject-${index}-view-data`}
-                >
-                  <Svg id="chart" width="18" height="18" fill="currentColor" />
-                  {t('viewData')}
-                </Button>
-
-                <ActionsMenu
-                  anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-                  transformOrigin={{ vertical: -6, horizontal: 'right' }}
-                  buttonColor="secondary"
-                  menuItems={getActionsMenu(filteredActivityOrFlow, subject)}
-                  data-testid={`${dataTestId}-subject-${index}`}
-                />
-              </StyledFlexTopCenter>
-            );
+      targetSubjects.map(
+        ({ submissionCount, currentlyAssigned, teamMemberCanViewData, ...subject }, index) => ({
+          id: {
+            value: subject.id,
+            content: () => <ParticipantSnippet {...subject} secretId={subject.secretUserId} />,
           },
-        },
-      })),
+          submissionCount: {
+            value: String(submissionCount),
+            content: () => String(submissionCount),
+          },
+          currentlyAssigned: {
+            value: String(currentlyAssigned),
+            content: () => (currentlyAssigned ? t('yes') : t('no')),
+          },
+          actions: {
+            value: '',
+            content: () => {
+              // Filter assignments attached to this activity/flow by target subject before
+              // passing to `getActionsMenu()` so that the Unassign action only prompts user to
+              // unassign for the specific target subject.
+              const filteredActivityOrFlow = {
+                ...activityOrFlow,
+                assignments: activityOrFlow.assignments.filter(
+                  ({ targetSubject }) => targetSubject.id === subject.id,
+                ),
+              };
+
+              const tooltipTitle = teamMemberCanViewData ? '' : t('subjectDataUnavailable');
+
+              return (
+                <StyledFlexTopCenter sx={{ gap: 0.8 }}>
+                  <OptionalTooltipWrapper tooltipTitle={tooltipTitle}>
+                    {/*https://mui.com/material-ui/react-tooltip/#disabled-elements*/}
+                    <span>
+                      <Button
+                        variant="outlined"
+                        onClick={() => onClickViewData(activityOrFlow, subject)}
+                        sx={{ mr: 0.4 }}
+                        data-testid={`${dataTestId}-subject-${index}-view-data`}
+                        disabled={!teamMemberCanViewData}
+                      >
+                        <Svg id="chart" width="18" height="18" fill="currentColor" />
+                        {t('viewData')}
+                      </Button>
+                    </span>
+                  </OptionalTooltipWrapper>
+
+                  <ActionsMenu
+                    anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                    transformOrigin={{ vertical: -6, horizontal: 'right' }}
+                    buttonColor="secondary"
+                    menuItems={getActionsMenu(filteredActivityOrFlow, subject)}
+                    data-testid={`${dataTestId}-subject-${index}`}
+                  />
+                </StyledFlexTopCenter>
+              );
+            },
+          },
+        }),
+      ),
     [activityOrFlow, dataTestId, getActionsMenu, onClickViewData, t, targetSubjects],
   );
 

--- a/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ExpandedView/ExpandedView.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ExpandedView/ExpandedView.tsx
@@ -75,7 +75,11 @@ export const ExpandedView = ({
                     anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
                     transformOrigin={{ vertical: -6, horizontal: 'right' }}
                     buttonColor="secondary"
-                    menuItems={getActionsMenu(filteredActivityOrFlow, subject)}
+                    menuItems={getActionsMenu({
+                      activityOrFlow: filteredActivityOrFlow,
+                      targetSubject: subject,
+                      teamMemberCanViewData,
+                    })}
                     data-testid={`${dataTestId}-subject-${index}`}
                   />
                 </StyledFlexTopCenter>

--- a/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ExpandedView/ExpandedView.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ExpandedView/ExpandedView.tsx
@@ -53,7 +53,7 @@ export const ExpandedView = ({
               return (
                 <StyledFlexTopCenter sx={{ gap: 0.8 }}>
                   <OptionalTooltipWrapper tooltipTitle={tooltipTitle}>
-                    {/*https://mui.com/material-ui/react-tooltip/#disabled-elements*/}
+                    {/* https://mui.com/material-ui/react-tooltip/#disabled-elements */}
                     <span>
                       <Button
                         variant="outlined"

--- a/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ExpandedView/ExpandedView.types.ts
+++ b/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ExpandedView/ExpandedView.types.ts
@@ -2,13 +2,12 @@ import { ParticipantActivityOrFlow, TargetSubjectsByRespondent } from 'api';
 import { SubjectDetails } from 'modules/Dashboard/types';
 import { MenuItem } from 'shared/components';
 
+import { GetActionsMenuParams } from '../../AssignmentsTab/AssignmentsTab.types';
+
 export type ExpandedViewProps = {
   activityOrFlow: ParticipantActivityOrFlow;
   targetSubjects?: TargetSubjectsByRespondent;
-  getActionsMenu: (
-    activityOrFlow: ParticipantActivityOrFlow,
-    targetSubjectArg?: SubjectDetails,
-  ) => MenuItem<unknown>[];
+  getActionsMenu: (params: GetActionsMenuParams) => MenuItem<unknown>[];
   onClickViewData: (
     activityOrFlow: ParticipantActivityOrFlow,
     targetSubject: SubjectDetails,

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -1759,5 +1759,5 @@
   "autoAssignActivityDisabled": "This activity is set to ‘Auto-assign’ in the Activity Builder and therefore cannot be assigned here.",
   "autoAssignFlowDisabled": "This flow is set to ‘Auto-assign’ in the Activity Flow Builder and therefore cannot be assigned here.",
   "goToDashboard": "Go to Dashboard",
-  "subjectDataUnavailable": "Data for this user is unavailable as they are not assigned to you"
+  "subjectDataUnavailable": "You are not allowed to view the data for this user"
 }

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -1758,5 +1758,6 @@
   "autoAssignTooltip": "Keep this box selected to automatically assign this Activity or Flow to all new Participants. If instead you’d like to manually assign Activities or Flows to your Participants (for either Self-Reporting or Multi-Informant reporting) unselect this box. You’ll then be able to assign Activities or Flows from the Activities Tab in your Applet.",
   "autoAssignActivityDisabled": "This activity is set to ‘Auto-assign’ in the Activity Builder and therefore cannot be assigned here.",
   "autoAssignFlowDisabled": "This flow is set to ‘Auto-assign’ in the Activity Flow Builder and therefore cannot be assigned here.",
-  "goToDashboard": "Go to Dashboard"
+  "goToDashboard": "Go to Dashboard",
+  "subjectDataUnavailable": "Data for this user is unavailable as they are not assigned to you"
 }

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -1758,5 +1758,5 @@
   "autoAssignActivityDisabled": "Cette activité est paramétrée sur « Attribution automatique » dans le générateur d'activités et ne peut donc pas être attribuée ici.",
   "autoAssignFlowDisabled": "Ce flux est défini sur « Auto-assign » dans l'Activity Flow Builder et ne peut donc pas être affecté ici.",
   "goToDashboard": "Aller au tableau de bord",
-  "subjectDataUnavailable": "Les données de cet utilisateur ne sont pas disponibles car elles ne vous sont pas attribuées"
+  "subjectDataUnavailable": "Vous n'êtes pas autorisé à afficher les données de cet utilisateur"
 }

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -1757,5 +1757,6 @@
   "autoAssignTooltip": "Gardez cette case cochée pour attribuer automatiquement cette activité ou ce flux à tous les nouveaux participants. Si, à la place, vous souhaitez attribuer manuellement des activités ou des flux à vos participants (pour une déclaration automatique ou une déclaration multi-informateurs), décochez cette case. Vous pourrez ensuite attribuer des activités ou des flux à partir de l'onglet Activités de votre applet.",
   "autoAssignActivityDisabled": "Cette activité est paramétrée sur « Attribution automatique » dans le générateur d'activités et ne peut donc pas être attribuée ici.",
   "autoAssignFlowDisabled": "Ce flux est défini sur « Auto-assign » dans l'Activity Flow Builder et ne peut donc pas être affecté ici.",
-  "goToDashboard": "Aller au tableau de bord"
+  "goToDashboard": "Aller au tableau de bord",
+  "subjectDataUnavailable": "Les données de cet utilisateur ne sont pas disponibles car elles ne vous sont pas attribuées"
 }

--- a/src/shared/components/Menu/Menu.tsx
+++ b/src/shared/components/Menu/Menu.tsx
@@ -4,7 +4,7 @@ import { Box, Divider, ListItemIcon, MenuItem } from '@mui/material';
 
 import { variables } from 'shared/styles/variables';
 import { StyledBodyLarge } from 'shared/styles/styledComponents';
-import { Tooltip } from 'shared/components/Tooltip';
+import { OptionalTooltipWrapper } from 'shared/components/Tooltip';
 
 import { StyledMenu, StyledMenuItemContent } from './Menu.styles';
 import { MenuItemType, MenuProps } from './Menu.types';
@@ -69,17 +69,8 @@ export const Menu = <T = unknown,>({
             onClose();
           };
 
-          const TooltipWrapper = ({ children }: { children: JSX.Element }) =>
-            tooltip ? (
-              <Tooltip tooltipTitle={tooltip} placement="right">
-                {children}
-              </Tooltip>
-            ) : (
-              children
-            );
-
           const menuItemContent = (
-            <TooltipWrapper>
+            <OptionalTooltipWrapper tooltipTitle={tooltip} placement="right">
               <StyledMenuItemContent customItemColor={customItemColor}>
                 {icon && <ListItemIcon>{icon}</ListItemIcon>}
                 {!!title && (
@@ -92,7 +83,7 @@ export const Menu = <T = unknown,>({
                   </StyledBodyLarge>
                 )}
               </StyledMenuItemContent>
-            </TooltipWrapper>
+            </OptionalTooltipWrapper>
           );
 
           switch (type) {

--- a/src/shared/components/Tooltip/Tooltip.tsx
+++ b/src/shared/components/Tooltip/Tooltip.tsx
@@ -109,3 +109,12 @@ export const Tooltip = ({
     </StyledTooltip>
   );
 };
+
+export const OptionalTooltipWrapper = ({ children, tooltipTitle, ...props }: TooltipProps) =>
+  tooltipTitle ? (
+    <Tooltip tooltipTitle={tooltipTitle} {...props}>
+      {children}
+    </Tooltip>
+  ) : (
+    children
+  );


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-8359](https://mindlogger.atlassian.net/browse/M2-8359)

This PR consumes https://github.com/ChildMindInstitute/mindlogger-backend-refactor/pull/1702 to disable the view data button on the By Participant view expanded card of the participant detail page, according to the data returned from the API. The button is disabled when the logged in admin user doesn't have permission to view that subject's data, and a tooltip is shown explaining the disabled state.

I've also disabled the export data action menu item for each target subject in the expanded view, using the same criteria as above (based on the API data).

Finally the view data button on the About Participant screen has been conditionally disabled based on the logged-in admin user's role and whether they are allowed to view data for the participant they are viewing

### 📸 Screenshots

#### As Coordinator

<img width="640" alt="image" src="https://github.com/user-attachments/assets/849f583f-39c1-4c01-ade8-2943e3fad2b8" />

<img width="640" alt="image" src="https://github.com/user-attachments/assets/d2e14f31-4d16-433a-ad20-d1518df6158e" />

#### As Reviewer

This reviewer does not have one of these subjects assigned to them

<img width="640" alt="image" src="https://github.com/user-attachments/assets/0fd7dd2c-ee16-440c-a69e-3e6b2cf8e8a4" />

### 🪤 Peer Testing

1. Create an applet and an activity
2. Add a limited account participant
3. Add a Reviewer team member, with the applet owner assigned as a subject
4. Add a Coordinator team member
5. As applet owner, complete activity for self
6. As applet owner, take now activity for limited account

#### As Coordinator

1. Log into admin panel, switch to the shared workspace, and go to Participants tab of the applet
2. Click the applet owner
3. Confirm that the view data button is **disabled** on the About Participant tab
4. Click By Participant
5. Expand the activity card to see the two submissions
6. Confirm that the view data button is **disabled** for the limited account subject

#### As Reviewer

1. Log into admin panel, switch to the shared workspace, and go to Participants tab of the applet
2. Click the applet owner
3. Confirm that the view data button is **enabled** on the About Participant tab and navigates as expected
4. Click By Participant
5. Expand the activity card to see the two submissions
6. Confirm that the view data button is disabled for the limited account subject
7. Confirm that the view data button is **enabled** for the owner subject and navigates as expected



### ✏️ Notes

N/A
