### PR TITLE
fix: update Time and TimeRange condition time parsing (M2-8306)

### DIFF
--- a/src/modules/Builder/components/ConditionRow/ConditionRow.utils.tsx
+++ b/src/modules/Builder/components/ConditionRow/ConditionRow.utils.tsx
@@ -362,7 +362,11 @@ export const getPayload = ({
           DEFAULT_PAYLOAD_MAX_VALUE,
       };
     default:
-      return {};
+      return formTimeType
+        ? {
+            fieldName: formTimeType,
+          }
+        : {};
   }
 };
 

--- a/src/modules/Builder/pages/BuilderApplet/BuilderApplet.utils.tsx
+++ b/src/modules/Builder/pages/BuilderApplet/BuilderApplet.utils.tsx
@@ -787,12 +787,11 @@ const getConditionPayload = (item: Item, condition: Condition) => {
   const conditionType = condition.type as ConditionType;
   if (TIME_SINGLE_CONDITION_TYPES.includes(conditionType)) {
     const conditionPayload = condition.payload as
-      | TimeSingleValueCondition<Time>['payload']
-      | TimeRangeSingleValueCondition<Time>['payload'];
+      | TimeSingleValueCondition<string>['payload']
+      | TimeRangeSingleValueCondition<string>['payload'];
 
     return {
       ...conditionPayload,
-      time: formatTime(conditionPayload.time.hours, conditionPayload.time.minutes),
     };
   }
   if (TIME_INTERVAL_CONDITION_TYPES.includes(conditionType)) {


### PR DESCRIPTION
### 📝 Description

Update Time parsing to fix an application crash when adding Time and TimeRange conditions

🔗 [Jira Ticket M2-8306](https://mindlogger.atlassian.net/browse/M2-8306)


### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| ![CleanShot 2025-01-24 at 11 51 53](https://github.com/user-attachments/assets/6231b619-cecf-4161-ba1b-b9b72342a6c0) | ![CleanShot 2025-01-24 at 11 50 19](https://github.com/user-attachments/assets/e1878699-6367-4bce-8a34-5c83413495d7) |

### 🪤 Peer Testing

- Create an Activity with 2+ items, including Time and/or TimeRange items
- Add Conditional Logic based on Time or TimeRange
- Select a Time
- Click Save
- Item should save correctly

### ✏️ Notes

The `enableItemFlowItemsG2` and `enableItemFlowExtendedItems`  feature flags need to be enabled in order to test Time/TimeRange conditions
