### PR TITLE
feat: Fix overly aggressive field validation on scores that makes entering negative numbers difficult (M2-8435)

### DIFF
--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/SelectionOption/SelectionOption.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/SelectionOption/SelectionOption.tsx
@@ -75,7 +75,8 @@ export const SelectionOption = ({
   const optionTextMaxLength = usePortraitLayout
     ? SELECT_OPTION_TEXT_MAX_LENGTH_PORTRAIT
     : SELECT_OPTION_TEXT_MAX_LENGTH;
-  const { text = '', isHidden = false, color, isNoneAbove = false } = option || {};
+  const { text = '', isHidden = false, score, color, isNoneAbove = false } = option || {};
+  const scoreString = score?.toString();
   const hasColor = color !== undefined;
   const hasPalette = !!palette;
   const isColorSet = color?.hex !== '';
@@ -107,6 +108,14 @@ export const SelectionOption = ({
 
   const handleScoreChange = (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     setValue(scoreName, event.target.value);
+  };
+
+  const handleScoreFieldBlur = async () => {
+    const valid = await trigger(scoreName);
+    if (valid) {
+      const score = getValues(scoreName);
+      setValue(scoreName, parseFloat(score));
+    }
   };
 
   const handleOptionTextChange = useFieldLengthError();
@@ -281,7 +290,7 @@ export const SelectionOption = ({
                         pattern: '^-?\\d*(\\.\\d+)?$',
                         inputMode: 'decimal',
                       }}
-                      onBlur={() => trigger(scoreName)}
+                      onBlur={handleScoreFieldBlur}
                       label={t('score')}
                       onChange={handleScoreChange}
                       data-testid={`${dataTestid}-score`}

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/SelectionOption/SelectionOption.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/SelectionOption/SelectionOption.tsx
@@ -16,6 +16,7 @@ import {
   StyledIconButton,
   StyledBodyMedium,
   variables,
+  StyledFlexTopStart,
 } from 'shared/styles';
 import { ItemResponseType } from 'shared/consts';
 import { falseReturnFunc, getEntityKey, getObjectFromList, toggleBooleanState } from 'shared/utils';
@@ -59,7 +60,7 @@ export const SelectionOption = ({
   const [indexToRemove, setIndexToRemove] = useState(-1);
   const [visibleActions, setVisibleActions] = useState(false);
   const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
-  const { setValue, watch, control, getValues } = useCustomFormContext();
+  const { setValue, watch, control, getValues, trigger } = useCustomFormContext();
   const { fieldName, activity } = useCurrentActivity();
   const [settings, responseType, option] = useWatch({
     control,
@@ -74,8 +75,7 @@ export const SelectionOption = ({
   const optionTextMaxLength = usePortraitLayout
     ? SELECT_OPTION_TEXT_MAX_LENGTH_PORTRAIT
     : SELECT_OPTION_TEXT_MAX_LENGTH;
-  const { text = '', isHidden = false, score, color, isNoneAbove = false } = option || {};
-  const scoreString = score?.toString();
+  const { text = '', isHidden = false, color, isNoneAbove = false } = option || {};
   const hasColor = color !== undefined;
   const hasPalette = !!palette;
   const isColorSet = color?.hex !== '';
@@ -106,9 +106,7 @@ export const SelectionOption = ({
   };
 
   const handleScoreChange = (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    if (event.target.value === '') return setValue(scoreName, 0);
-
-    setValue(scoreName, +event.target.value);
+    setValue(scoreName, event.target.value);
   };
 
   const handleOptionTextChange = useFieldLengthError();
@@ -235,53 +233,63 @@ export const SelectionOption = ({
                 {t('descriptionForNoneOption')}
               </StyledBodyMedium>
             )}
-            <StyledFlexTopCenter sx={{ m: theme.spacing(1.5, 0, hasTooltipsChecked ? 4 : 2.4) }}>
-              <StyledSvgWrapper sx={{ mr: theme.spacing(2) }}>
-                <Svg id={isSingleSelection ? 'radio-button-outline' : 'checkbox-multiple-filled'} />
-              </StyledSvgWrapper>
-              <StyledFlexTopCenter sx={{ mr: theme.spacing(1) }}>
-                <Uploader
-                  uiType={UploaderUiType.Secondary}
-                  width={5.6}
-                  height={5.6}
-                  setValue={(val: string) => setValue(`${optionName}.image`, val || undefined)}
-                  getValue={() => imageSrc || ''}
-                  data-testid={`${dataTestid}-image`}
-                />
-              </StyledFlexTopCenter>
-              <StyledTextInputWrapper hasScores={!!scoreString}>
-                <InputController
-                  withDebounce
-                  {...commonInputProps}
-                  name={optionTextName}
-                  label={t('optionText')}
-                  placeholder={placeholder}
-                  onChange={(event) =>
-                    handleOptionTextChange({
-                      event,
-                      fieldName: optionTextName,
-                      maxLength: optionTextMaxLength,
-                    })
-                  }
-                  maxLength={optionTextMaxLength}
-                  data-testid={`${dataTestid}-text`}
-                  InputLabelProps={{ shrink: true }}
-                />
-              </StyledTextInputWrapper>
-              {scoreString && (
-                <StyledScoreWrapper>
-                  <InputController
-                    {...commonInputProps}
-                    name={scoreName}
-                    type="number"
-                    label={t('score')}
-                    minNumberValue={Number.MIN_SAFE_INTEGER}
-                    onChange={handleScoreChange}
-                    data-testid={`${dataTestid}-score`}
+            <StyledFlexTopStart sx={{ m: theme.spacing(1.5, 0, hasTooltipsChecked ? 4 : 2.4) }}>
+              <StyledFlexTopCenter>
+                <StyledSvgWrapper sx={{ mr: theme.spacing(2) }}>
+                  <Svg
+                    id={isSingleSelection ? 'radio-button-outline' : 'checkbox-multiple-filled'}
                   />
-                </StyledScoreWrapper>
-              )}
-            </StyledFlexTopCenter>
+                </StyledSvgWrapper>
+                <StyledFlexTopCenter sx={{ mr: theme.spacing(1) }}>
+                  <Uploader
+                    uiType={UploaderUiType.Secondary}
+                    width={5.6}
+                    height={5.6}
+                    setValue={(val: string) => setValue(`${optionName}.image`, val || undefined)}
+                    getValue={() => imageSrc || ''}
+                    data-testid={`${dataTestid}-image`}
+                  />
+                </StyledFlexTopCenter>
+              </StyledFlexTopCenter>
+              <StyledFlexTopStart sx={{ width: '100%' }}>
+                <StyledTextInputWrapper hasScores={settings.addScores}>
+                  <InputController
+                    withDebounce
+                    {...commonInputProps}
+                    name={optionTextName}
+                    label={t('optionText')}
+                    placeholder={placeholder}
+                    onChange={(event) =>
+                      handleOptionTextChange({
+                        event,
+                        fieldName: optionTextName,
+                        maxLength: optionTextMaxLength,
+                      })
+                    }
+                    maxLength={optionTextMaxLength}
+                    data-testid={`${dataTestid}-text`}
+                    InputLabelProps={{ shrink: true }}
+                  />
+                </StyledTextInputWrapper>
+                {settings.addScores && (
+                  <StyledScoreWrapper>
+                    <InputController
+                      {...commonInputProps}
+                      name={scoreName}
+                      type="text"
+                      inputProps={{
+                        pattern: '^-?\\d*(\\.\\d+)?$',
+                        inputMode: 'decimal',
+                      }}
+                      onBlur={() => trigger(scoreName)}
+                      label={t('score')}
+                      onChange={handleScoreChange}
+                      data-testid={`${dataTestid}-score`}
+                    />
+                  </StyledScoreWrapper>
+                )}
+              </StyledFlexTopStart>
+            </StyledFlexTopStart>
             {hasTooltipsChecked && (
               <StyledTooltipWrapper>
                 <InputController

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/SelectionOption/SelectionOption.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/SelectionOption/SelectionOption.tsx
@@ -40,7 +40,7 @@ import {
   StyledTextInputWrapper,
   StyledTooltipWrapper,
 } from './SelectionOption.styles';
-import { SelectionOptionProps } from './SelectionOption.types';
+import { OptionActions, SelectionOptionProps } from './SelectionOption.types';
 import { getActions, getDependentConditions } from './SelectionOption.utils';
 import { useSetSelectionOptionValue } from './SelectionOption.hooks';
 import { RemoveOptionPopup } from './RemoveOptionPopup';
@@ -75,8 +75,7 @@ export const SelectionOption = ({
   const optionTextMaxLength = usePortraitLayout
     ? SELECT_OPTION_TEXT_MAX_LENGTH_PORTRAIT
     : SELECT_OPTION_TEXT_MAX_LENGTH;
-  const { text = '', isHidden = false, score, color, isNoneAbove = false } = option || {};
-  const scoreString = score?.toString();
+  const { text = '', isHidden = false, color, isNoneAbove = false } = option || {};
   const hasColor = color !== undefined;
   const hasPalette = !!palette;
   const isColorSet = color?.hex !== '';
@@ -158,7 +157,7 @@ export const SelectionOption = ({
     handleRemoveModalClose();
   };
 
-  const actions = {
+  const actions: OptionActions['actions'] = {
     optionHide: () => setValue(`${optionName}.isHidden`, !isHidden),
     paletteClick: () => actionsRef.current && setAnchorEl(actionsRef.current),
     optionRemove: () => {

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -883,6 +883,10 @@
   "defaultPort": "Default Port",
   "invalidIpAddress": "Invalid IP Address",
   "invalidPort": "Invalid Port",
+  "scoreTooLow": "This score is too low. Please enter a higher number.",
+  "scoreTooHigh": "This score is too high. Please enter a lower number.",
+  "scoreMustBeNumber": "The score must be a number",
+  "scorePrecisionError": "The score must be a number with a maximum of 2 decimal places",
   "integrations": "Integrations",
   "loris": {
     "configurationPopupTitle": "LORIS Configuration",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -881,6 +881,10 @@
   "defaultIpAddress": "Adresse IP par défaut",
   "defaultPort": "Port par défaut",
   "invalidIpAddress": "Adresse IP invalide",
+  "scoreTooLow": "Ce score est trop faible. Veuillez saisir un nombre plus élevé.",
+  "scoreTooHigh": "Ce score est trop élevé. Veuillez saisir un nombre inférieur.",
+  "scoreMustBeNumber": "Le score doit être un nombre",
+  "scorePrecisionError": "Le score doit être un nombre avec un maximum de 2 décimales",
   "integrations": "Intégrations",
   "loris": {
     "configurationPopupTitle": "Configuration de LORIS",


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-8435](https://mindlogger.atlassian.net/browse/M2-8435)

This PR updates the score fields in the applet builder to make it easier to enter negative numbers. The previous version of the field was type `number` and so only allowed numerical input. This update makes a few changes:
- The field type has been changed to `text` to allow free text input
- The following validations have been added:
  - Validate that the text input is numerical
  - The minimum value is -9007199254740991 (MIN_SAFE_INTEGER)
  - The maximum value is 9007199254740991 (MAX_SAFE_INTEGER)
  - Only up to two decimal places are allowed
- An error message has been added for the score field, and the styling updated to account for it

### 📸 Screenshots

Manual negative number input is now allowed

https://github.com/user-attachments/assets/b4d63d25-9f3b-4531-8373-623e56eb4398

These are some error states that have been added

<img width="859" alt="image" src="https://github.com/user-attachments/assets/16eef26c-e7e2-4b85-9899-0b77bcc4a8ab" />

<img width="859" alt="image" src="https://github.com/user-attachments/assets/679aac0c-8d54-4bc3-933d-9629b67eab34" />

<img width="859" alt="image" src="https://github.com/user-attachments/assets/d2536404-8007-4014-9343-b3a674245506" />

<img width="859" alt="image" src="https://github.com/user-attachments/assets/29fcbee2-cd35-4525-a282-6c3597646896" />

<img width="859" alt="image" src="https://github.com/user-attachments/assets/13c5b9c4-e041-4025-965f-f3ef50e2456f" />

### 🪤 Peer Testing

1. Create an activity with a single selection and a multiple selection item
2. Enable scores for both items
3. In each item, perform the following checks and confirm the expected behavior

#### Blank

1. Delete the input from the score field
2. Unfocus the score field
3. Confirm the error message is displayed: "The score must be a number"

#### Normal input

1. Enter each of the following into the score field by clearing the field and typing it in, unfocusing the field between each: [100, -100, 4.56, -4.56, 0, -0]
2. Confirm that no error message is displayed for any of them
3. Confirm that -0 is changed to 0 after unfocusing

#### Non-numerical input

1. Enter some non-numerical text into the score field
2. Unfocus the score field
3. Confirm the error message is displayed: "The score must be a number"
4. Click the **Save & Publish** button
5. Confirm the applet is not saved and the item and field are highlighted for the user's attention

#### Score too high

1. Enter the number 9007199254740992 (or higher) into the score field
2. Unfocus the score field
3. Confirm the error message is displayed: "This score is too high. Please enter a lower number."
4. Click the **Save & Publish** button
5. Confirm the applet is not saved and the item and field are highlighted for the user's attention

#### Score too low

1. Enter the number -9007199254740992 (or lower) into the score field
2. Unfocus the score field
3. Confirm the error message is displayed: "This score is too low. Please enter a higher number."
4. Click the **Save & Publish** button
5. Confirm the applet is not saved and the item and field are highlighted for the user's attention

#### Precision error

1. Enter a number with 3 or more decimal places into the score field
2. Unfocus the score field
3. Confirm the error message is displayed: "The score must be a number with a maximum of 2 decimal places"
4. Click the **Save & Publish** button
5. Confirm the applet is not saved and the item and field are highlighted for the user's attention

#### Slider item

1. Create a slider item
2. Enable scores
3. Confirm that these validations do not apply to the slider item

### ✏️ Notes

- Scientific notation is now also allowed (e.g. `1e4`)
- I came up with the copy for the error messages myself. I'm clearing them with product now and will update them if there are any changes
