### PR TITLE
chore: Remove managers query from ParticipantDropdown (M2-8462)

### DIFF
--- a/src/modules/Dashboard/api/api.ts
+++ b/src/modules/Dashboard/api/api.ts
@@ -93,6 +93,7 @@ import {
 } from './api.types';
 import { DEFAULT_ROWS_PER_PAGE } from './api.const';
 import { ApiSuccessResponse } from './base.types';
+import { SubjectDetailsWithRoles } from '../types';
 
 export const getUserDetailsApi = (signal?: AbortSignal) =>
   authApiClient.get('/users/me', { signal });
@@ -913,7 +914,10 @@ export const getRespondentDetailsApi = (
     signal,
   });
 
-export const getSubjectDetailsApi = ({ subjectId }: SubjectId, signal?: AbortSignal) =>
+export const getSubjectDetailsApi = (
+  { subjectId }: SubjectId,
+  signal?: AbortSignal,
+): Promise<AxiosResponse<SubjectDetailsWithRoles>> =>
   authApiClient.get(`/subjects/${subjectId}`, {
     signal,
   });

--- a/src/modules/Dashboard/api/api.types.ts
+++ b/src/modules/Dashboard/api/api.types.ts
@@ -5,7 +5,7 @@ import { RetentionPeriods, EncryptedAnswerSharedProps, ExportActivity } from 'sh
 import { Encryption } from 'shared/utils';
 import { User } from 'modules/Auth/state';
 
-import { SubjectDetails } from '../types';
+import { SubjectDetails, SubjectDetailsWithRoles } from '../types';
 
 export type GetAppletsParams = {
   params: {
@@ -727,7 +727,7 @@ export type GetTargetSubjectsByRespondentParams = SubjectId & {
 };
 
 export type TargetSubjectsByRespondent = Array<
-  SubjectDetails &
+  SubjectDetailsWithRoles &
     AppletId & {
       submissionCount: number;
       currentlyAssigned: boolean;

--- a/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityAssignDrawer.test.tsx
+++ b/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityAssignDrawer.test.tsx
@@ -64,10 +64,10 @@ const mockedGetAppletParticipants = mockSuccessfulHttpResponse<ParticipantsData>
 const mockedGetAppletManagers = mockSuccessfulHttpResponse<ManagersData>({
   result: [
     {
-      id: mockedOwnerParticipant.id,
+      id: mockedOwnerParticipant.id!,
       firstName: mockedUserData.firstName,
       lastName: mockedUserData.lastName,
-      email: mockedOwnerParticipant.email,
+      email: mockedOwnerParticipant.email!,
       roles: [Roles.Owner],
       lastSeen: new Date().toDateString(),
       isPinned: mockedOwnerParticipant.isPinned,

--- a/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityAssignDrawer.test.tsx
+++ b/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityAssignDrawer.test.tsx
@@ -64,10 +64,10 @@ const mockedGetAppletParticipants = mockSuccessfulHttpResponse<ParticipantsData>
 const mockedGetAppletManagers = mockSuccessfulHttpResponse<ManagersData>({
   result: [
     {
-      id: mockedOwnerParticipant.id!,
+      id: mockedOwnerParticipant.id as string,
       firstName: mockedUserData.firstName,
       lastName: mockedUserData.lastName,
-      email: mockedOwnerParticipant.email!,
+      email: mockedOwnerParticipant.email as string,
       roles: [Roles.Owner],
       lastSeen: new Date().toDateString(),
       isPinned: mockedOwnerParticipant.isPinned,

--- a/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityReview/ActivityReview.test.tsx
+++ b/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityReview/ActivityReview.test.tsx
@@ -7,17 +7,17 @@ import {
   mockedAppletId,
   mockedCurrentWorkspace,
   mockedEncryption,
-  mockedLimitedParticipant,
-  mockedOwnerId,
   mockedFullParticipant1,
   mockedFullParticipant2,
+  mockedLimitedParticipant,
+  mockedOwnerId,
   mockedUserData,
 } from 'shared/mock';
 import { useParticipantDropdown } from 'modules/Dashboard/components';
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
 import { mockGetRequestResponses, mockSuccessfulHttpResponse } from 'shared/utils/axios-mocks';
 import { ParticipantTag, Roles } from 'shared/consts';
-import { ParticipantStatus } from 'modules/Dashboard/types';
+import { Participant, ParticipantStatus } from 'modules/Dashboard/types';
 import { ParticipantsData } from 'modules/Dashboard/features/Participants';
 import { ManagersData } from 'modules/Dashboard/features';
 
@@ -36,15 +36,13 @@ const mockAssignments = [
   },
 ];
 
-const mockedOwnerRespondent = {
+const mockedOwnerRespondent: Participant = {
   id: mockedUserData.id,
   nicknames: [`${mockedUserData.firstName} ${mockedUserData.lastName}`],
   secretIds: ['mockedOwnerSecretId'],
   isAnonymousRespondent: false,
   lastSeen: new Date().toDateString(),
   isPinned: false,
-  accessId: '912e17b8-195f-4685-b77b-137539b9054d',
-  role: Roles.Owner,
   details: [
     {
       appletId: mockedAppletId,
@@ -61,6 +59,7 @@ const mockedOwnerRespondent = {
       subjectLastName: 'Doe',
       subjectCreatedAt: '2023-09-26T12:11:46.162083',
       invitation: null,
+      roles: [Roles.Owner, Roles.Respondent],
     },
   ],
   status: ParticipantStatus.Invited,
@@ -80,10 +79,10 @@ const mockedGetAppletParticipants = mockSuccessfulHttpResponse<ParticipantsData>
 const mockedGetAppletManagers = mockSuccessfulHttpResponse<ManagersData>({
   result: [
     {
-      id: mockedOwnerRespondent.id,
+      id: mockedOwnerRespondent.id!,
       firstName: mockedUserData.firstName,
       lastName: mockedUserData.lastName,
-      email: mockedOwnerRespondent.email,
+      email: mockedOwnerRespondent.email!,
       roles: [Roles.Owner],
       lastSeen: new Date().toDateString(),
       isPinned: mockedOwnerRespondent.isPinned,

--- a/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityReview/ActivityReview.test.tsx
+++ b/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityReview/ActivityReview.test.tsx
@@ -79,10 +79,10 @@ const mockedGetAppletParticipants = mockSuccessfulHttpResponse<ParticipantsData>
 const mockedGetAppletManagers = mockSuccessfulHttpResponse<ManagersData>({
   result: [
     {
-      id: mockedOwnerRespondent.id!,
+      id: mockedOwnerRespondent.id as string,
       firstName: mockedUserData.firstName,
       lastName: mockedUserData.lastName,
-      email: mockedOwnerRespondent.email!,
+      email: mockedOwnerRespondent.email as string,
       roles: [Roles.Owner],
       lastSeen: new Date().toDateString(),
       isPinned: mockedOwnerRespondent.isPinned,

--- a/src/modules/Dashboard/components/ActivityAssignDrawer/AssignmentsTable/AssignmentsTable.test.tsx
+++ b/src/modules/Dashboard/components/ActivityAssignDrawer/AssignmentsTable/AssignmentsTable.test.tsx
@@ -67,10 +67,10 @@ const mockedGetAppletParticipants = mockSuccessfulHttpResponse<ParticipantsData>
 const mockedGetAppletManagers = mockSuccessfulHttpResponse<ManagersData>({
   result: [
     {
-      id: mockedOwnerParticipant.id,
+      id: mockedOwnerParticipant.id!,
       firstName: mockedUserData.firstName,
       lastName: mockedUserData.lastName,
-      email: mockedOwnerParticipant.email,
+      email: mockedOwnerParticipant.email!,
       roles: [Roles.Owner],
       lastSeen: new Date().toDateString(),
       isPinned: mockedOwnerParticipant.isPinned,

--- a/src/modules/Dashboard/components/ActivityAssignDrawer/AssignmentsTable/AssignmentsTable.test.tsx
+++ b/src/modules/Dashboard/components/ActivityAssignDrawer/AssignmentsTable/AssignmentsTable.test.tsx
@@ -67,10 +67,10 @@ const mockedGetAppletParticipants = mockSuccessfulHttpResponse<ParticipantsData>
 const mockedGetAppletManagers = mockSuccessfulHttpResponse<ManagersData>({
   result: [
     {
-      id: mockedOwnerParticipant.id!,
+      id: mockedOwnerParticipant.id as string,
       firstName: mockedUserData.firstName,
       lastName: mockedUserData.lastName,
-      email: mockedOwnerParticipant.email!,
+      email: mockedOwnerParticipant.email as string,
       roles: [Roles.Owner],
       lastSeen: new Date().toDateString(),
       isPinned: mockedOwnerParticipant.isPinned,

--- a/src/modules/Dashboard/components/ActivityAssignDrawer/AssignmentsTable/AssignmentsTable.tsx
+++ b/src/modules/Dashboard/components/ActivityAssignDrawer/AssignmentsTable/AssignmentsTable.tsx
@@ -4,8 +4,8 @@ import { Box, Button } from '@mui/material';
 
 import {
   DashboardTableProps,
-  FullTeamSearchType,
   ParticipantDropdownOption,
+  SearchResultUserTypes,
 } from 'modules/Dashboard/components';
 import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 import { Svg } from 'shared/components';
@@ -75,9 +75,9 @@ export const AssignmentsTable = ({
 
   const handleRespondentSearch = useCallback(
     async (query: string) => {
-      const participantSearchTypes: [FullTeamSearchType, ...FullTeamSearchType[]] = ['team'];
+      const participantSearchTypes: SearchResultUserTypes = { team: true };
       if (enableParticipantMultiInformant) {
-        participantSearchTypes.push('full-participant');
+        participantSearchTypes.fullParticipant = true;
       }
 
       return handleSearch(query, participantSearchTypes);
@@ -87,7 +87,10 @@ export const AssignmentsTable = ({
 
   const handleSubjectSearch = useCallback(
     async (query: string, selfOption: ParticipantDropdownOption | null) => {
-      const results = await handleSearch(query, ['any-participant']);
+      const results = await handleSearch(query, {
+        fullParticipant: true,
+        limitedParticipant: true,
+      });
 
       if (selfOption) {
         // Filter out self option from search results as it's already included by the base options.

--- a/src/modules/Dashboard/components/FlowGrid/FlowGrid.hooks.tsx
+++ b/src/modules/Dashboard/components/FlowGrid/FlowGrid.hooks.tsx
@@ -115,6 +115,7 @@ export function useFlowGridMenu({
                     secretId: subject.secretUserId,
                     userId: subject.userId,
                     isTeamMember: subject.tag === 'Team',
+                    roles: subject.roles,
                   },
                 }
               : undefined;

--- a/src/modules/Dashboard/components/FlowGrid/FlowGrid.types.ts
+++ b/src/modules/Dashboard/components/FlowGrid/FlowGrid.types.ts
@@ -1,13 +1,13 @@
 import { BoxProps } from '@mui/material';
 
-import { SubjectDetails } from 'modules/Dashboard/types';
+import { SubjectDetailsWithRoles } from 'modules/Dashboard/types';
 import { Activity, ActivityFlow, SingleApplet } from 'redux/modules';
 
 export interface FlowGridProps extends BoxProps {
   applet?: SingleApplet;
   flows?: ActivityFlow[];
   activities?: Activity[];
-  subject?: SubjectDetails;
+  subject?: SubjectDetailsWithRoles;
   onClickAssign: (flowId: string) => void;
   onClickUnassign?: (flowId: string) => void;
   onClickItem?: (props: { activityFlowId: string }) => void;
@@ -18,7 +18,7 @@ export type UseFlowGridMenuProps = {
   appletId?: string;
   hasParticipants?: boolean;
   testId: string;
-  subject?: SubjectDetails;
+  subject?: SubjectDetailsWithRoles;
   onClickExportData: (flowId: string) => void;
   onClickAssign: (flowId: string) => void;
   onClickUnassign?: (flowId: string) => void;

--- a/src/modules/Dashboard/components/ParticipantDropdown/ParticipantDropdown.test.tsx
+++ b/src/modules/Dashboard/components/ParticipantDropdown/ParticipantDropdown.test.tsx
@@ -79,6 +79,6 @@ describe('ParticipantDropdown', () => {
       />,
     );
 
-    expect(queryByDisplayValue(testValue.secretId!)).toBeInTheDocument();
+    expect(queryByDisplayValue(testValue.secretId as string)).toBeInTheDocument();
   });
 });

--- a/src/modules/Dashboard/components/ParticipantDropdown/ParticipantDropdown.test.tsx
+++ b/src/modules/Dashboard/components/ParticipantDropdown/ParticipantDropdown.test.tsx
@@ -2,6 +2,7 @@ import { renderWithProviders } from 'shared/utils/renderWithProviders';
 import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 
 import { ParticipantDropdown } from './ParticipantDropdown';
+import { ParticipantDropdownOption } from './ParticipantDropdown.types';
 
 jest.mock('shared/hooks/useFeatureFlags');
 
@@ -35,11 +36,12 @@ describe('ParticipantDropdown', () => {
   });
 
   test('Uses value if provided', () => {
-    const testValue = {
+    const testValue: ParticipantDropdownOption = {
       id: 'id',
       nickname: 'nickname',
       secretId: 'secretId',
       isTeamMember: false,
+      roles: [],
     };
 
     const { queryByDisplayValue } = renderWithProviders(
@@ -59,10 +61,11 @@ describe('ParticipantDropdown', () => {
   });
 
   test('Renders value correctly without nickname', () => {
-    const testValue = {
+    const testValue: ParticipantDropdownOption = {
       id: 'id',
       secretId: 'secretId',
       isTeamMember: false,
+      roles: [],
     };
 
     const { queryByDisplayValue } = renderWithProviders(
@@ -76,6 +79,6 @@ describe('ParticipantDropdown', () => {
       />,
     );
 
-    expect(queryByDisplayValue(testValue.secretId)).toBeInTheDocument();
+    expect(queryByDisplayValue(testValue.secretId!)).toBeInTheDocument();
   });
 });

--- a/src/modules/Dashboard/components/ParticipantDropdown/ParticipantDropdown.types.ts
+++ b/src/modules/Dashboard/components/ParticipantDropdown/ParticipantDropdown.types.ts
@@ -3,6 +3,8 @@ import { AxiosError, AxiosResponse } from 'axios';
 
 import { ParticipantSnippetInfo } from 'modules/Dashboard/components/ParticipantSnippet';
 import { ApiErrorResponse } from 'redux/modules';
+import { AtLeastOne } from 'shared/types';
+import { Roles } from 'shared/consts';
 
 export enum ParticipantDropdownVariant {
   Outlined = 'outlined',
@@ -14,6 +16,7 @@ export type ParticipantDropdownOption = ParticipantSnippetInfo & {
   id: string;
   userId?: string | null;
   isTeamMember: boolean;
+  roles: Roles[];
 };
 
 export type ParticipantDropdownProps = Omit<
@@ -36,8 +39,13 @@ export type ParticipantDropdownProps = Omit<
   variant?: ParticipantDropdownVariant;
 };
 
-export type AnyTeamSearchType = 'team' | 'any-participant';
-export type FullTeamSearchType = 'team' | 'full-participant';
+export type SearchResultUserTypes = AtLeastOne<{
+  team?: boolean;
+  fullParticipant?: boolean;
+  limitedParticipant?: boolean;
+  pendingInvitedParticipant?: boolean;
+  anonymousParticipant?: boolean;
+}>;
 
 export type UseParticipantDropdownProps = {
   appletId?: string;

--- a/src/modules/Dashboard/components/ParticipantDropdown/ParticipantDropdown.utils.ts
+++ b/src/modules/Dashboard/components/ParticipantDropdown/ParticipantDropdown.utils.ts
@@ -1,6 +1,7 @@
 import { Participant } from 'modules/Dashboard/types';
 import { joinWihComma } from 'shared/utils';
 import i18n from 'i18n';
+import { TEAM_MEMBER_ROLES } from 'shared/consts';
 
 import { ParticipantDropdownOption } from './ParticipantDropdown.types';
 
@@ -14,7 +15,8 @@ export const participantToOption = (participant: Participant): ParticipantDropdo
     secretId: stringSecretIds,
     nickname: stringNicknames,
     tag: participant.details[0].subjectTag,
-    isTeamMember: !!participant.id && participant.details[0].subjectTag === 'Team',
+    isTeamMember: participant.details[0].roles.some((role) => TEAM_MEMBER_ROLES.includes(role)),
+    roles: participant.details[0].roles,
   };
 };
 

--- a/src/modules/Dashboard/components/TakeNowModal/TakeNowDropdown.test.tsx
+++ b/src/modules/Dashboard/components/TakeNowModal/TakeNowDropdown.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
 import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 import { ParticipantDropdownOption } from 'modules/Dashboard/components';
+import { Roles } from 'shared/consts';
 
 import { TakeNowDropdown } from './TakeNowDropdown';
 
@@ -78,11 +79,12 @@ describe('TakeNowDropdown', () => {
   });
 
   test('Uses value if provided', () => {
-    const testValue = {
+    const testValue: ParticipantDropdownOption = {
       id: 'id',
       nickname: 'nickname',
       secretId: 'secretId',
       isTeamMember: false,
+      roles: [],
     };
 
     const { queryByDisplayValue } = renderWithProviders(
@@ -104,10 +106,11 @@ describe('TakeNowDropdown', () => {
   });
 
   test('Renders value correctly without nickname', () => {
-    const testValue = {
+    const testValue: ParticipantDropdownOption = {
       id: 'id',
       secretId: 'secretId',
       isTeamMember: false,
+      roles: [],
     };
 
     const { queryByDisplayValue } = renderWithProviders(
@@ -123,7 +126,7 @@ describe('TakeNowDropdown', () => {
       />,
     );
 
-    expect(queryByDisplayValue(testValue.secretId)).toBeInTheDocument();
+    expect(queryByDisplayValue(testValue.secretId!)).toBeInTheDocument();
   });
 
   test('Does not show warning message when the value is not present', () => {
@@ -150,6 +153,7 @@ describe('TakeNowDropdown', () => {
       userId: 'user-id',
       tag: 'Team',
       isTeamMember: true,
+      roles: [Roles.Owner, Roles.Respondent],
     };
 
     const { queryByTestId } = renderWithProviders(
@@ -175,6 +179,7 @@ describe('TakeNowDropdown', () => {
       userId: 'user-id',
       tag: 'Teacher',
       isTeamMember: false,
+      roles: [Roles.Respondent],
     };
 
     const { queryByTestId } = renderWithProviders(
@@ -199,6 +204,7 @@ describe('TakeNowDropdown', () => {
       id: 'subject-id',
       tag: 'Child',
       isTeamMember: false,
+      roles: [],
     };
 
     const { queryByTestId } = renderWithProviders(
@@ -223,6 +229,7 @@ describe('TakeNowDropdown', () => {
       id: 'subject-id',
       tag: 'Child',
       isTeamMember: false,
+      roles: [],
     };
 
     const { queryByTestId } = renderWithProviders(
@@ -258,6 +265,7 @@ describe('TakeNowDropdown', () => {
         userId: 'user-id',
         tag: 'Team',
         isTeamMember: true,
+        roles: [Roles.Owner, Roles.Respondent],
       };
 
       const { queryByTestId } = renderWithProviders(
@@ -283,6 +291,7 @@ describe('TakeNowDropdown', () => {
         userId: 'user-id',
         tag: 'Teacher',
         isTeamMember: false,
+        roles: [Roles.Respondent],
       };
 
       const { queryByTestId } = renderWithProviders(
@@ -307,6 +316,7 @@ describe('TakeNowDropdown', () => {
         id: 'subject-id',
         tag: 'Child',
         isTeamMember: false,
+        roles: [],
       };
 
       const { queryByTestId } = renderWithProviders(
@@ -331,6 +341,7 @@ describe('TakeNowDropdown', () => {
         id: 'subject-id',
         tag: 'Child',
         isTeamMember: false,
+        roles: [],
       };
 
       const { queryByTestId } = renderWithProviders(

--- a/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.tsx
+++ b/src/modules/Dashboard/components/TakeNowModal/TakeNowModal.tsx
@@ -42,8 +42,8 @@ import { HydratedActivityFlow } from 'modules/Dashboard/types';
 import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 import {
   ActivityFlowThumbnail,
-  FullTeamSearchType,
   ParticipantDropdownOption,
+  SearchResultUserTypes,
   useParticipantDropdown,
 } from 'modules/Dashboard/components';
 
@@ -402,7 +402,13 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
                     setIsSelfReporting(selfReportingCondition);
                   }}
                   data-testid={`${dataTestId}-take-now-modal-source-subject-dropdown`}
-                  handleSearch={(query) => handleSearch(query, ['team', 'any-participant'])}
+                  handleSearch={(query) =>
+                    handleSearch(query, {
+                      team: true,
+                      fullParticipant: true,
+                      limitedParticipant: true,
+                    })
+                  }
                   canShowWarningMessage={true}
                   showGroups
                 />
@@ -454,11 +460,11 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
                   }}
                   data-testid={`${dataTestId}-take-now-modal-logged-in-user-dropdown`}
                   handleSearch={(query) => {
-                    const participantSearchTypes: [FullTeamSearchType, ...FullTeamSearchType[]] = [
-                      'team',
-                    ];
+                    const participantSearchTypes: SearchResultUserTypes = {
+                      team: true,
+                    };
                     if (enableParticipantMultiInformant) {
-                      participantSearchTypes.push('full-participant');
+                      participantSearchTypes.fullParticipant = true;
                     }
 
                     return handleSearch(query, participantSearchTypes);
@@ -484,7 +490,9 @@ export const useTakeNowModal = ({ dataTestId }: UseTakeNowModalProps) => {
                 setTargetSubject(option);
               }}
               data-testid={`${dataTestId}-take-now-modal-target-subject-dropdown`}
-              handleSearch={(query) => handleSearch(query, ['team', 'any-participant'])}
+              handleSearch={(query) =>
+                handleSearch(query, { team: true, fullParticipant: true, limitedParticipant: true })
+              }
             />
             <SubjectRelationError />
           </StyledFlexColumn>

--- a/src/modules/Dashboard/features/Participant/Activities/Activities.tsx
+++ b/src/modules/Dashboard/features/Participant/Activities/Activities.tsx
@@ -191,6 +191,7 @@ export const Activities = () => {
                   nickname: subject.result.nickname,
                   tag: subject.result.tag,
                   isTeamMember: subject.result.tag === 'Team',
+                  roles: subject.result.roles,
                 };
               }
 

--- a/src/modules/Dashboard/features/Participant/Activities/Activities.tsx
+++ b/src/modules/Dashboard/features/Participant/Activities/Activities.tsx
@@ -27,6 +27,7 @@ import { workspaces } from 'shared/state';
 import { checkIfCanAccessData, Mixpanel, MixpanelEventType, MixpanelProps } from 'shared/utils';
 import { ActivityAssignDrawer, ActivityUnassignDrawer } from 'modules/Dashboard/components';
 import { hydrateActivityFlows } from 'modules/Dashboard/utils';
+import { TEAM_MEMBER_ROLES } from 'shared/consts';
 
 import { ActivityOrFlowId } from './Activities.types';
 import { UnlockAppletPopup } from '../../Respondents/Popups/UnlockAppletPopup';
@@ -190,7 +191,9 @@ export const Activities = () => {
                   secretId: subject.result.secretUserId,
                   nickname: subject.result.nickname,
                   tag: subject.result.tag,
-                  isTeamMember: subject.result.tag === 'Team',
+                  isTeamMember: subject.result.roles.some((role) =>
+                    TEAM_MEMBER_ROLES.includes(role),
+                  ),
                   roles: subject.result.roles,
                 };
               }

--- a/src/modules/Dashboard/features/Participant/Assignments/AssignmentsTab/AssignmentsTab.hooks.test.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/AssignmentsTab/AssignmentsTab.hooks.test.tsx
@@ -38,7 +38,6 @@ import {
   targetSubjectDropdownTestId,
 } from 'modules/Dashboard/components/TakeNowModal/TakeNowModal.test-utils';
 import { ActionsMenu } from 'shared/components';
-import { SubjectDetails } from 'modules/Dashboard/types';
 import { EditablePerformanceTasksType } from 'modules/Builder/features/Activities/Activities.types';
 import { getPerformanceTaskPath } from 'modules/Builder/features/Activities/Activities.utils';
 import {
@@ -48,6 +47,7 @@ import {
   StartAssignActivityOrFlowEvent,
   StartUnassignActivityOrFlowEvent,
 } from 'shared/utils';
+import { SubjectDetailsWithRoles } from 'modules/Dashboard/types';
 
 import { useAssignmentsTab } from './AssignmentsTab.hooks';
 
@@ -130,8 +130,8 @@ const spyMixpanelTrack = jest.spyOn(Mixpanel, 'track');
 
 type UseAssignmentsHookTestProps = {
   activityOrFlow: ParticipantActivityOrFlow;
-  targetSubject?: SubjectDetails;
-  respondentSubject?: SubjectDetails;
+  targetSubject?: SubjectDetailsWithRoles;
+  respondentSubject?: SubjectDetailsWithRoles;
 };
 
 const UseAssignmentsHookTest = ({

--- a/src/modules/Dashboard/features/Participant/Assignments/AssignmentsTab/AssignmentsTab.types.ts
+++ b/src/modules/Dashboard/features/Participant/Assignments/AssignmentsTab/AssignmentsTab.types.ts
@@ -1,6 +1,6 @@
 import { PropsWithChildren } from 'react';
 
-import { SubjectDetails } from 'modules/Dashboard/types';
+import { SubjectDetailsWithRoles } from 'modules/Dashboard/types';
 import { ParticipantActivityOrFlow } from 'modules/Dashboard/api';
 
 export type AssignmentsTabProps = PropsWithChildren<{
@@ -11,14 +11,14 @@ export type AssignmentsTabProps = PropsWithChildren<{
 
 export type UseAssignmentsTabProps = {
   appletId?: string;
-  targetSubject?: SubjectDetails;
-  respondentSubject?: SubjectDetails;
+  targetSubject?: SubjectDetailsWithRoles;
+  respondentSubject?: SubjectDetailsWithRoles;
   handleRefetch?: () => void;
   dataTestId: string;
 };
 
 export type GetActionsMenuParams = {
   activityOrFlow: ParticipantActivityOrFlow;
-  targetSubject?: SubjectDetails;
+  targetSubject?: SubjectDetailsWithRoles;
   teamMemberCanViewData?: boolean;
 };

--- a/src/modules/Dashboard/features/Participants/Participants.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.tsx
@@ -17,13 +17,12 @@ import {
   checkIfCanManageParticipants,
   checkIfCanViewParticipants,
   getDateInUserTimezone,
-  isManagerOrOwner,
   joinWihComma,
   Mixpanel,
   MixpanelProps,
   MixpanelEventType,
 } from 'shared/utils';
-import { DEFAULT_ROWS_PER_PAGE, Roles } from 'shared/consts';
+import { DEFAULT_ROWS_PER_PAGE } from 'shared/consts';
 import { StyledBody, StyledFlexWrap, StyledMaybeEmpty } from 'shared/styles';
 import { Participant, ParticipantStatus } from 'modules/Dashboard/types';
 import { AddParticipantPopup, UpgradeAccountPopup } from 'modules/Dashboard/features/Applet/Popups';
@@ -445,18 +444,14 @@ export const Participants = () => {
 
     for (const detail of details) {
       const appletRoles = rolesData?.data?.[detail.appletId];
-      if (isManagerOrOwner(appletRoles?.[0])) {
+      if (!appletRoles) continue;
+      if (checkIfCanManageParticipants([appletRoles[0]])) {
         editable.push(detail);
-        viewable.push(detail);
         scheduling.push(detail);
-        continue;
       }
-      if (appletRoles?.includes(Roles.Reviewer)) {
+
+      if (checkIfCanViewParticipants(appletRoles)) {
         viewable.push(detail);
-      }
-      if (appletRoles?.includes(Roles.Coordinator)) {
-        scheduling.push(detail);
-        editable.push(detail);
       }
     }
 

--- a/src/modules/Dashboard/features/Participants/Participants.utils.test.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.utils.test.tsx
@@ -30,6 +30,7 @@ describe('Participants utils tests', () => {
         subjectLastName: 'Doe',
         subjectCreatedAt: '2021-10-01T00:00:00.000Z',
         invitation: null,
+        roles: [],
       },
       {
         appletId: 'b7db8ff7-6d0b-40fd-8dfc-93f96e7ad788',
@@ -44,6 +45,7 @@ describe('Participants utils tests', () => {
         subjectLastName: 'Doe',
         subjectCreatedAt: '2021-10-01T00:00:00.000Z',
         invitation: null,
+        roles: [],
       },
     ];
 

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataHeader/RespondentDataHeader.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataHeader/RespondentDataHeader.test.tsx
@@ -8,12 +8,13 @@ import {
   mockedFullParticipantId1,
   mockedActivityId,
   mockedFullSubjectId1,
+  mockedFullParticipant1Details,
 } from 'shared/mock';
 import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 import { Roles } from 'shared/consts';
 import { getPreloadedState } from 'shared/tests/getPreloadedState';
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
-import { SubjectDetails } from 'modules/Dashboard/types';
+import { SubjectDetailsWithRoles } from 'modules/Dashboard/types';
 import * as MixpanelFunc from 'shared/utils/mixpanel';
 import { MixpanelEventType, MixpanelProps } from 'shared/utils/mixpanel';
 
@@ -36,7 +37,7 @@ jest.mock('shared/hooks/useFeatureFlags', () => ({
 
 const mockUseFeatureFlags = jest.mocked(useFeatureFlags);
 
-const mockedSubject: SubjectDetails = {
+const mockedSubject: SubjectDetailsWithRoles = {
   nickname: mockedFullParticipant1.nicknames[0],
   secretUserId: mockedFullParticipant1.secretIds[0],
   userId: mockedFullParticipantId1,
@@ -44,6 +45,7 @@ const mockedSubject: SubjectDetails = {
   id: mockedFullSubjectId1,
   firstName: 'John',
   lastName: 'Doe',
+  roles: mockedFullParticipant1Details.roles,
 };
 
 const mockedActivity = {

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataHeader/RespondentDataHeader.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataHeader/RespondentDataHeader.tsx
@@ -30,7 +30,7 @@ import { page } from 'resources';
 import { palette } from 'shared/styles/variables/palette';
 import { hasPermissionToViewData } from 'modules/Dashboard/pages/RespondentData/RespondentData.utils';
 import { NavigationEyebrow } from 'shared/components/NavigationEyebrow';
-import { ItemResponseType } from 'shared/consts';
+import { ItemResponseType, TEAM_MEMBER_ROLES } from 'shared/consts';
 import { ActivityFlowThumbnail, ActivityAssignDrawer } from 'modules/Dashboard/components';
 
 import { RespondentDataHeaderProps } from './RespondentDataHeader.types';
@@ -86,7 +86,7 @@ export const RespondentDataHeader = ({
         userId: subject.userId,
         secretId: subject.secretUserId,
         nickname: subject.nickname,
-        isTeamMember: subject.tag === 'Team',
+        isTeamMember: subject.roles.some((role) => TEAM_MEMBER_ROLES.includes(role)),
         roles: subject.roles,
       },
     });

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataHeader/RespondentDataHeader.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataHeader/RespondentDataHeader.tsx
@@ -87,6 +87,7 @@ export const RespondentDataHeader = ({
         secretId: subject.secretUserId,
         nickname: subject.nickname,
         isTeamMember: subject.tag === 'Team',
+        roles: subject.roles,
       },
     });
   };

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataHeader/RespondentDataHeader.types.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataHeader/RespondentDataHeader.types.ts
@@ -1,10 +1,12 @@
-import { HydratedActivityFlow } from 'modules/Dashboard/types/Dashboard.types';
-import { SubjectDetails } from 'modules/Dashboard/types';
+import {
+  HydratedActivityFlow,
+  SubjectDetailsWithRoles,
+} from 'modules/Dashboard/types/Dashboard.types';
 import { Activity, SingleApplet } from 'redux/modules';
 
 export interface RespondentDataHeaderProps {
   applet: SingleApplet;
-  subject: SubjectDetails;
+  subject: SubjectDetailsWithRoles;
   activityOrFlow?: Activity | HydratedActivityFlow;
   dataTestid: string;
 }

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { endOfMonth, format, startOfMonth } from 'date-fns';
 import mockAxios from 'jest-mock-axios';
 import { FormProvider, useForm } from 'react-hook-form';
+import { PreloadedState } from '@reduxjs/toolkit';
 
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
 import {
@@ -17,6 +18,7 @@ import { DateFormats, Roles, JEST_TEST_TIMEOUT, MAX_LIMIT, ParticipantTag } from
 import { initialStateData } from 'shared/state';
 import { page } from 'resources';
 import * as dashboardHooks from 'modules/Dashboard/hooks';
+import { RootState } from 'redux/store';
 
 import { RespondentDataReview } from './RespondentDataReview';
 
@@ -27,7 +29,7 @@ const route1 = `/dashboard/${mockedAppletId}/participants/${mockedFullSubjectId1
 const route2 = `/dashboard/${mockedAppletId}/participants/${mockedFullSubjectId1}/dataviz/responses?selectedDate=2023-12-15&answerId=answer-id-2-2&isFeedbackVisible=true`;
 const routeWithoutSelectedDate = `/dashboard/${mockedAppletId}/participants/${mockedFullSubjectId1}/dataviz/responses`;
 const routePath = page.appletParticipantDataReview;
-const preloadedState = {
+const preloadedState: PreloadedState<RootState> = {
   workspaces: {
     workspaces: initialStateData,
     currentWorkspace: {
@@ -40,7 +42,6 @@ const preloadedState = {
         [mockedAppletId]: [Roles.Manager],
       },
     },
-    applet: mockedApplet,
     workspacesRoles: initialStateData,
   },
   applet: {
@@ -69,6 +70,7 @@ const preloadedState = {
           userId: mockedFullSubjectId1,
           firstName: 'John',
           lastName: 'Doe',
+          roles: [Roles.Respondent],
         },
       },
     },

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.hooks.test.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.hooks.test.ts
@@ -3,6 +3,8 @@ import * as routerDom from 'react-router-dom';
 import { renderHookWithProviders } from 'shared/utils/renderHookWithProviders';
 import { users } from 'redux/modules';
 import { getRespondentName } from 'shared/utils';
+import { SubjectDetailsWithRoles } from 'modules/Dashboard/types';
+import { Roles } from 'shared/consts';
 
 import { useResponsesSummary } from './ResponsesSummary.hooks';
 
@@ -19,7 +21,7 @@ describe('useResponsesSummary', () => {
 
   test('should return a correct array with review description objects', () => {
     jest.spyOn(routerDom, 'useParams').mockReturnValue({ respondentId: '123' });
-    const res = {
+    const res: SubjectDetailsWithRoles = {
       secretUserId: 'secret123',
       nickname: 'John Doe',
       firstName: 'John',
@@ -27,6 +29,7 @@ describe('useResponsesSummary', () => {
       id: '123',
       lastSeen: '2024-04-10T10:00:00',
       userId: '123',
+      roles: [Roles.Respondent],
     };
 
     users.useRespondent = jest.fn().mockReturnValue({ result: res });

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ResponsesSummary/ResponsesSummary.test.tsx
@@ -1,7 +1,9 @@
 import { screen } from '@testing-library/react';
 
+import { SubjectDetailsWithRoles } from 'modules/Dashboard/types';
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
 import { getRespondentName } from 'shared/utils';
+import { Roles } from 'shared/consts';
 
 import { ResponsesSummary } from './ResponsesSummary';
 import { ResponsesSummaryProps } from './ResponsesSummary.types';
@@ -10,7 +12,7 @@ import { EMPTY_IDENTIFIER } from './ResponsesSummary.const';
 const dataTestId = 'review';
 const mockedIdentifier = 'ident-1';
 const mockedVersion = 'version-111.0.25';
-const sourceSubject = {
+const sourceSubject: SubjectDetailsWithRoles = {
   secretUserId: 'secret123',
   nickname: 'John Doe',
   firstName: 'John',
@@ -18,6 +20,7 @@ const sourceSubject = {
   id: '123',
   lastSeen: '2024-04-10T10:00:00',
   userId: '123',
+  roles: [Roles.Respondent],
 };
 const renderComponent = (props?: Partial<ResponsesSummaryProps>) =>
   renderWithProviders(

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewMenu/ReviewMenu.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewMenu/ReviewMenu.test.tsx
@@ -1,11 +1,11 @@
 import { useForm } from 'react-hook-form';
 import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { PreloadedState } from '@reduxjs/toolkit';
 
 import { page } from 'resources';
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
 import {
-  mockedApplet,
   mockedAppletId,
   mockedCurrentWorkspace,
   mockedFullParticipant1,
@@ -14,6 +14,7 @@ import {
 } from 'shared/mock';
 import { ParticipantTag, Roles } from 'shared/consts';
 import { initialStateData } from 'shared/state';
+import { RootState } from 'redux/store';
 
 import { RespondentsDataFormValues } from '../../RespondentData.types';
 import { ReviewMenu } from './ReviewMenu';
@@ -22,7 +23,7 @@ import { ReviewMenuProps } from './ReviewMenu.types';
 const mockedAnswerId = '0a7bcd14-24a3-48ed-8d6b-b059a6541ae4';
 const route = `/dashboard/${mockedAppletId}/participants/${mockedFullSubjectId1}/dataviz/responses?selectedDate=2023-12-05&answerId=${mockedAnswerId}`;
 const routePath = page.appletParticipantDataReview;
-const preloadedState = {
+const preloadedState: PreloadedState<RootState> = {
   workspaces: {
     workspaces: initialStateData,
     currentWorkspace: {
@@ -35,7 +36,6 @@ const preloadedState = {
         [mockedAppletId]: [Roles.Manager],
       },
     },
-    applet: mockedApplet,
     workspacesRoles: initialStateData,
   },
   users: {
@@ -61,6 +61,7 @@ const preloadedState = {
           userId: null,
           firstName: 'John',
           lastName: 'Doe',
+          roles: [],
         },
       },
     },

--- a/src/modules/Dashboard/features/Respondents/Respondents.utils.test.tsx
+++ b/src/modules/Dashboard/features/Respondents/Respondents.utils.test.tsx
@@ -4,8 +4,9 @@ import { variables } from 'shared/styles';
 import { ParticipantTag } from 'shared/consts';
 
 import { getRespondentActions, getHeadCells } from './Respondents.utils';
+import { ParticipantDetail } from '../../types';
 
-const applets = [
+const applets: ParticipantDetail[] = [
   {
     appletId: 'fbc90304-3fc9-4a71-a85f-aa7944278107',
     appletDisplayName: 'Applet 1',
@@ -19,6 +20,7 @@ const applets = [
     subjectLastName: 'Doe',
     subjectCreatedAt: '2023-09-26T12:11:46.162083',
     invitation: null,
+    roles: [],
   },
   {
     appletId: 'b7db8ff7-6d0b-40fd-8dfc-93f96e7ad788',
@@ -33,6 +35,7 @@ const applets = [
     subjectLastName: 'Doe',
     subjectCreatedAt: '2023-09-26T12:11:46.162083',
     invitation: null,
+    roles: [],
   },
 ];
 

--- a/src/modules/Dashboard/state/Users/Users.schema.ts
+++ b/src/modules/Dashboard/state/Users/Users.schema.ts
@@ -1,8 +1,8 @@
 import { BaseSchema } from 'shared/state/Base';
-import { Participant, SubjectDetails } from 'modules/Dashboard/types';
+import { Participant, SubjectDetails, SubjectDetailsWithRoles } from 'modules/Dashboard/types';
 
 export type UsersSchema = {
   allRespondents: BaseSchema<{ result: Participant[]; count: number } | null>;
   respondentDetails: BaseSchema<{ result: SubjectDetails } | null>;
-  subjectDetails: BaseSchema<{ result: SubjectDetails } | null>;
+  subjectDetails: BaseSchema<{ result: SubjectDetailsWithRoles } | null>;
 };

--- a/src/modules/Dashboard/types/Dashboard.types.ts
+++ b/src/modules/Dashboard/types/Dashboard.types.ts
@@ -44,6 +44,7 @@ export type ParticipantDetail = {
   subjectFirstName: string;
   subjectLastName: string;
   subjectCreatedAt: string;
+  roles: Roles[];
 
   /**
    * The `key` in `/invitations/{key}`. This is `null` after the invitation is approved
@@ -60,7 +61,6 @@ export enum ParticipantStatus {
 export type Participant = {
   id: string | null;
   nicknames: string[];
-  role: Roles;
   secretIds: string[];
   lastSeen: string;
   isPinned?: boolean;
@@ -79,6 +79,10 @@ export type SubjectDetails = {
   userId: string | null;
   firstName: string;
   lastName: string;
+};
+
+export type SubjectDetailsWithRoles = SubjectDetails & {
+  roles: Roles[];
 };
 
 export enum AccountType {

--- a/src/shared/consts.tsx
+++ b/src/shared/consts.tsx
@@ -95,6 +95,15 @@ export enum Roles {
   SuperAdmin = 'super_admin',
 }
 
+export const TEAM_MEMBER_ROLES = [
+  Roles.SuperAdmin,
+  Roles.Owner,
+  Roles.Manager,
+  Roles.Coordinator,
+  Roles.Editor,
+  Roles.Reviewer,
+];
+
 export enum ItemResponseType {
   ABTrails = 'ABTrails',
   Audio = 'audio',

--- a/src/shared/mock.ts
+++ b/src/shared/mock.ts
@@ -8,7 +8,13 @@ import {
 } from 'modules/Dashboard/api/api.types';
 import { page } from 'resources';
 import { DeviceType, ItemFormValuesCommonType, OrderName } from 'modules/Builder/types';
-import { Manager, Participant, ParticipantStatus, SubjectDetails } from 'modules/Dashboard/types';
+import {
+  Manager,
+  Participant,
+  ParticipantDetail,
+  ParticipantStatus,
+  SubjectDetailsWithRoles,
+} from 'modules/Dashboard/types';
 import { AssessmentActivityItem } from 'modules/Dashboard/features/RespondentData/RespondentDataReview';
 
 import {
@@ -23,6 +29,7 @@ import {
   SubscaleTotalScore,
 } from './consts';
 import {
+  Activity,
   ActivitySettingsSubscale,
   ActivitySettingsSubscaleItem,
   Item,
@@ -70,7 +77,7 @@ export const mockedApplet = {
   encryption: mockedEncryption,
 } as Applet;
 
-export const mockedOwnerSubject: SubjectDetails = {
+export const mockedOwnerSubject: SubjectDetailsWithRoles = {
   id: '123e4567-e89b-12d3-a456-426614174000',
   secretUserId: 'mockedOwnerSecretId',
   nickname: `${mockedUserData.firstName} ${mockedUserData.lastName}`,
@@ -79,17 +86,16 @@ export const mockedOwnerSubject: SubjectDetails = {
   userId: mockedUserData.id,
   firstName: mockedUserData.firstName,
   lastName: mockedUserData.lastName,
+  roles: [Roles.Owner, Roles.Respondent],
 };
 
-export const mockedOwnerParticipant = {
+export const mockedOwnerParticipant: Participant = {
   id: mockedUserData.id,
   nicknames: [mockedOwnerSubject.nickname],
   secretIds: [mockedOwnerSubject.secretUserId],
   isAnonymousRespondent: false,
   lastSeen: new Date().toDateString(),
   isPinned: false,
-  accessId: '912e17b8-195f-4685-b77b-137539b9054d',
-  role: Roles.Owner,
   details: [
     {
       appletId: mockedApplet.id,
@@ -106,6 +112,7 @@ export const mockedOwnerParticipant = {
       subjectLastName: mockedOwnerSubject.lastName,
       subjectCreatedAt: '2023-09-26T12:11:46.162083',
       invitation: null,
+      roles: [Roles.Owner, Roles.Respondent],
     },
   ],
   status: ParticipantStatus.Invited,
@@ -113,10 +120,10 @@ export const mockedOwnerParticipant = {
 };
 
 export const mockedOwnerManager: Manager = {
-  id: mockedOwnerParticipant.id,
+  id: mockedOwnerParticipant.id!,
   firstName: mockedUserData.firstName,
   lastName: mockedUserData.lastName,
-  email: mockedOwnerParticipant.email,
+  email: mockedOwnerParticipant.email!,
   roles: [Roles.Owner],
   lastSeen: new Date().toDateString(),
   isPinned: mockedOwnerParticipant.isPinned,
@@ -193,7 +200,7 @@ export const mockedCurrentWorkspace = {
 };
 export const mockedFullParticipantId1 = 'b60a142d-2b7f-4328-841c-dbhjhj4afcf1c7';
 export const mockedFullSubjectId1 = 'subject-id-987';
-export const mockedFullSubject1: SubjectDetails = {
+export const mockedFullSubject1: SubjectDetailsWithRoles = {
   id: mockedFullSubjectId1,
   secretUserId: 'mockedSecretId',
   nickname: 'Mocked Respondent',
@@ -202,7 +209,27 @@ export const mockedFullSubject1: SubjectDetails = {
   userId: mockedFullParticipantId1,
   firstName: 'John',
   lastName: 'Doe',
+  roles: [Roles.Respondent],
 };
+
+export const mockedFullParticipant1Details: ParticipantDetail = {
+  appletId: mockedAppletId,
+  appletDisplayName: 'Mocked Applet',
+  appletImage: '',
+  accessId: 'aebf08ab-c781-4229-a625-271838ebdff4',
+  respondentNickname: mockedFullSubject1.nickname,
+  respondentSecretId: mockedFullSubject1.secretUserId,
+  hasIndividualSchedule: false,
+  encryption: mockedEncryption,
+  subjectId: mockedFullSubjectId1,
+  subjectTag: mockedFullSubject1.tag,
+  subjectFirstName: mockedFullSubject1.firstName,
+  subjectLastName: mockedFullSubject1.lastName,
+  subjectCreatedAt: '2023-09-26T12:11:46.162083',
+  invitation: null,
+  roles: [Roles.Respondent],
+};
+
 export const mockedFullParticipant1: Participant = {
   id: mockedFullParticipantId1,
   nicknames: [mockedFullSubject1.nickname],
@@ -210,25 +237,7 @@ export const mockedFullParticipant1: Participant = {
   isAnonymousRespondent: false,
   lastSeen: new Date().toDateString(),
   isPinned: false,
-  role: Roles.Respondent,
-  details: [
-    {
-      appletId: mockedAppletId,
-      appletDisplayName: 'Mocked Applet',
-      appletImage: '',
-      accessId: 'aebf08ab-c781-4229-a625-271838ebdff4',
-      respondentNickname: mockedFullSubject1.nickname,
-      respondentSecretId: mockedFullSubject1.secretUserId,
-      hasIndividualSchedule: false,
-      encryption: mockedEncryption,
-      subjectId: mockedFullSubjectId1,
-      subjectTag: mockedFullSubject1.tag,
-      subjectFirstName: mockedFullSubject1.firstName,
-      subjectLastName: mockedFullSubject1.lastName,
-      subjectCreatedAt: '2023-09-26T12:11:46.162083',
-      invitation: null,
-    },
-  ],
+  details: [mockedFullParticipant1Details],
   status: ParticipantStatus.Invited,
   email: 'resp1@mail.com',
 };
@@ -242,7 +251,6 @@ export const mockedFullParticipant2: Participant = {
   isAnonymousRespondent: false,
   lastSeen: new Date().toDateString(),
   isPinned: false,
-  role: Roles.Respondent,
   status: ParticipantStatus.Invited,
   email: 'resp2@mail.com',
   details: [
@@ -261,12 +269,13 @@ export const mockedFullParticipant2: Participant = {
       subjectLastName: 'Doe',
       subjectCreatedAt: '2023-09-26T12:11:46.162083',
       invitation: null,
+      roles: [Roles.Respondent],
     },
   ],
 };
 
 export const mockedLimitedSubjectId = 'limited-subject-id-123';
-export const mockedLimitedSubject: SubjectDetails = {
+export const mockedLimitedSubject: SubjectDetailsWithRoles = {
   id: mockedLimitedSubjectId,
   secretUserId: 'limited-1',
   nickname: 'Limited 1',
@@ -275,35 +284,183 @@ export const mockedLimitedSubject: SubjectDetails = {
   userId: null,
   firstName: 'Limited',
   lastName: 'One',
+  roles: [],
 };
-export const mockedLimitedParticipant = {
+
+export const mockedLimitedParticipantDetails: ParticipantDetail = {
+  appletId: mockedAppletId,
+  appletDisplayName: mockedApplet.displayName,
+  appletImage: '',
+  accessId: null,
+  respondentNickname: mockedLimitedSubject.nickname,
+  respondentSecretId: mockedLimitedSubject.secretUserId,
+  hasIndividualSchedule: false,
+  encryption: mockedApplet.encryption,
+  subjectId: mockedLimitedSubjectId,
+  subjectTag: mockedLimitedSubject.tag,
+  subjectFirstName: mockedLimitedSubject.firstName,
+  subjectLastName: mockedLimitedSubject.lastName,
+  subjectCreatedAt: '2024-07-12T13:07:25.455726',
+  invitation: null,
+  roles: [],
+};
+
+export const mockedLimitedParticipant: Participant = {
   id: null,
   nicknames: [mockedLimitedSubject.nickname],
   secretIds: [mockedLimitedSubject.secretUserId],
   isAnonymousRespondent: false,
   lastSeen: new Date().toDateString(),
   isPinned: false,
-  role: Roles.Respondent,
   status: ParticipantStatus.NotInvited,
   email: null,
-  details: [
+  details: [mockedLimitedParticipantDetails],
+};
+
+export const mockedAppletDataExistingActivity: Activity = {
+  name: 'Existing Activity',
+  description: {
+    en: '',
+  },
+  splashScreen: '',
+  image: '',
+  showAllAtOnce: false,
+  isSkippable: false,
+  isReviewable: false,
+  responseIsEditable: true,
+  isHidden: false,
+  scoresAndReports: {
+    generateReport: false,
+    showScoreSummary: false,
+    reports: [],
+  },
+  subscaleSetting: null,
+  id: '56a4ebe4-3d7f-485c-8293-093cabf29fa3',
+  items: [
     {
-      appletId: mockedAppletId,
-      appletDisplayName: mockedApplet.displayName,
-      appletImage: '',
-      accessId: null,
-      respondentNickname: mockedLimitedSubject.nickname,
-      respondentSecretId: mockedLimitedSubject.secretUserId,
-      hasIndividualSchedule: false,
-      encryption: mockedApplet.encryption,
-      subjectId: mockedLimitedSubjectId,
-      subjectTag: mockedLimitedSubject.tag,
-      subjectFirstName: mockedLimitedSubject.firstName,
-      subjectLastName: mockedLimitedSubject.lastName,
-      subjectCreatedAt: '2024-07-12T13:07:25.455726',
-      invitation: null,
+      question: {
+        en: 'ss',
+      },
+      responseType: ItemResponseType.SingleSelection,
+      responseValues: {
+        options: [
+          {
+            id: '0d764084-f3bb-4a91-b74d-3fae4a0beb1f',
+            text: 's1',
+            score: 2,
+            value: 0,
+          },
+          {
+            id: 'e3ca9405-71e9-4627-8311-d405f383246e',
+            text: 's23333333',
+            score: 4,
+            value: 1,
+          },
+        ],
+      },
+      config: defaultSingleSelectionConfig,
+      name: 'Item1',
+      id: 'c17b7b59-8074-4c69-b787-88ea9ea3df5d',
+      order: 1,
+    },
+    {
+      question: {
+        en: 'ms',
+      },
+      responseType: ItemResponseType.MultipleSelection,
+      responseValues: {
+        options: [
+          {
+            id: '7a71bf32-8d25-4040-88a0-8ae3f1c4f8bc',
+            text: 'm1',
+            score: 1,
+            value: 0,
+          },
+          {
+            id: '188fc535-1e45-444d-88ec-91cb29737b03',
+            text: 'm2',
+            score: 1,
+            value: 1,
+          },
+          {
+            id: 'cea898cc-d4be-4320-be11-b6bc6e72a9d1',
+            text: 'm3',
+            score: 1,
+            value: 2,
+          },
+        ],
+      },
+      config: defaultMultiSelectionConfig,
+      name: 'Item2',
+      conditionalLogic: {
+        match: ConditionalLogicMatch.Any,
+        conditions: [
+          {
+            itemName: 'Item1',
+            type: ConditionType.EqualToOption,
+            payload: {
+              optionValue: '0',
+            },
+          },
+        ],
+      },
+      id: 'dad4e249-6a19-4c71-9806-e87b1c9e751b',
+      order: 2,
+    },
+    {
+      question: {
+        en: 'slider',
+      },
+      responseType: ItemResponseType.Slider,
+      responseValues: {
+        minLabel: 'min',
+        maxLabel: 'max',
+        minValue: 1,
+        maxValue: 4,
+      },
+      config: defaultSliderConfig,
+      name: 'Item3',
+      conditionalLogic: {
+        match: ConditionalLogicMatch.Any,
+        conditions: [
+          {
+            itemName: 'Item2',
+            type: ConditionType.NotIncludesOption,
+            payload: {
+              optionValue: '0',
+            },
+          },
+        ],
+      },
+      id: '97c34ed6-4d18-4cb6-a0c8-b1cb2efaa24c',
+      order: 3,
+    },
+    {
+      question: {
+        en: 'time',
+      },
+      responseType: ItemResponseType.Time,
+      responseValues: null,
+      config: defaultTimeConfig,
+      name: 'Item4',
+      id: '4b334484-947b-4287-941c-ed4cbf0dc955',
+      order: 4,
+    },
+    {
+      question: {
+        en: 'text',
+      },
+      responseType: ItemResponseType.Text,
+      responseValues: null,
+      config: defaultTextConfig,
+      name: 'Item5',
+      id: '8fa4788f-54a5-40c4-82c5-2c297a94b959',
+      order: 5,
     },
   ],
+  createdAt: '2023-10-19T08:29:43.180317',
+  isPerformanceTask: false,
+  performanceTaskType: null,
 };
 
 export const mockedAppletData: SingleApplet = {
@@ -334,151 +491,7 @@ export const mockedAppletData: SingleApplet = {
   updatedAt: '2023-10-19T08:29:43.167613',
   isPublished: false,
   activities: [
-    {
-      name: 'Existing Activity',
-      description: {
-        en: '',
-      },
-      splashScreen: '',
-      image: '',
-      showAllAtOnce: false,
-      isSkippable: false,
-      isReviewable: false,
-      responseIsEditable: true,
-      isHidden: false,
-      scoresAndReports: {
-        generateReport: false,
-        showScoreSummary: false,
-        reports: [],
-      },
-      subscaleSetting: null,
-      id: '56a4ebe4-3d7f-485c-8293-093cabf29fa3',
-      items: [
-        {
-          question: {
-            en: 'ss',
-          },
-          responseType: ItemResponseType.SingleSelection,
-          responseValues: {
-            options: [
-              {
-                id: '0d764084-f3bb-4a91-b74d-3fae4a0beb1f',
-                text: 's1',
-                score: 2,
-                value: 0,
-              },
-              {
-                id: 'e3ca9405-71e9-4627-8311-d405f383246e',
-                text: 's23333333',
-                score: 4,
-                value: 1,
-              },
-            ],
-          },
-          config: defaultSingleSelectionConfig,
-          name: 'Item1',
-          id: 'c17b7b59-8074-4c69-b787-88ea9ea3df5d',
-          order: 1,
-        },
-        {
-          question: {
-            en: 'ms',
-          },
-          responseType: ItemResponseType.MultipleSelection,
-          responseValues: {
-            options: [
-              {
-                id: '7a71bf32-8d25-4040-88a0-8ae3f1c4f8bc',
-                text: 'm1',
-                score: 1,
-                value: 0,
-              },
-              {
-                id: '188fc535-1e45-444d-88ec-91cb29737b03',
-                text: 'm2',
-                score: 1,
-                value: 1,
-              },
-              {
-                id: 'cea898cc-d4be-4320-be11-b6bc6e72a9d1',
-                text: 'm3',
-                score: 1,
-                value: 2,
-              },
-            ],
-          },
-          config: defaultMultiSelectionConfig,
-          name: 'Item2',
-          conditionalLogic: {
-            match: ConditionalLogicMatch.Any,
-            conditions: [
-              {
-                itemName: 'Item1',
-                type: ConditionType.EqualToOption,
-                payload: {
-                  optionValue: '0',
-                },
-              },
-            ],
-          },
-          id: 'dad4e249-6a19-4c71-9806-e87b1c9e751b',
-          order: 2,
-        },
-        {
-          question: {
-            en: 'slider',
-          },
-          responseType: ItemResponseType.Slider,
-          responseValues: {
-            minLabel: 'min',
-            maxLabel: 'max',
-            minValue: 1,
-            maxValue: 4,
-          },
-          config: defaultSliderConfig,
-          name: 'Item3',
-          conditionalLogic: {
-            match: ConditionalLogicMatch.Any,
-            conditions: [
-              {
-                itemName: 'Item2',
-                type: ConditionType.NotIncludesOption,
-                payload: {
-                  optionValue: '0',
-                },
-              },
-            ],
-          },
-          id: '97c34ed6-4d18-4cb6-a0c8-b1cb2efaa24c',
-          order: 3,
-        },
-        {
-          question: {
-            en: 'time',
-          },
-          responseType: ItemResponseType.Time,
-          responseValues: null,
-          config: defaultTimeConfig,
-          name: 'Item4',
-          id: '4b334484-947b-4287-941c-ed4cbf0dc955',
-          order: 4,
-        },
-        {
-          question: {
-            en: 'text',
-          },
-          responseType: ItemResponseType.Text,
-          responseValues: null,
-          config: defaultTextConfig,
-          name: 'Item5',
-          id: '8fa4788f-54a5-40c4-82c5-2c297a94b959',
-          order: 5,
-        },
-      ],
-      createdAt: '2023-10-19T08:29:43.180317',
-      isPerformanceTask: false,
-      performanceTaskType: null,
-    },
+    mockedAppletDataExistingActivity,
     {
       name: 'Newly added activity',
       description: {

--- a/src/shared/types/generics.ts
+++ b/src/shared/types/generics.ts
@@ -2,3 +2,12 @@ export type ArrayElement<ArrayType extends readonly unknown[]> =
   ArrayType extends readonly (infer ElementType)[] ? ElementType : never;
 
 export type MaybeNull<T> = T | null;
+
+/**
+ * A utility type that requires at least one of the keys in the object to be present. Useful for defining
+ * a type with all optional keys, where its use requires at least one of the keys to be present.
+ */
+export type AtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyof T, Keys>> &
+  {
+    [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>;
+  }[Keys];


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-8462](https://mindlogger.atlassian.net/browse/M2-8462)

The `useParticipantDropdown` hook previously tried to eagerly fetch the list of team members for filtering the list of respondents, which doesn’t work for users who don’t have permission to consume the workspace managers endpoint (`/workspaces/{owner_id}/applets/{applet_id}/managers`). This PR removes the managers query from the `useParticipantDropdown` hook, and instead makes use of the changes in https://github.com/ChildMindInstitute/mindlogger-backend-refactor/pull/1705 to do the filtering of respondents.

The consequence of this change is that the assign activity drawer is no longer broken for coordinator users. It also prevents the hook from infinitely re-rendering offscreen for other users who don't have permission to consume this endpoint (e.g. reviewers)

I've also fixed the permission set for coordinators, allowing them to pre-populate the assign activity drawer with a respondent or target subject.

### 📸 Screenshots

#### Assign Activity Drawer Before

https://github.com/user-attachments/assets/c1aafce5-1c85-467d-ba31-5b0267e20558

#### Assign Activity Drawer After

https://github.com/user-attachments/assets/4b2d341f-099f-4182-9f01-a7d6fc0412a6

#### Infinite Re-Rerender Offscreen Before

https://github.com/user-attachments/assets/9cc970a3-08e9-4044-82fd-4be78c8caadd

#### Infinite Re-Rerender Offscreen After

https://github.com/user-attachments/assets/9b1ea870-86e1-4e12-8c04-91feb63f2674

### 🪤 Peer Testing

1. Create an applet and a manual assign activity
2. Add a full account participant
3. Add a Coordinator team member
4. Sign in as the coordinator team member
5. Navigate to the owner’s workspace
6. Select the applet from step 1 of the preconditions
7. Go to the participants tab
8. Open the action menu for one of the participants
9. Click assign activity
10. Confirm that the assign activity drawer opens with the participant pre-populated
11. Open the dev tools network tab and confirm that there aren't failed requests to the managers endpoint

### ✏️ Notes

N/A
