### PR TITLE
refactor: Transition from `useAsync` to RTK Query (M2-8618)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 - [Typescript](https://www.typescriptlang.org/) - TypeScript is JavaScript with syntax for types
 - [React](https://reactjs.org/) - A JavaScript library for building user interfaces
-- [Redux Toolkit](https://redux-toolkit.js.org/) - Global state manager for JavaScript applications
 - [Material UI](https://mui.com/) - Library of React UI components
-- [Axios](https://axios-http.com/) - Promise-based HTTP Client for node.js and the browser
+- [Redux Toolkit](https://redux-toolkit.js.org/) - Global state manager for JavaScript applications
+- [RTK Query](https://redux-toolkit.js.org/rtk-query/overview) - Data fetching and caching tool, included in Redux Toolkit <sup>[[1]](#footnote-1)</sup>
+- [Axios](https://axios-http.com/) - Promise-based HTTP Client, used by RTK Query to execute queries
 - [React-app-rewired](https://github.com/timarney/react-app-rewired/) - All the benefits of create-react-app without the limitations of "no config"
 
 ## Available Scripts
@@ -92,18 +93,31 @@ See the section about [running tests](https://facebook.github.io/create-react-ap
 
 ## Environment Variables
 
-| Key                              | Required | Default value         | Description                                         |
-|----------------------------------|----------|-----------------------|-----------------------------------------------------|
-| REACT_APP_API_DOMAIN             | yes      | null                  | MindLogger Backend API base URL                     |
-| REACT_APP_WEB_URI                | yes      | http://localhost:5173 | Base URL of the MindLogger respondent web app       |
-| REACT_APP_ENV                    | no       | null                  | Environment to run the app in (`prod` or `staging`) |
-| REACT_APP_DEVELOP_BUILD_VERSION  | no       | null                  | Footer app build number                             |
-| REACT_APP_MIXPANEL_TOKEN         | no       | null                  | Mixpanel token                                      |
-| REACT_APP_LAUNCHDARKLY_CLIENT_ID | no       | null                  | LaunchDarkly client key to choose target environment |
-| REACT_APP_DD_APP_ID              | no       | ""                    | DataDog RUM App ID                                  |
-| REACT_APP_DD_CLIENT_TOKEN        | no       | ""                    | DataDog RUM Client token                            |                                          
-| REACT_APP_DD_VERSION             | no       | local                 | Current admin panel version                         |
-| REACT_APP_DD_TRACING_URLS        | no       | http://localhost:3000 | Comma separated URL prefixes that Datadog is allowed to trace. |  
+| Key                              | Required | Default value         | Description                                                    |
+| -------------------------------- | -------- | --------------------- | -------------------------------------------------------------- |
+| REACT_APP_API_DOMAIN             | yes      | null                  | MindLogger Backend API base URL                                |
+| REACT_APP_WEB_URI                | yes      | http://localhost:5173 | Base URL of the MindLogger respondent web app                  |
+| REACT_APP_ENV                    | no       | null                  | Environment to run the app in (`prod` or `staging`)            |
+| REACT_APP_DEVELOP_BUILD_VERSION  | no       | null                  | Footer app build number                                        |
+| REACT_APP_MIXPANEL_TOKEN         | no       | null                  | Mixpanel token                                                 |
+| REACT_APP_LAUNCHDARKLY_CLIENT_ID | no       | null                  | LaunchDarkly client key to choose target environment           |
+| REACT_APP_DD_APP_ID              | no       | ""                    | DataDog RUM App ID                                             |
+| REACT_APP_DD_CLIENT_TOKEN        | no       | ""                    | DataDog RUM Client token                                       |
+| REACT_APP_DD_VERSION             | no       | local                 | Current admin panel version                                    |
+| REACT_APP_DD_TRACING_URLS        | no       | http://localhost:3000 | Comma separated URL prefixes that Datadog is allowed to trace. |
+
+## Developer Notes
+
+<a id="footnote-1"></a>
+
+### <sup>[1]</sup> Migration to RTK Query
+Currently only a subset of API calls have been migrated to use RTK Query. The remaining unmigrated calls still use the following approaches:
+
+  - Queries are done via a custom hook, `useAsync`, a rudimentary querying mechanism that is similar to RTK Query's `useLazyQuery` syntax, but lacks caching.
+    - Sometimes Redux state, with API calls being made inside thunks, is inconsistently used to loosely mimic "cache" for certain entities.
+  - Mutations are done by calling individual mutation functions directly, lacking integrated cache invalidation.
+
+Migration of such relics is a work-in-progress, with the goal of all API calls, including API-based Redux thunks, being converted to simpler RTK Query syntax. All new API calls should use RTK Query.
 
 ## License
 

--- a/src/modules/Dashboard/api/api.ts
+++ b/src/modules/Dashboard/api/api.ts
@@ -132,18 +132,6 @@ export const getFilteredWorkspaceAppletsApi = (
   });
 };
 
-export const getWorkspaceManagersApi = ({ params }: GetAppletsParams, signal?: AbortSignal) => {
-  const { ownerId, appletId, ...restParams } = params;
-
-  return authApiClient.get(
-    `/workspaces/${ownerId}/${appletId ? `applets/${appletId}/` : ''}managers`,
-    {
-      params: restParams,
-      signal,
-    },
-  );
-};
-
 export const getWorkspaceRespondentsApi = (
   { params }: GetWorkspaceRespondentsParams,
   signal?: AbortSignal,

--- a/src/modules/Dashboard/api/api.ts
+++ b/src/modules/Dashboard/api/api.ts
@@ -54,7 +54,6 @@ import {
   DeleteSubject,
   TargetSubjectId,
   SubjectId,
-  GetActivitiesParams,
   DeleteReview,
   EncryptedActivityAnswer,
   GetWorkspaceRespondentsParams,
@@ -84,7 +83,6 @@ import {
   PostAssignmentsParams,
   GetSubjectActivitiesParams,
   AppletSubjectActivitiesResponse,
-  AppletActivitiesResponse,
   AppletAssignmentsResponse,
   AppletParticipantActivitiesResponse,
   GetTargetSubjectsByRespondentParams,
@@ -920,15 +918,6 @@ export const getSubjectDetailsApi = (
   signal?: AbortSignal,
 ): Promise<AxiosResponse<SubjectDetailsWithDataAccess>> =>
   authApiClient.get(`/subjects/${subjectId}`, {
-    signal,
-  });
-
-export const getAppletActivitiesApi = (
-  { params: { appletId, ...params } }: GetActivitiesParams,
-  signal?: AbortSignal,
-): Promise<AxiosResponse<AppletActivitiesResponse>> =>
-  authApiClient.get(`/activities/applet/${appletId}`, {
-    params,
     signal,
   });
 

--- a/src/modules/Dashboard/api/api.ts
+++ b/src/modules/Dashboard/api/api.ts
@@ -1,13 +1,12 @@
 import axios, { AxiosResponse } from 'axios';
 
 import { AppletId, ActivityId, ActivityFlowId, Response, ResponseWithObject } from 'shared/api';
-import { ExportDataResult, Invitation } from 'shared/types';
+import { ExportDataResult } from 'shared/types';
 import { DEFAULT_ROWS_PER_PAGE as SHARED_DEFAULT_ROWS_PER_PAGE, MAX_LIMIT } from 'shared/consts'; // TODO: replace MAX_LIMIT with infinity scroll
 import { authApiClient } from 'shared/api/apiConfig';
 
 import {
   TransferOwnershipType,
-  AppletInvitationData,
   DuplicateApplet,
   FolderId,
   AppletEncryption,
@@ -48,10 +47,6 @@ import {
   GetRespondentDetailsParams,
   AssessmentResult,
   SubmitDates,
-  AppletShellAccountData,
-  SubjectInvitationData,
-  EditSubject,
-  DeleteSubject,
   TargetSubjectId,
   SubjectId,
   DeleteReview,
@@ -77,7 +72,6 @@ import {
   FeedbackNote,
   GetActivityResponse,
   GetActivityParams,
-  EditSubjectResponse,
   CreateTemporaryMultiInformantRelation,
   GetAssignmentsParams,
   PostAssignmentsParams,
@@ -241,69 +235,10 @@ export const editManagerAccessApi = (
     { signal },
   );
 
-export const editSubjectApi = (
-  { subjectId, values }: EditSubject,
-  signal?: AbortSignal,
-): Promise<AxiosResponse<ApiSuccessResponse<EditSubjectResponse>>> =>
-  authApiClient.put(
-    `/subjects/${subjectId}`,
-    {
-      ...values,
-    },
-    { signal },
-  );
-
-export const deleteSubjectApi = (
-  { subjectId, deleteAnswers }: DeleteSubject,
-  signal?: AbortSignal,
-) =>
-  authApiClient.delete(`/subjects/${subjectId}`, {
-    signal,
-    data: {
-      deleteAnswers,
-    },
-  });
-
 export const deleteAppletApi = ({ appletId }: AppletId, signal?: AbortSignal) =>
   authApiClient.delete(`/applets/${appletId}`, {
     signal,
   });
-
-export const postAppletInvitationApi = (
-  { url, appletId, options }: AppletInvitationData,
-  signal?: AbortSignal,
-) =>
-  authApiClient.post<ResponseWithObject<Invitation>>(
-    `/invitations/${appletId}/${url}`,
-    { ...options },
-    {
-      signal,
-    },
-  );
-
-export const postAppletShellAccountApi = (
-  { appletId, options }: AppletShellAccountData,
-  signal?: AbortSignal,
-) =>
-  authApiClient.post(
-    `/invitations/${appletId}/shell-account`,
-    { ...options },
-    {
-      signal,
-    },
-  );
-
-export const postSubjectInvitationApi = (
-  { appletId, subjectId, email, language }: SubjectInvitationData,
-  signal?: AbortSignal,
-) =>
-  authApiClient.post(
-    `/invitations/${appletId}/subject`,
-    { subjectId, email, language },
-    {
-      signal,
-    },
-  );
 
 export const duplicateAppletApi = ({ appletId, options }: DuplicateApplet, signal?: AbortSignal) =>
   authApiClient.post<ResponseWithObject<Applet>>(

--- a/src/modules/Dashboard/api/api.ts
+++ b/src/modules/Dashboard/api/api.ts
@@ -51,7 +51,6 @@ import {
   SubjectId,
   DeleteReview,
   EncryptedActivityAnswer,
-  GetWorkspaceRespondentsParams,
   GetAppletSubmissionsParams,
   GetAppletSubmissionsResponse,
   ReviewEntity,
@@ -84,9 +83,7 @@ import {
   AppletParticipantActivitiesMetadataResponse,
 } from './api.types';
 import { DEFAULT_ROWS_PER_PAGE } from './api.const';
-import { ApiSuccessResponse } from './base.types';
 import { SubjectDetailsWithDataAccess } from '../types';
-import { ParticipantsDataWithDataAccess } from '../features/Participants';
 
 export const getUserDetailsApi = (signal?: AbortSignal) =>
   authApiClient.get('/users/me', { signal });
@@ -124,21 +121,6 @@ export const getFilteredWorkspaceAppletsApi = (
     params: restParams,
     signal,
   });
-};
-
-export const getWorkspaceRespondentsApi = (
-  { params }: GetWorkspaceRespondentsParams,
-  signal?: AbortSignal,
-): Promise<AxiosResponse<ParticipantsDataWithDataAccess>> => {
-  const { ownerId, appletId, ...restParams } = params;
-
-  return authApiClient.get(
-    `/workspaces/${ownerId}/${appletId ? `applets/${appletId}/` : ''}respondents`,
-    {
-      params: restParams,
-      signal,
-    },
-  );
 };
 
 export const getWorkspaceInfoApi = ({ ownerId }: OwnerId, signal?: AbortSignal) =>

--- a/src/modules/Dashboard/api/api.types.ts
+++ b/src/modules/Dashboard/api/api.types.ts
@@ -5,7 +5,12 @@ import { RetentionPeriods, EncryptedAnswerSharedProps, ExportActivity } from 'sh
 import { Encryption } from 'shared/utils';
 import { User } from 'modules/Auth/state';
 
-import { SubjectDetails, SubjectDetailsWithDataAccess } from '../types';
+import {
+  Manager,
+  ParticipantWithDataAccess,
+  SubjectDetails,
+  SubjectDetailsWithDataAccess,
+} from '../types';
 
 export type GetAppletsParams = {
   params: {
@@ -20,10 +25,24 @@ export type GetAppletsParams = {
   };
 };
 
+export type GetWorkspaceManagersParams = GetAppletsParams;
+
+export type WorkspaceManagersResponse = {
+  result: Manager[];
+  count: number;
+  orderingFields?: string[];
+};
+
 export type GetWorkspaceRespondentsParams = GetAppletsParams & {
   params: {
     userId?: string;
   };
+};
+
+export type WorkspaceRespondentsResponse = {
+  result: ParticipantWithDataAccess[];
+  count: number;
+  orderingFields?: string[];
 };
 
 export type GetActivitiesParams = {
@@ -285,6 +304,10 @@ export type EditSubjectResponse = {
   secretUserId: string;
   nickname: string | null;
   tag: ParticipantTag | null;
+  firstName: string | null;
+  lastName: string | null;
+  title?: string | null;
+  role?: Roles | null;
 };
 
 export type DeleteSubject = SubjectId & {
@@ -306,7 +329,7 @@ export type AppletInvitationOptions = {
 };
 
 export type AppletInvitationData = AppletId & {
-  url: string;
+  url: 'respondent' | 'reviewer' | 'managers';
   options: AppletInvitationOptions;
 };
 

--- a/src/modules/Dashboard/api/apiSlice.ts
+++ b/src/modules/Dashboard/api/apiSlice.ts
@@ -1,0 +1,150 @@
+import { TagDescription } from '@reduxjs/toolkit/query';
+
+import {
+  AppletActivitiesResponse,
+  GetActivitiesParams,
+  GetWorkspaceManagersParams,
+  GetWorkspaceRespondentsParams,
+  WorkspaceRespondentsResponse,
+  WorkspaceManagersResponse,
+  AppletInvitationData,
+  AppletShellAccountData,
+  EditSubject,
+  DeleteSubject,
+  EditSubjectResponse,
+  SubjectInvitationData,
+} from 'api';
+import { apiSlice } from 'shared/api/apiSlice';
+
+import { ApiSuccessResponse } from './base.types';
+
+export const apiDashboardSlice = apiSlice.injectEndpoints({
+  endpoints: (builder) => ({
+    getAppletActivities: builder.query<AppletActivitiesResponse['result'], GetActivitiesParams>({
+      query: ({ params: { appletId, ...rest } }) => ({
+        url: `/activities/applet/${appletId}`,
+        params: rest,
+      }),
+      transformResponse: ({ result }: AppletActivitiesResponse) => result,
+      providesTags: (result) => (result ? [{ type: 'Applet', id: result.appletDetail.id }] : []),
+    }),
+
+    getWorkspaceManagers: builder.query<WorkspaceManagersResponse, GetWorkspaceManagersParams>({
+      query: ({ params: { ownerId, appletId, ...rest } }) => ({
+        url: `/workspaces/${ownerId}/${appletId ? `applets/${appletId}/` : ''}managers`,
+        params: rest,
+      }),
+      providesTags: (data) => [
+        ...(data?.result.map((manager) => ({
+          type: 'User' as const,
+          id: manager.id,
+        })) ?? []),
+        { type: 'User', id: 'LIST' },
+      ],
+    }),
+
+    getWorkspaceRespondents: builder.query<
+      WorkspaceRespondentsResponse,
+      GetWorkspaceRespondentsParams
+    >({
+      query: ({ params: { ownerId, appletId, ...rest } }) => ({
+        url: `/workspaces/${ownerId}/${appletId ? `applets/${appletId}/` : ''}respondents`,
+        params: rest,
+      }),
+      providesTags: (data) => {
+        const tags: TagDescription<'Applet' | 'Subject' | 'User'>[] = [
+          { type: 'Subject', id: 'LIST' },
+          { type: 'User', id: 'LIST' },
+        ];
+
+        if (!data) return tags;
+
+        for (const respondent of data.result) {
+          if (respondent.id) {
+            tags.push({
+              type: 'User' as const,
+              id: respondent.id,
+            });
+          }
+
+          tags.push({
+            type: 'Subject' as const,
+            id: respondent.details[0].subjectId,
+          });
+        }
+
+        return tags;
+      },
+    }),
+
+    createInvitation: builder.mutation<
+      ApiSuccessResponse<EditSubjectResponse>,
+      AppletInvitationData
+    >({
+      query: ({ appletId, url, options }) => ({
+        url: `/invitations/${appletId}/${url}`,
+        method: 'POST',
+        body: options,
+      }),
+      invalidatesTags: [
+        { type: 'Subject', id: 'LIST' },
+        { type: 'User', id: 'LIST' },
+      ],
+    }),
+
+    createSubjectInvitation: builder.mutation<
+      ApiSuccessResponse<EditSubjectResponse>,
+      SubjectInvitationData
+    >({
+      query: ({ appletId, ...body }) => ({
+        url: `/invitations/${appletId}/subject`,
+        method: 'POST',
+        body,
+      }),
+      invalidatesTags: (data, error, { subjectId }) => [{ type: 'Subject', id: subjectId }],
+    }),
+
+    createShellAccount: builder.mutation<
+      ApiSuccessResponse<EditSubjectResponse>,
+      AppletShellAccountData
+    >({
+      query: ({ appletId, options }) => ({
+        url: `/invitations/${appletId}/shell-account`,
+        method: 'POST',
+        body: options,
+      }),
+      invalidatesTags: [{ type: 'Subject', id: 'LIST' }],
+    }),
+
+    editSubject: builder.mutation<ApiSuccessResponse<EditSubjectResponse>, EditSubject>({
+      query: ({ subjectId, values }) => ({
+        url: `/subjects/${subjectId}`,
+        method: 'PUT',
+        body: values,
+      }),
+      invalidatesTags: (data, error, { subjectId }) => [{ type: 'Subject', id: subjectId }],
+    }),
+
+    deleteSubject: builder.mutation<ApiSuccessResponse<EditSubjectResponse>, DeleteSubject>({
+      query: ({ subjectId, deleteAnswers }) => ({
+        url: `/subjects/${subjectId}`,
+        method: 'DELETE',
+        body: { deleteAnswers },
+      }),
+      invalidatesTags: (data, error, { subjectId }) => [{ type: 'Subject', id: subjectId }],
+    }),
+  }),
+});
+
+export const {
+  useGetAppletActivitiesQuery,
+  useGetWorkspaceRespondentsQuery,
+  useGetWorkspaceManagersQuery,
+  useLazyGetWorkspaceRespondentsQuery,
+  useLazyGetWorkspaceManagersQuery,
+  useCreateInvitationMutation,
+  useCreateSubjectInvitationMutation,
+  useCreateShellAccountMutation,
+  useEditSubjectMutation,
+  useDeleteSubjectMutation,
+} = apiDashboardSlice;

--- a/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityAssignDrawer.test.tsx
+++ b/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityAssignDrawer.test.tsx
@@ -2,7 +2,7 @@ import { screen, fireEvent, within, waitFor } from '@testing-library/react';
 import { t } from 'i18next';
 import mockAxios from 'jest-mock-axios';
 
-import { ApiResponseCodes } from 'api';
+import { ApiResponseCodes, WorkspaceManagersResponse, WorkspaceRespondentsResponse } from 'api';
 import {
   mockedApplet,
   mockedAppletData,
@@ -14,13 +14,14 @@ import {
   mockedOwnerId,
   mockedOwnerParticipant,
   mockedFullParticipant1,
-  mockedFullParticipant2,
   mockedUserData,
+  mockedFullParticipant1WithDataAccess,
+  mockedFullParticipant2WithDataAccess,
+  mockedOwnerParticipantWithDataAccess,
+  mockedLimitedParticipantWithDataAccess,
 } from 'shared/mock';
 import { Roles } from 'shared/consts';
 import { mockGetRequestResponses, mockSuccessfulHttpResponse } from 'shared/utils/axios-mocks';
-import { ParticipantsData } from 'modules/Dashboard/features/Participants';
-import { ManagersData } from 'modules/Dashboard/features';
 import { initialStateData } from 'redux/modules';
 import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
@@ -51,17 +52,17 @@ const mockedGetApplet = {
   data: { result: mockedAppletData },
 };
 
-const mockedGetAppletParticipants = mockSuccessfulHttpResponse<ParticipantsData>({
+const mockedGetAppletParticipants = mockSuccessfulHttpResponse<WorkspaceRespondentsResponse>({
   result: [
-    mockedFullParticipant1,
-    mockedFullParticipant2,
-    mockedOwnerParticipant,
-    mockedLimitedParticipant,
+    mockedFullParticipant1WithDataAccess,
+    mockedFullParticipant2WithDataAccess,
+    mockedOwnerParticipantWithDataAccess,
+    mockedLimitedParticipantWithDataAccess,
   ],
   count: 4,
 });
 
-const mockedGetAppletManagers = mockSuccessfulHttpResponse<ManagersData>({
+const mockedGetAppletManagers = mockSuccessfulHttpResponse<WorkspaceManagersResponse>({
   result: [
     {
       id: mockedOwnerParticipant.id as string,
@@ -156,8 +157,8 @@ describe('ActivityAssignDrawer', () => {
       [GET_WORKSPACE_MANAGERS_URL]: mockedGetAppletManagers,
       [GET_WORKSPACE_RESPONDENTS_URL]: (params) => {
         if (params.userId === mockedOwnerParticipant.id) {
-          return mockSuccessfulHttpResponse<ParticipantsData>({
-            result: [mockedOwnerParticipant],
+          return mockSuccessfulHttpResponse<WorkspaceRespondentsResponse>({
+            result: [mockedOwnerParticipantWithDataAccess],
             count: 1,
           });
         }

--- a/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityReview/ActivityReview.test.tsx
+++ b/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityReview/ActivityReview.test.tsx
@@ -8,9 +8,13 @@ import {
   mockedCurrentWorkspace,
   mockedEncryption,
   mockedFullParticipant1,
+  mockedFullParticipant1WithDataAccess,
   mockedFullParticipant2,
+  mockedFullParticipant2WithDataAccess,
   mockedLimitedParticipant,
+  mockedLimitedParticipantWithDataAccess,
   mockedOwnerId,
+  mockedOwnerParticipantWithDataAccess,
   mockedUserData,
 } from 'shared/mock';
 import { useParticipantDropdown } from 'modules/Dashboard/components';
@@ -18,8 +22,7 @@ import { renderWithProviders } from 'shared/utils/renderWithProviders';
 import { mockGetRequestResponses, mockSuccessfulHttpResponse } from 'shared/utils/axios-mocks';
 import { ParticipantTag, Roles } from 'shared/consts';
 import { Participant, ParticipantStatus } from 'modules/Dashboard/types';
-import { ParticipantsData } from 'modules/Dashboard/features/Participants';
-import { ManagersData } from 'modules/Dashboard/features';
+import { WorkspaceManagersResponse, WorkspaceRespondentsResponse } from 'api';
 
 import { ActivityReviewProps } from './ActivityReview.types';
 import { ActivityReview } from './ActivityReview';
@@ -66,17 +69,17 @@ const mockedOwnerRespondent: Participant = {
   email: mockedUserData.email,
 };
 
-const mockedGetAppletParticipants = mockSuccessfulHttpResponse<ParticipantsData>({
+const mockedGetAppletParticipants = mockSuccessfulHttpResponse<WorkspaceRespondentsResponse>({
   result: [
-    mockedFullParticipant1,
-    mockedFullParticipant2,
-    mockedOwnerRespondent,
-    mockedLimitedParticipant,
+    mockedFullParticipant1WithDataAccess,
+    mockedFullParticipant2WithDataAccess,
+    mockedOwnerParticipantWithDataAccess,
+    mockedLimitedParticipantWithDataAccess,
   ],
   count: 4,
 });
 
-const mockedGetAppletManagers = mockSuccessfulHttpResponse<ManagersData>({
+const mockedGetAppletManagers = mockSuccessfulHttpResponse<WorkspaceManagersResponse>({
   result: [
     {
       id: mockedOwnerRespondent.id as string,
@@ -155,8 +158,8 @@ describe('ActivityReview component', () => {
       [GET_WORKSPACE_MANAGERS_URL]: mockedGetAppletManagers,
       [GET_WORKSPACE_RESPONDENTS_URL]: (params) => {
         if (params.userId === mockedOwnerRespondent.id) {
-          return mockSuccessfulHttpResponse<ParticipantsData>({
-            result: [mockedOwnerRespondent],
+          return mockSuccessfulHttpResponse<WorkspaceRespondentsResponse>({
+            result: [mockedOwnerParticipantWithDataAccess],
             count: 1,
           });
         }

--- a/src/modules/Dashboard/components/ActivityAssignDrawer/AssignmentsTable/AssignmentsTable.test.tsx
+++ b/src/modules/Dashboard/components/ActivityAssignDrawer/AssignmentsTable/AssignmentsTable.test.tsx
@@ -15,15 +15,17 @@ import {
   mockedFullParticipant1,
   mockedFullParticipant2,
   mockedUserData,
+  mockedFullParticipant1WithDataAccess,
+  mockedFullParticipant2WithDataAccess,
+  mockedOwnerParticipantWithDataAccess,
+  mockedLimitedParticipantWithDataAccess,
 } from 'shared/mock';
 import { mockGetRequestResponses, mockSuccessfulHttpResponse } from 'shared/utils/axios-mocks';
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
 import { initialStateData } from 'redux/modules';
 import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 import { Roles } from 'shared/consts';
-import { ParticipantsData } from 'modules/Dashboard/features/Participants';
-import { ManagersData } from 'modules/Dashboard/features';
-import { ApiResponseCodes } from 'api';
+import { ApiResponseCodes, WorkspaceManagersResponse, WorkspaceRespondentsResponse } from 'api';
 
 import { selectParticipant } from '../ActivityAssignDrawer.test-utils';
 import { AssignmentsTable } from './AssignmentsTable';
@@ -54,17 +56,17 @@ const mockedGetApplet = {
   data: { result: mockedAppletData },
 };
 
-const mockedGetAppletParticipants = mockSuccessfulHttpResponse<ParticipantsData>({
+const mockedGetAppletParticipants = mockSuccessfulHttpResponse<WorkspaceRespondentsResponse>({
   result: [
-    mockedFullParticipant1,
-    mockedFullParticipant2,
-    mockedOwnerParticipant,
-    mockedLimitedParticipant,
+    mockedFullParticipant1WithDataAccess,
+    mockedFullParticipant2WithDataAccess,
+    mockedOwnerParticipantWithDataAccess,
+    mockedLimitedParticipantWithDataAccess,
   ],
   count: 4,
 });
 
-const mockedGetAppletManagers = mockSuccessfulHttpResponse<ManagersData>({
+const mockedGetAppletManagers = mockSuccessfulHttpResponse<WorkspaceManagersResponse>({
   result: [
     {
       id: mockedOwnerParticipant.id as string,
@@ -157,8 +159,8 @@ describe('AssignmentsTable', () => {
       [GET_WORKSPACE_MANAGERS_URL]: mockedGetAppletManagers,
       [GET_WORKSPACE_RESPONDENTS_URL]: (params) => {
         if (params.userId === mockedOwnerParticipant.id) {
-          return mockSuccessfulHttpResponse<ParticipantsData>({
-            result: [mockedOwnerParticipant],
+          return mockSuccessfulHttpResponse<WorkspaceRespondentsResponse>({
+            result: [mockedOwnerParticipantWithDataAccess],
             count: 1,
           });
         }

--- a/src/modules/Dashboard/components/ParticipantDropdown/ParticipantDropdown.hooks.ts
+++ b/src/modules/Dashboard/components/ParticipantDropdown/ParticipantDropdown.hooks.ts
@@ -38,11 +38,10 @@ export const useParticipantDropdown = ({
 
   const { data: participantsData, isLoading: isFetchingParticipants } =
     useGetWorkspaceRespondentsQuery({ params: { appletId, ownerId, limit: 100 } }, { skip });
-  const participants = useMemo(() => participantsData?.result ?? [], [participantsData]);
 
   const allParticipants = useMemo(
-    () => participants.filter(isParticipantValid).map(participantToOption),
-    [isParticipantValid, participants],
+    () => (participantsData?.result ?? []).filter(isParticipantValid).map(participantToOption),
+    [isParticipantValid, participantsData?.result],
   );
 
   const { data: loggedInTeamMemberData, isLoading: isFetchingLoggedInTeamMember } =

--- a/src/modules/Dashboard/components/ParticipantDropdown/ParticipantDropdown.types.ts
+++ b/src/modules/Dashboard/components/ParticipantDropdown/ParticipantDropdown.types.ts
@@ -1,8 +1,6 @@
 import { AutocompleteProps } from '@mui/material/Autocomplete/Autocomplete';
-import { AxiosError, AxiosResponse } from 'axios';
 
 import { ParticipantSnippetInfo } from 'modules/Dashboard/components/ParticipantSnippet';
-import { ApiErrorResponse } from 'redux/modules';
 import { AtLeastOne } from 'shared/types';
 import { Roles } from 'shared/consts';
 
@@ -51,7 +49,4 @@ export type UseParticipantDropdownProps = {
   appletId?: string;
   includePendingAccounts?: boolean;
   skip?: boolean;
-  successCallback?: (data: AxiosResponse) => void;
-  errorCallback?: (data?: AxiosError<ApiErrorResponse> | null) => void;
-  finallyCallback?: () => void;
 };

--- a/src/modules/Dashboard/features/Applet/Activities/Activities.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Activities/Activities.test.tsx
@@ -1,9 +1,10 @@
 import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import mockAxios, { HttpResponse } from 'jest-mock-axios';
+import { HttpResponse } from 'jest-mock-axios';
 import { generatePath } from 'react-router-dom';
+import mockAxios from '__mocks__/axios';
 
-import { ApiResponseCodes } from 'api';
+import { ApiResponseCodes, WorkspaceManagersResponse, WorkspaceRespondentsResponse } from 'api';
 import { page } from 'resources';
 import { Roles } from 'shared/consts';
 import {
@@ -15,6 +16,9 @@ import {
   mockedFullParticipant2,
   mockedUserData,
   mockedOwnerParticipant,
+  mockedFullParticipant1WithDataAccess,
+  mockedFullParticipant2WithDataAccess,
+  mockedOwnerParticipantWithDataAccess,
 } from 'shared/mock';
 import { getPreloadedState } from 'shared/tests/getPreloadedState';
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
@@ -24,8 +28,6 @@ import {
   mockSuccessfulHttpResponse,
 } from 'shared/utils/axios-mocks';
 import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
-import { ParticipantsData } from 'modules/Dashboard/features/Participants';
-import { ManagersData } from 'modules/Dashboard/features/Managers';
 import {
   expectMixpanelTrack,
   openTakeNowModal,
@@ -346,12 +348,17 @@ describe('Dashboard > Applet > Activities screen', () => {
   });
 
   describe('Take now modal', () => {
-    const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
-      result: [mockedFullParticipant1, mockedFullParticipant2, mockedOwnerParticipant],
-      count: 3,
-    });
+    const successfulGetAppletParticipantsMock =
+      mockSuccessfulHttpResponse<WorkspaceRespondentsResponse>({
+        result: [
+          mockedFullParticipant1WithDataAccess,
+          mockedFullParticipant2WithDataAccess,
+          mockedOwnerParticipantWithDataAccess,
+        ],
+        count: 3,
+      });
 
-    const successfulGetAppletManagersMock = mockSuccessfulHttpResponse<ManagersData>({
+    const successfulGetAppletManagersMock = mockSuccessfulHttpResponse<WorkspaceManagersResponse>({
       result: [mockedOwnerManager],
       count: 1,
     });
@@ -377,8 +384,8 @@ describe('Dashboard > Applet > Activities screen', () => {
         [`/activities/applet/${mockedAppletId}`]: successfulGetAppletActivitiesMock,
         [`/workspaces/${mockedOwnerId}/applets/${mockedAppletId}/respondents`]: (params) => {
           if (params.userId === mockedOwnerParticipant.id) {
-            return mockSuccessfulHttpResponse<ParticipantsData>({
-              result: [mockedOwnerParticipant],
+            return mockSuccessfulHttpResponse<WorkspaceRespondentsResponse>({
+              result: [mockedOwnerParticipantWithDataAccess],
               count: 1,
             });
           }

--- a/src/modules/Dashboard/features/Applet/Activities/Activities.tsx
+++ b/src/modules/Dashboard/features/Applet/Activities/Activities.tsx
@@ -6,7 +6,6 @@ import { Spinner } from 'shared/components';
 import { ActivityGrid, useActivityGrid } from 'modules/Dashboard/components/ActivityGrid';
 import { DataExportPopup } from 'modules/Dashboard/features/Respondents/Popups';
 import { FlowGrid } from 'modules/Dashboard/components/FlowGrid';
-import { Activity, ActivityFlow } from 'redux/modules';
 import { applet } from 'shared/state/Applet';
 import { StyledFlexColumn } from 'shared/styles';
 import { ActivityAssignDrawer } from 'modules/Dashboard/components';
@@ -32,8 +31,8 @@ export const Activities = () => {
     { skip: !appletId },
   );
 
-  const activities: Activity[] = useMemo(() => data?.activitiesDetails ?? [], [data]);
-  const flows: ActivityFlow[] = useMemo(() => data?.appletDetail.activityFlows ?? [], [data]);
+  const activities = data?.activitiesDetails ?? [];
+  const flows = data?.appletDetail.activityFlows ?? [];
   const showContent = !isLoading || !!activities.length;
 
   const { formatRow, TakeNowModal } = useActivityGrid({
@@ -63,8 +62,8 @@ export const Activities = () => {
   });
 
   const formattedActivities = useMemo(
-    () => activities.map((activity) => formatRow(activity)),
-    [activities, formatRow],
+    () => (data?.activitiesDetails ?? []).map((activity) => formatRow(activity)),
+    [data?.activitiesDetails, formatRow],
   );
 
   return (

--- a/src/modules/Dashboard/features/Applet/Activities/Activities.tsx
+++ b/src/modules/Dashboard/features/Applet/Activities/Activities.tsx
@@ -1,10 +1,8 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 
-import { getAppletActivitiesApi } from 'api';
 import { Spinner } from 'shared/components';
-import { useAsync } from 'shared/hooks';
 import { ActivityGrid, useActivityGrid } from 'modules/Dashboard/components/ActivityGrid';
 import { DataExportPopup } from 'modules/Dashboard/features/Respondents/Popups';
 import { FlowGrid } from 'modules/Dashboard/components/FlowGrid';
@@ -13,6 +11,7 @@ import { applet } from 'shared/state/Applet';
 import { StyledFlexColumn } from 'shared/styles';
 import { ActivityAssignDrawer } from 'modules/Dashboard/components';
 import { Mixpanel, MixpanelEventType, MixpanelProps } from 'shared/utils';
+import { useGetAppletActivitiesQuery } from 'modules/Dashboard/api/apiSlice';
 
 import { ActivitiesSectionHeader } from './ActivitiesSectionHeader';
 import { ActivitiesToolbar } from './ActivitiesToolbar';
@@ -27,13 +26,14 @@ export const Activities = () => {
   const { result: appletData } = applet.useAppletData() ?? {};
   const { appletId } = useParams();
   const { t } = useTranslation('app');
-  const { execute, isLoading, value } = useAsync(getAppletActivitiesApi, { retainValue: true });
 
-  const activities: Activity[] = useMemo(() => value?.data.result.activitiesDetails ?? [], [value]);
-  const flows: ActivityFlow[] = useMemo(
-    () => value?.data.result.appletDetail.activityFlows ?? [],
-    [value],
+  const { data, isLoading } = useGetAppletActivitiesQuery(
+    { params: { appletId: appletId as string } },
+    { skip: !appletId },
   );
+
+  const activities: Activity[] = useMemo(() => data?.activitiesDetails ?? [], [data]);
+  const flows: ActivityFlow[] = useMemo(() => data?.appletDetail.activityFlows ?? [], [data]);
   const showContent = !isLoading || !!activities.length;
 
   const { formatRow, TakeNowModal } = useActivityGrid({
@@ -46,29 +46,26 @@ export const Activities = () => {
       setActivityId(activityId);
       setShowExportPopup(true);
     }, []),
-    onClickAssign: useCallback((activityId) => {
-      setActivityId(activityId);
-      setShowActivityAssign(true);
-      Mixpanel.track({
-        action: MixpanelEventType.StartAssignActivityOrFlow,
-        [MixpanelProps.AppletId]: appletId,
-        [MixpanelProps.ActivityId]: activityId,
-        [MixpanelProps.EntityType]: 'activity',
-        [MixpanelProps.Via]: 'Applet - Activities',
-      });
-    }, []),
+    onClickAssign: useCallback(
+      (activityId) => {
+        setActivityId(activityId);
+        setShowActivityAssign(true);
+        Mixpanel.track({
+          action: MixpanelEventType.StartAssignActivityOrFlow,
+          [MixpanelProps.AppletId]: appletId,
+          [MixpanelProps.ActivityId]: activityId,
+          [MixpanelProps.EntityType]: 'activity',
+          [MixpanelProps.Via]: 'Applet - Activities',
+        });
+      },
+      [appletId],
+    ),
   });
 
   const formattedActivities = useMemo(
     () => activities.map((activity) => formatRow(activity)),
     [activities, formatRow],
   );
-
-  useEffect(() => {
-    if (!appletId) return;
-
-    execute({ params: { appletId } });
-  }, [appletId, execute]);
 
   return (
     <StyledFlexColumn sx={{ gap: 2.4, height: '100%' }}>

--- a/src/modules/Dashboard/features/Applet/Overview/Overview.tsx
+++ b/src/modules/Dashboard/features/Applet/Overview/Overview.tsx
@@ -52,12 +52,8 @@ export const Overview = () => {
     [appletId, getAppletPrivateKey, navigate],
   );
 
-  const handleAddPopupClose = (shouldRefetch = false) => {
+  const handleAddPopupClose = () => {
     setAddPopupOpen(false);
-
-    if (!!appletId && shouldRefetch) {
-      execute({ appletId, limit });
-    }
   };
 
   const dashboardTableProps = useMemo(

--- a/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.tsx
@@ -14,10 +14,10 @@ import { useAppDispatch } from 'redux/store';
 import { banners } from 'redux/modules';
 import { AccountType } from 'modules/Dashboard/types/Dashboard.types';
 import {
-  apiDashboardSlice,
   useCreateInvitationMutation,
   useCreateShellAccountMutation,
 } from 'modules/Dashboard/api/apiSlice';
+import { apiSlice } from 'shared/api/apiSlice';
 
 import {
   RESPONDENT_ALREADY_INVITED,
@@ -247,7 +247,7 @@ export const AddParticipantPopup = ({
               setPublicLinkDialogOpen(false);
 
               if (shouldRefetch) {
-                dispatch(apiDashboardSlice.util.invalidateTags([{ type: 'Subject', id: 'LIST' }]));
+                dispatch(apiSlice.util.invalidateTags([{ type: 'Subject', id: 'LIST' }]));
               }
             }}
           />

--- a/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.types.ts
+++ b/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantPopup.types.ts
@@ -5,7 +5,7 @@ import { UserSelectableParticipantTag } from 'shared/consts';
 export type AddParticipantPopupProps = {
   popupVisible: boolean;
   appletId: string | null;
-  onClose?: (shouldRefetch: boolean) => void;
+  onClose?: () => void;
   'data-testid': string;
 };
 

--- a/src/modules/Dashboard/features/Applet/Popups/UpgradeAccountPopup/UpgradeAccountPopup.types.ts
+++ b/src/modules/Dashboard/features/Applet/Popups/UpgradeAccountPopup/UpgradeAccountPopup.types.ts
@@ -5,7 +5,7 @@ export type UpgradeAccountPopupProps = {
   popupVisible: boolean;
   appletId: string | null;
   subjectId: string;
-  onClose?: (shouldRefetch: boolean) => void;
+  onClose?: () => void;
   'data-testid'?: string;
 } & ParticipantSnippetInfo;
 

--- a/src/modules/Dashboard/features/Applet/Schedule/AddIndividualSchedulePopup/AddIndividualSchedulePopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/AddIndividualSchedulePopup/AddIndividualSchedulePopup.tsx
@@ -2,13 +2,14 @@ import { useTranslation } from 'react-i18next';
 import { Trans } from 'react-i18next';
 
 import { createIndividualEventsApi } from 'api';
-import { applets, users } from 'modules/Dashboard/state';
-import { workspaces } from 'redux/modules';
+import { applets } from 'modules/Dashboard/state';
 import { useAppDispatch } from 'redux/store';
 import { Modal, Spinner, SpinnerUiType } from 'shared/components';
 import { useAsync } from 'shared/hooks';
 import { theme, StyledModalWrapper, StyledBodyLarge, variables } from 'shared/styles';
 import { getErrorMessage } from 'shared/utils';
+import { workspaces } from 'redux/modules';
+import { apiDashboardSlice } from 'modules/Dashboard/api/apiSlice';
 
 import { AddIndividualSchedulePopupProps } from './AddIndividualSchedulePopup.types';
 
@@ -34,11 +35,10 @@ export const AddIndividualSchedulePopup = ({
     dispatch(applets.thunk.getEvents({ appletId, respondentId: userId }));
 
     if (ownerId) {
-      dispatch(
-        users.thunk.getAllWorkspaceRespondents({
-          params: { ownerId, appletId, shell: false },
-        }),
-      );
+      // Refresh current user after creating schedule to update hasIndividualSchedule flag.
+      // TODO: When createIndividualEventsApi has been migrated to RTK Query and configured to
+      // invalidate the associated user, this can be removed:
+      dispatch(apiDashboardSlice.util.invalidateTags([{ type: 'User', id: userId }]));
     }
 
     onClose?.();

--- a/src/modules/Dashboard/features/Applet/Schedule/AddIndividualSchedulePopup/AddIndividualSchedulePopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/AddIndividualSchedulePopup/AddIndividualSchedulePopup.tsx
@@ -9,7 +9,7 @@ import { useAsync } from 'shared/hooks';
 import { theme, StyledModalWrapper, StyledBodyLarge, variables } from 'shared/styles';
 import { getErrorMessage } from 'shared/utils';
 import { workspaces } from 'redux/modules';
-import { apiDashboardSlice } from 'modules/Dashboard/api/apiSlice';
+import { apiSlice } from 'shared/api/apiSlice';
 
 import { AddIndividualSchedulePopupProps } from './AddIndividualSchedulePopup.types';
 
@@ -39,7 +39,7 @@ export const AddIndividualSchedulePopup = ({
       // TODO: When createIndividualEventsApi has been migrated to RTK Query and configured to
       // invalidate the associated user (https://mindlogger.atlassian.net/browse/M2-8879), this can
       // be removed:
-      dispatch(apiDashboardSlice.util.invalidateTags([{ type: 'User', id: userId }]));
+      dispatch(apiSlice.util.invalidateTags([{ type: 'User', id: userId }]));
     }
 
     onClose?.();

--- a/src/modules/Dashboard/features/Applet/Schedule/AddIndividualSchedulePopup/AddIndividualSchedulePopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/AddIndividualSchedulePopup/AddIndividualSchedulePopup.tsx
@@ -37,7 +37,8 @@ export const AddIndividualSchedulePopup = ({
     if (ownerId) {
       // Refresh current user after creating schedule to update hasIndividualSchedule flag.
       // TODO: When createIndividualEventsApi has been migrated to RTK Query and configured to
-      // invalidate the associated user, this can be removed:
+      // invalidate the associated user (https://mindlogger.atlassian.net/browse/M2-8879), this can
+      // be removed:
       dispatch(apiDashboardSlice.util.invalidateTags([{ type: 'User', id: userId }]));
     }
 

--- a/src/modules/Dashboard/features/Applet/Schedule/ConfirmEditDefaultSchedulePopup/ConfirmEditDefaultSchedulePopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/ConfirmEditDefaultSchedulePopup/ConfirmEditDefaultSchedulePopup.tsx
@@ -2,8 +2,7 @@ import { Box, Button } from '@mui/material';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { createIndividualEventsApi } from 'api';
-import { applets, users } from 'modules/Dashboard/state';
-import { workspaces } from 'redux/modules';
+import { applets } from 'modules/Dashboard/state';
 import { Modal, Spinner, SpinnerUiType } from 'shared/components';
 import {
   StyledBody,
@@ -16,6 +15,8 @@ import {
 import { useAsync } from 'shared/hooks';
 import { getErrorMessage } from 'shared/utils';
 import { useAppDispatch } from 'redux/store';
+import { workspaces } from 'redux/modules';
+import { apiDashboardSlice } from 'modules/Dashboard/api/apiSlice';
 
 import { ConfirmEditDefaultSchedulePopupProps } from './ConfirmEditDefaultSchedulePopup.types';
 
@@ -39,9 +40,10 @@ export const ConfirmEditDefaultSchedulePopup = ({
     dispatch(applets.thunk.getEvents({ appletId, respondentId: userId }));
 
     if (ownerId) {
-      dispatch(
-        users.thunk.getAllWorkspaceRespondents({ params: { ownerId, appletId, shell: false } }),
-      );
+      // Refresh current user after creating schedule to update hasIndividualSchedule flag.
+      // TODO: When createIndividualEventsApi has been migrated to RTK Query and configured to
+      // invalidate the associated user, this can be removed:
+      dispatch(apiDashboardSlice.util.invalidateTags([{ type: 'User', id: userId }]));
     }
 
     onOpenFollowUpPopup?.();

--- a/src/modules/Dashboard/features/Applet/Schedule/ConfirmEditDefaultSchedulePopup/ConfirmEditDefaultSchedulePopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/ConfirmEditDefaultSchedulePopup/ConfirmEditDefaultSchedulePopup.tsx
@@ -16,7 +16,7 @@ import { useAsync } from 'shared/hooks';
 import { getErrorMessage } from 'shared/utils';
 import { useAppDispatch } from 'redux/store';
 import { workspaces } from 'redux/modules';
-import { apiDashboardSlice } from 'modules/Dashboard/api/apiSlice';
+import { apiSlice } from 'shared/api/apiSlice';
 
 import { ConfirmEditDefaultSchedulePopupProps } from './ConfirmEditDefaultSchedulePopup.types';
 
@@ -44,7 +44,7 @@ export const ConfirmEditDefaultSchedulePopup = ({
       // TODO: When createIndividualEventsApi has been migrated to RTK Query and configured to
       // invalidate the associated user (https://mindlogger.atlassian.net/browse/M2-8879), this can
       // be removed:
-      dispatch(apiDashboardSlice.util.invalidateTags([{ type: 'User', id: userId }]));
+      dispatch(apiSlice.util.invalidateTags([{ type: 'User', id: userId }]));
     }
 
     onOpenFollowUpPopup?.();

--- a/src/modules/Dashboard/features/Applet/Schedule/ConfirmEditDefaultSchedulePopup/ConfirmEditDefaultSchedulePopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/ConfirmEditDefaultSchedulePopup/ConfirmEditDefaultSchedulePopup.tsx
@@ -42,7 +42,8 @@ export const ConfirmEditDefaultSchedulePopup = ({
     if (ownerId) {
       // Refresh current user after creating schedule to update hasIndividualSchedule flag.
       // TODO: When createIndividualEventsApi has been migrated to RTK Query and configured to
-      // invalidate the associated user, this can be removed:
+      // invalidate the associated user (https://mindlogger.atlassian.net/browse/M2-8879), this can
+      // be removed:
       dispatch(apiDashboardSlice.util.invalidateTags([{ type: 'User', id: userId }]));
     }
 

--- a/src/modules/Dashboard/features/Applet/Schedule/EventForm/EventForm.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/EventForm/EventForm.tsx
@@ -14,8 +14,9 @@ import { applet, workspaces } from 'shared/state';
 import { Periodicity, createEventApi, updateEventApi } from 'api';
 import { useAsync } from 'shared/hooks/useAsync';
 import { useAppDispatch } from 'redux/store';
-import { calendarEvents, users } from 'modules/Dashboard/state';
+import { calendarEvents } from 'modules/Dashboard/state';
 import { AnalyticsCalendarPrefix } from 'shared/consts';
+import { apiDashboardSlice } from 'modules/Dashboard/api/apiSlice';
 
 import {
   EventFormProps,
@@ -111,15 +112,10 @@ export const EventForm = forwardRef<EventFormRef, EventFormProps>(
       if (!appletId) return;
       dispatch(applets.thunk.getEvents({ appletId, respondentId: userId }));
       if (userId && ownerId && eventsData.length === 0) {
-        dispatch(
-          users.thunk.getAllWorkspaceRespondents({
-            params: {
-              ownerId,
-              appletId,
-              shell: false,
-            },
-          }),
-        );
+        // Refresh current user after deleting all events to update the hasIndividualSchedule flag.
+        // TODO: When createIndividualEventsApi has been migrated to RTK Query and configured to
+        // invalidate the associated user, this can be removed:
+        dispatch(apiDashboardSlice.util.invalidateTags([{ type: 'User', id: userId }]));
       }
     };
 

--- a/src/modules/Dashboard/features/Applet/Schedule/EventForm/EventForm.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/EventForm/EventForm.tsx
@@ -16,7 +16,7 @@ import { useAsync } from 'shared/hooks/useAsync';
 import { useAppDispatch } from 'redux/store';
 import { calendarEvents } from 'modules/Dashboard/state';
 import { AnalyticsCalendarPrefix } from 'shared/consts';
-import { apiDashboardSlice } from 'modules/Dashboard/api/apiSlice';
+import { apiSlice } from 'shared/api/apiSlice';
 
 import {
   EventFormProps,
@@ -116,7 +116,7 @@ export const EventForm = forwardRef<EventFormRef, EventFormProps>(
         // TODO: When createIndividualEventsApi has been migrated to RTK Query and configured to
         // invalidate the associated user (https://mindlogger.atlassian.net/browse/M2-8879), this
         // can be removed:
-        dispatch(apiDashboardSlice.util.invalidateTags([{ type: 'User', id: userId }]));
+        dispatch(apiSlice.util.invalidateTags([{ type: 'User', id: userId }]));
       }
     };
 

--- a/src/modules/Dashboard/features/Applet/Schedule/EventForm/EventForm.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/EventForm/EventForm.tsx
@@ -114,7 +114,8 @@ export const EventForm = forwardRef<EventFormRef, EventFormProps>(
       if (userId && ownerId && eventsData.length === 0) {
         // Refresh current user after deleting all events to update the hasIndividualSchedule flag.
         // TODO: When createIndividualEventsApi has been migrated to RTK Query and configured to
-        // invalidate the associated user, this can be removed:
+        // invalidate the associated user (https://mindlogger.atlassian.net/browse/M2-8879), this
+        // can be removed:
         dispatch(apiDashboardSlice.util.invalidateTags([{ type: 'User', id: userId }]));
       }
     };

--- a/src/modules/Dashboard/features/Applet/Schedule/RemoveIndividualSchedulePopup/RemoveIndividualSchedulePopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/RemoveIndividualSchedulePopup/RemoveIndividualSchedulePopup.tsx
@@ -7,7 +7,7 @@ import { removeIndividualEventsApi } from 'api';
 import { useAppDispatch } from 'redux/store';
 import { useAsync } from 'shared/hooks/useAsync';
 import { applets } from 'modules/Dashboard/state';
-import { apiDashboardSlice } from 'modules/Dashboard/api/apiSlice';
+import { apiSlice } from 'shared/api/apiSlice';
 
 import { RemoveIndividualScheduleProps } from './RemoveIndividualSchedulePopup.types';
 import { Steps } from './RemoveIndividualSchedule.types';
@@ -47,7 +47,7 @@ export const RemoveIndividualSchedulePopup = ({
     // TODO: When removeIndividualEventsApi has been migrated to RTK Query and configured to
     // invalidate the associated user (https://mindlogger.atlassian.net/browse/M2-8879), this can be
     // removed:
-    dispatch(apiDashboardSlice.util.invalidateTags([{ type: 'User', id: userId }]));
+    dispatch(apiSlice.util.invalidateTags([{ type: 'User', id: userId }]));
   };
 
   const screens = getScreens({

--- a/src/modules/Dashboard/features/Applet/Schedule/RemoveIndividualSchedulePopup/RemoveIndividualSchedulePopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/RemoveIndividualSchedulePopup/RemoveIndividualSchedulePopup.tsx
@@ -45,7 +45,8 @@ export const RemoveIndividualSchedulePopup = ({
 
     // Refresh current user after deleting schedule to update the hasIndividualSchedule flag.
     // TODO: When removeIndividualEventsApi has been migrated to RTK Query and configured to
-    // invalidate the associated user, this can be removed:
+    // invalidate the associated user (https://mindlogger.atlassian.net/browse/M2-8879), this can be
+    // removed:
     dispatch(apiDashboardSlice.util.invalidateTags([{ type: 'User', id: userId }]));
   };
 

--- a/src/modules/Dashboard/features/Applet/Schedule/RemoveIndividualSchedulePopup/RemoveIndividualSchedulePopup.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/RemoveIndividualSchedulePopup/RemoveIndividualSchedulePopup.tsx
@@ -6,8 +6,8 @@ import { StyledModalWrapper } from 'shared/styles';
 import { removeIndividualEventsApi } from 'api';
 import { useAppDispatch } from 'redux/store';
 import { useAsync } from 'shared/hooks/useAsync';
-import { applets, users } from 'modules/Dashboard/state';
-import { workspaces } from 'shared/state';
+import { applets } from 'modules/Dashboard/state';
+import { apiDashboardSlice } from 'modules/Dashboard/api/apiSlice';
 
 import { RemoveIndividualScheduleProps } from './RemoveIndividualSchedulePopup.types';
 import { Steps } from './RemoveIndividualSchedule.types';
@@ -25,8 +25,6 @@ export const RemoveIndividualSchedulePopup = ({
   const { t } = useTranslation();
   const [step, setStep] = useState<Steps>(0);
   const dispatch = useAppDispatch();
-  const { getAllWorkspaceRespondents } = users.thunk;
-  const { ownerId } = workspaces.useData() || {};
 
   const { execute, error, isLoading } = useAsync(removeIndividualEventsApi, () => {
     if (!appletId || !userId) return;
@@ -45,13 +43,10 @@ export const RemoveIndividualSchedulePopup = ({
   const handleRemovedScheduleClose = () => {
     onClose();
 
-    if (!appletId || !ownerId) return;
-
-    dispatch(
-      getAllWorkspaceRespondents({
-        params: { ownerId, appletId, shell: false },
-      }),
-    );
+    // Refresh current user after deleting schedule to update the hasIndividualSchedule flag.
+    // TODO: When removeIndividualEventsApi has been migrated to RTK Query and configured to
+    // invalidate the associated user, this can be removed:
+    dispatch(apiDashboardSlice.util.invalidateTags([{ type: 'User', id: userId }]));
   };
 
   const screens = getScreens({

--- a/src/modules/Dashboard/features/Applet/Schedule/Schedule.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/Schedule.tsx
@@ -1,12 +1,10 @@
 import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 
-import { usePermissions } from 'shared/hooks';
 import { applet, workspaces } from 'shared/state';
-import { applets, users } from 'modules/Dashboard/state';
+import { applets } from 'modules/Dashboard/state';
 import { useAppDispatch } from 'redux/store';
-import { Spinner } from 'shared/components';
-import { StyledBody } from 'shared/styles';
+import { usePermissions } from 'shared/hooks';
 
 import { Calendar } from './Calendar';
 import { Legend } from './Legend';
@@ -21,21 +19,10 @@ export const Schedule = () => {
   const { result: appletData } = applet.useAppletData() ?? {};
   const { data: workspaceRoles } = workspaces.useRolesData() ?? {};
   const { ownerId } = workspaces.useData() || {};
-  const loadingStatus = users.useAllRespondentsStatus();
-  const isLoading = loadingStatus === 'loading' || loadingStatus === 'idle';
-  const { getAllWorkspaceRespondents, getRespondentDetails } = users.thunk;
   const preparedEvents = usePreparedEvents(appletData);
   const hasAccess = appletId ? checkIfHasAccessToSchedule(workspaceRoles?.[appletId]) : false;
 
-  const { isForbidden, noPermissionsComponent } = usePermissions(() => {
-    if (!appletId || !hasAccess) return;
-
-    return dispatch(
-      getAllWorkspaceRespondents({
-        params: { ownerId, appletId, shell: false },
-      }),
-    );
-  });
+  const { noPermissionsComponent } = usePermissions(() => undefined);
 
   useEffect(() => {
     if (!appletId || !hasAccess) return;
@@ -45,15 +32,11 @@ export const Schedule = () => {
     return () => {
       dispatch(applets.actions.resetEventsData());
     };
-  }, [appletId, dispatch, getRespondentDetails, hasAccess, ownerId]);
+  }, [appletId, dispatch, hasAccess, ownerId]);
 
-  if (isForbidden || !hasAccess) return noPermissionsComponent;
+  if (!hasAccess) return noPermissionsComponent;
 
-  return isLoading ? (
-    <StyledBody>
-      <Spinner />
-    </StyledBody>
-  ) : (
+  return (
     <ScheduleProvider appletId={appletId} appletName={appletData?.displayName}>
       <StyledSchedule>
         <StyledLeftPanel>

--- a/src/modules/Dashboard/features/Managers/Managers.test.tsx
+++ b/src/modules/Dashboard/features/Managers/Managers.test.tsx
@@ -172,15 +172,14 @@ describe('Managers component tests', () => {
     await waitFor(() => {
       expect(mockAxios.get).toHaveBeenLastCalledWith(
         `/workspaces/${mockedOwnerId}/applets/${mockedAppletId}/managers`,
-        {
+        expect.objectContaining({
           params: {
             limit: 20,
             page: 1,
             search: mockedSearchValue,
             ordering: '+lastName',
           },
-          signal: undefined,
-        },
+        }),
       );
     });
 

--- a/src/modules/Dashboard/features/Managers/Managers.tsx
+++ b/src/modules/Dashboard/features/Managers/Managers.tsx
@@ -3,7 +3,7 @@ import { Avatar as MuiAvatar, Box, Button } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 
-import { GetAppletsParams, getWorkspaceInfoApi, getWorkspaceManagersApi } from 'api';
+import { GetAppletsParams, getWorkspaceInfoApi } from 'api';
 import {
   ActionsMenu,
   Avatar,
@@ -29,18 +29,17 @@ import {
 import { Roles, DEFAULT_ROWS_PER_PAGE } from 'shared/consts';
 import { StyledBody, StyledFlexWrap, StyledMaybeEmpty, variables } from 'shared/styles';
 import { useAppDispatch } from 'redux/store';
+import { useLazyGetWorkspaceManagersQuery } from 'modules/Dashboard/api/apiSlice';
 
 import { AddManagerPopup, ManagersRemoveAccessPopup, EditAccessPopup } from './Popups';
-import { ManagersActions, ManagersData } from './Managers.types';
+import { ManagersActions } from './Managers.types';
 import { getManagerActions, getHeadCells } from './Managers.utils';
 
 export const Managers = () => {
   const { t } = useTranslation('app');
   const dispatch = useAppDispatch();
   const { appletId } = useParams();
-  const [managersData, setManagersData] = useState<ManagersData | null>(null);
   const [workspaceInfo, setWorkspaceInfo] = useState<WorkspaceInfo | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
   const dataTestId = 'dashboard-managers';
 
   const rolesData = workspaces.useRolesData();
@@ -53,21 +52,14 @@ export const Managers = () => {
   // Coordinators can add reviewers for other participants
   const canAddReviewers = checkIfCanManageParticipants(roles);
 
-  const { execute } = useAsync(
-    getWorkspaceManagersApi,
-    (response) => {
-      setManagersData(response?.data || null);
-    },
-    undefined,
-    () => setIsLoading(false),
-  );
+  const [execute, { data: managersData, isLoading }] = useLazyGetWorkspaceManagersQuery();
+
   const { execute: executeGetWorkspaceInfoApi } = useAsync(getWorkspaceInfoApi, (res) => {
     setWorkspaceInfo(res?.data?.result || null);
   });
 
   const getWorkspaceManagers = (args?: GetAppletsParams) => {
     if (!canViewTeam) return Promise.resolve();
-    setIsLoading(true);
 
     const ordering = args?.params.ordering ?? '+lastName,+firstName';
 

--- a/src/modules/Dashboard/features/Managers/Managers.types.ts
+++ b/src/modules/Dashboard/features/Managers/Managers.types.ts
@@ -7,9 +7,3 @@ export type ManagersActions = {
   copyEmailAddressAction: ({ context }: MenuActionProps<Manager>) => void;
   copyInvitationLinkAction: ({ context }: MenuActionProps<Manager>) => void;
 };
-
-export type ManagersData = {
-  result: Manager[];
-  count: number;
-  orderingFields?: string[];
-};

--- a/src/modules/Dashboard/features/Managers/Popups/AddManagerPopup/AddManagerPopup.types.ts
+++ b/src/modules/Dashboard/features/Managers/Popups/AddManagerPopup/AddManagerPopup.types.ts
@@ -5,7 +5,7 @@ import { Roles } from 'shared/consts';
 export type AddManagerPopupProps = {
   popupVisible: boolean;
   appletId: string | null;
-  onClose?: (shouldRefetch: boolean) => void;
+  onClose?: () => void;
   workspaceInfo: WorkspaceInfo | null;
   'data-testid'?: string;
 };

--- a/src/modules/Dashboard/features/Managers/Popups/ManagersEditAccessPopup/ManagersEditAccessPopup.test.tsx
+++ b/src/modules/Dashboard/features/Managers/Popups/ManagersEditAccessPopup/ManagersEditAccessPopup.test.tsx
@@ -9,9 +9,9 @@ import {
   mockedAppletId,
   mockedCurrentWorkspace,
   mockedOwnerId,
-  mockedFullSubjectId1,
-  mockedFullSubjectId2,
   mockedUserData,
+  mockedFullParticipant1,
+  mockedFullParticipant2,
 } from 'shared/mock';
 import { Roles } from 'shared/consts';
 import { initialStateData } from 'shared/state';
@@ -55,45 +55,11 @@ const preloadedState = {
       },
     },
   },
-  users: {
-    allRespondents: {
-      data: {
-        result: [
-          {
-            id: '429fe361-478b-49f0-b681-d476eaec5c52',
-            nicknames: ['John Doe'],
-            secretIds: ['66947648-8eea-4106-9081-4b66117ef2e6'],
-            isAnonymousRespondent: false,
-            details: [
-              {
-                appletId: mockedAppletId,
-                appletDisplayName: 'Mock Applet',
-                accessId: 'f49a8aa2-bc9c-46cc-a9b5-03f191d908a2',
-                respondentNickname: 'John Doe',
-                respondentSecretId: '66947648-8eea-4106-9081-4b66117ef2e6',
-                subjectId: mockedFullSubjectId1,
-              },
-            ],
-          },
-          {
-            id: 'c48b275d-db4b-4f79-8469-9198b45985d3',
-            nicknames: ['Sam Carter'],
-            secretIds: ['78ec50c9-cac8-46fe-9232-352c4c561a33'],
-            isAnonymousRespondent: false,
-            details: [
-              {
-                appletId: mockedAppletId,
-                appletDisplayName: 'Mock Applet',
-                accessId: '71d4840d-ab38-4b88-a65e-417918d8d329',
-                respondentNickname: 'Sam Carter',
-                respondentSecretId: '78ec50c9-cac8-46fe-9232-352c4c561a33',
-                subjectId: mockedFullSubjectId2,
-              },
-            ],
-          },
-        ],
-      },
-    },
+};
+
+const mockedRespondents = {
+  data: {
+    result: [mockedFullParticipant1, mockedFullParticipant2],
   },
 };
 
@@ -221,7 +187,7 @@ describe('EditAccessPopup component', () => {
       ),
     ).toBeInTheDocument();
 
-    mockAxios.get.mockResolvedValue(preloadedState.users.allRespondents);
+    mockAxios.get.mockResolvedValue(mockedRespondents);
 
     const editRole = screen.getByTestId(`${dataTestid}-access-edit-role`);
     expect(editRole).toBeInTheDocument();

--- a/src/modules/Dashboard/features/Managers/Popups/SelectRespondentsPopup/SelectRespondentsPopup.test.tsx
+++ b/src/modules/Dashboard/features/Managers/Popups/SelectRespondentsPopup/SelectRespondentsPopup.test.tsx
@@ -35,13 +35,6 @@ const preloadedState = {
     workspacesRoles: initialStateData,
   },
   users: {
-    allRespondents: {
-      ...initialStateData,
-      data: {
-        result: [mockedFullParticipant1, mockedFullParticipant2],
-        count: 2,
-      },
-    },
     respondentDetails: {
       ...initialStateData,
     },
@@ -72,10 +65,13 @@ const successfulResponse = {
 };
 
 describe('SelectRespondentsPopup component tests', () => {
-  test('should appear popup without selected respondents', async () => {
+  beforeEach(() => {
     mockAxios.get.mockResolvedValueOnce(successfulResponse);
+  });
+
+  test('should appear popup without selected respondents', async () => {
     renderWithProviders(getPopup(false), { preloadedState });
-    const tableRows = screen.queryAllByTestId(/table-row-\d+/);
+    const tableRows = await screen.findAllByTestId(/table-row-\d+/);
     const select = screen.getByTestId('select-respondents-popup-search-across');
     const selectInput = await waitFor(() => select.querySelector('input'));
 
@@ -92,7 +88,6 @@ describe('SelectRespondentsPopup component tests', () => {
   });
 
   test('should appear popup with selected respondents', async () => {
-    mockAxios.get.mockResolvedValueOnce(successfulResponse);
     renderWithProviders(getPopup(), { preloadedState });
 
     await waitFor(() => {
@@ -101,19 +96,17 @@ describe('SelectRespondentsPopup component tests', () => {
   });
 
   test('should confirm popup with selected respondents', async () => {
-    mockAxios.get.mockResolvedValueOnce(successfulResponse);
     renderWithProviders(getPopup(), { preloadedState });
+
+    await screen.findAllByTestId(/table-row-\d+/);
 
     fireEvent.click(screen.getByText('Confirm'));
 
-    await waitFor(() => {
-      expect(mockedCloseFn).toBeCalledWith([mockedFullSubjectId1]);
-    });
+    expect(mockedCloseFn).toBeCalledWith([mockedFullSubjectId1]);
   });
 
   describe('should search respondents', () => {
     test('across all', async () => {
-      mockAxios.get.mockResolvedValueOnce(successfulResponse);
       renderWithProviders(getPopup(), { preloadedState });
       const mockedSearchValue = 'mockedSearchValue';
 
@@ -133,7 +126,6 @@ describe('SelectRespondentsPopup component tests', () => {
     });
 
     test('across selected', async () => {
-      mockAxios.get.mockResolvedValueOnce(successfulResponse);
       renderWithProviders(getPopup(), { preloadedState });
 
       const select = screen.getByTestId('select-respondents-popup-search-across');
@@ -148,7 +140,6 @@ describe('SelectRespondentsPopup component tests', () => {
     });
 
     test('across unselected', async () => {
-      mockAxios.get.mockResolvedValueOnce(successfulResponse);
       renderWithProviders(getPopup(), { preloadedState });
 
       const select = screen.getByTestId('select-respondents-popup-search-across');

--- a/src/modules/Dashboard/features/Managers/Popups/SelectRespondentsPopup/SelectRespondentsPopup.tsx
+++ b/src/modules/Dashboard/features/Managers/Popups/SelectRespondentsPopup/SelectRespondentsPopup.tsx
@@ -4,8 +4,8 @@ import { useTranslation } from 'react-i18next';
 
 import { StyledModalWrapper } from 'shared/styles';
 import { Modal } from 'shared/components';
-import { users, workspaces } from 'redux/modules';
-import { useAppDispatch } from 'redux/store';
+import { workspaces } from 'redux/modules';
+import { useGetWorkspaceRespondentsQuery } from 'modules/Dashboard/api/apiSlice';
 
 import { SelectRespondents } from './SelectRespondents';
 import { SelectRespondentsPopupProps } from './SuccessSharePopup.types';
@@ -22,13 +22,17 @@ export const SelectRespondentsPopup = ({
 }: SelectRespondentsPopupProps) => {
   const name = `${firstName} ${lastName}`;
   const { t } = useTranslation();
-  const dispatch = useAppDispatch();
 
   const { ownerId } = workspaces.useData() || {};
-  const respondentsData = users.useAllRespondentsData();
+
+  const { data: respondentsData } = useGetWorkspaceRespondentsQuery(
+    { params: { appletId, ownerId } },
+    { skip: !ownerId },
+  );
+
   const respondents = useMemo(
     () =>
-      respondentsData?.result?.reduce(
+      respondentsData?.result.reduce(
         (acc: Respondent[], { nicknames, secretIds, isAnonymousRespondent, details }) => {
           if (!isAnonymousRespondent) {
             acc.push({
@@ -59,17 +63,6 @@ export const SelectRespondentsPopup = ({
 
     onClose(selectedRespondents);
   };
-
-  useEffect(() => {
-    if (!ownerId) return;
-
-    const { getAllWorkspaceRespondents } = users.thunk;
-    dispatch(
-      getAllWorkspaceRespondents({
-        params: { ownerId, appletId },
-      }),
-    );
-  }, [ownerId]);
 
   useEffect(() => {
     if (!respondents?.length) return;

--- a/src/modules/Dashboard/features/Participant/Activities/Activities.test.tsx
+++ b/src/modules/Dashboard/features/Participant/Activities/Activities.test.tsx
@@ -4,7 +4,7 @@ import mockAxios, { HttpResponse } from 'jest-mock-axios';
 import { generatePath } from 'react-router-dom';
 import { PreloadedState } from '@reduxjs/toolkit';
 
-import { ApiResponseCodes } from 'api';
+import { ApiResponseCodes, WorkspaceManagersResponse, WorkspaceRespondentsResponse } from 'api';
 import { page } from 'resources';
 import { Roles } from 'shared/consts';
 import {
@@ -20,6 +20,9 @@ import {
   mockedFullSubjectId1,
   mockedFullSubjectId2,
   mockedOwnerSubjectWithDataAccess,
+  mockedFullParticipant1WithDataAccess,
+  mockedFullParticipant2WithDataAccess,
+  mockedOwnerParticipantWithDataAccess,
 } from 'shared/mock';
 import { getPreloadedState } from 'shared/tests/getPreloadedState';
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
@@ -30,8 +33,6 @@ import {
 } from 'shared/utils/axios-mocks';
 import { RootState } from 'redux/store';
 import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
-import { ParticipantsData } from 'modules/Dashboard/features/Participants';
-import { ManagersData } from 'modules/Dashboard/features/Managers';
 import {
   expectMixpanelTrack,
   openTakeNowModal,
@@ -115,9 +116,6 @@ const preloadedState: PreloadedState<RootState> = {
   ...getPreloadedState(),
   users: {
     respondentDetails: mockSchema(null),
-    allRespondents: mockSchema(null, {
-      status: 'idle',
-    }),
     subjectDetails: mockSchema({
       result: mockedOwnerSubjectWithDataAccess,
     }),
@@ -251,12 +249,17 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
   });
 
   describe('Take Now modal', () => {
-    const successfulGetAppletParticipantsMock = mockSuccessfulHttpResponse<ParticipantsData>({
-      result: [mockedFullParticipant1, mockedFullParticipant2, mockedOwnerParticipant],
-      count: 3,
-    });
+    const successfulGetAppletParticipantsMock =
+      mockSuccessfulHttpResponse<WorkspaceRespondentsResponse>({
+        result: [
+          mockedFullParticipant1WithDataAccess,
+          mockedFullParticipant2WithDataAccess,
+          mockedOwnerParticipantWithDataAccess,
+        ],
+        count: 3,
+      });
 
-    const successfulGetAppletManagersMock = mockSuccessfulHttpResponse<ManagersData>({
+    const successfulGetAppletManagersMock = mockSuccessfulHttpResponse<WorkspaceManagersResponse>({
       result: [mockedOwnerManager],
       count: 1,
     });
@@ -283,8 +286,8 @@ describe('Dashboard > Applet > Participant > Activities screen', () => {
         [getAppletSubjectActivitiesUrl]: successfulGetAppletSubjectActivitiesMock,
         [getWorkspaceRespondentsUrl]: (params) => {
           if (params.userId === mockedOwnerParticipant.id) {
-            return mockSuccessfulHttpResponse<ParticipantsData>({
-              result: [mockedOwnerParticipant],
+            return mockSuccessfulHttpResponse<WorkspaceRespondentsResponse>({
+              result: [mockedOwnerParticipantWithDataAccess],
               count: 1,
             });
           }

--- a/src/modules/Dashboard/features/Participant/Assignments/AboutParticipant/AboutParticipant.test.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/AboutParticipant/AboutParticipant.test.tsx
@@ -143,9 +143,6 @@ const preloadedState: (role?: Roles) => PreloadedState<RootState> = (role) => ({
   ...getPreloadedState(role),
   users: {
     respondentDetails: mockSchema(null),
-    allRespondents: mockSchema(null, {
-      status: 'idle',
-    }),
     subjectDetails: mockSchema({
       result: mockedOwnerSubjectWithDataAccess,
     }),

--- a/src/modules/Dashboard/features/Participant/Assignments/AssignmentsTab/AssignmentsTab.hooks.test.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/AssignmentsTab/AssignmentsTab.hooks.test.tsx
@@ -4,7 +4,12 @@ import { PreloadedState } from '@reduxjs/toolkit';
 import { Button } from '@mui/material';
 import userEvent from '@testing-library/user-event';
 
-import { ApiResponseCodes, ParticipantActivityOrFlow } from 'api';
+import {
+  ApiResponseCodes,
+  ParticipantActivityOrFlow,
+  WorkspaceManagersResponse,
+  WorkspaceRespondentsResponse,
+} from 'api';
 import { page } from 'resources';
 import { Roles } from 'shared/consts';
 import {
@@ -12,15 +17,16 @@ import {
   mockParticipantActivities,
   mockedAppletData,
   mockedAppletId,
-  mockedLimitedParticipant,
   mockedLimitedSubject,
   mockedOwnerId,
   mockedOwnerManager,
   mockedOwnerParticipant,
   mockedOwnerSubject,
-  mockedFullParticipant1,
   mockedFullSubject1,
   mockedOwnerSubjectWithDataAccess,
+  mockedOwnerParticipantWithDataAccess,
+  mockedFullParticipant1WithDataAccess,
+  mockedLimitedParticipantWithDataAccess,
 } from 'shared/mock';
 import { getPreloadedState } from 'shared/tests/getPreloadedState';
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
@@ -31,8 +37,6 @@ import {
 } from 'shared/utils/axios-mocks';
 import { RootState } from 'redux/store';
 import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
-import { ParticipantsData } from 'modules/Dashboard/features/Participants';
-import { ManagersData } from 'modules/Dashboard/features/Managers';
 import {
   openTakeNowModal,
   sourceSubjectDropdownTestId,
@@ -83,9 +87,6 @@ const preloadedState: PreloadedState<RootState> = {
   ...getPreloadedState(),
   users: {
     respondentDetails: mockSchema(null),
-    allRespondents: mockSchema(null, {
-      status: 'idle',
-    }),
     subjectDetails: mockSchema({
       result: mockedOwnerSubjectWithDataAccess,
     }),
@@ -186,20 +187,20 @@ describe('useAssignmentsTab hook', () => {
       [GET_APPLET_ACTIVITIES_URL]: successfulGetAppletActivitiesMock,
       [GET_WORKSPACE_RESPONDENTS_URL]: ({ userId }) => {
         const respondents = [
-          mockedOwnerParticipant,
-          mockedFullParticipant1,
-          mockedLimitedParticipant,
+          mockedOwnerParticipantWithDataAccess,
+          mockedFullParticipant1WithDataAccess,
+          mockedLimitedParticipantWithDataAccess,
         ];
         const filteredRespondents = userId
           ? respondents.filter((r) => r.id === userId)
           : respondents;
 
-        return mockSuccessfulHttpResponse<ParticipantsData>({
+        return mockSuccessfulHttpResponse<WorkspaceRespondentsResponse>({
           result: filteredRespondents,
           count: filteredRespondents.length,
         });
       },
-      [GET_WORKSPACE_MANAGERS_URL]: mockSuccessfulHttpResponse<ManagersData>({
+      [GET_WORKSPACE_MANAGERS_URL]: mockSuccessfulHttpResponse<WorkspaceManagersResponse>({
         result: [mockedOwnerManager],
         count: 1,
       }),

--- a/src/modules/Dashboard/features/Participant/Assignments/AssignmentsTab/AssignmentsTab.hooks.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/AssignmentsTab/AssignmentsTab.hooks.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { generatePath, useNavigate } from 'react-router-dom';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { Activity, applet, workspaces } from 'redux/modules';
 import { useAsync, useEncryptionStorage, useFeatureFlags } from 'shared/hooks';
@@ -16,7 +16,6 @@ import {
 } from 'shared/utils';
 import {
   ActivityAssignmentStatus,
-  getAppletActivitiesApi,
   getAppletParticipantActivitiesMetadataApi,
   ParticipantActivityOrFlow,
   ParticipantActivityOrFlowMetadata,
@@ -32,6 +31,7 @@ import { useTakeNowModal } from 'modules/Dashboard/components/TakeNowModal/TakeN
 import { ActivityAssignDrawer, ActivityUnassignDrawer } from 'modules/Dashboard/components';
 import { EditablePerformanceTasks } from 'modules/Builder/features/Activities/Activities.const';
 import { SubjectDetails } from 'modules/Dashboard/types';
+import { useGetAppletActivitiesQuery } from 'modules/Dashboard/api/apiSlice';
 
 import { GetActionsMenuParams, UseAssignmentsTabProps } from './AssignmentsTab.types';
 
@@ -67,12 +67,13 @@ export const useAssignmentsTab = ({
   // TODO: We only call getAppletActivitiesApi because we need full items data for each activity.
   // Remove this and associated effect below after supportedPlatforms prop is returned by API.
   // https://mindlogger.atlassian.net/browse/M2-7906
-  const { execute: fetchActivities, value: fetchedActivities } = useAsync(getAppletActivitiesApi, {
-    retainValue: true,
-  });
+  const { data: fetchedActivities } = useGetAppletActivitiesQuery(
+    { params: { appletId: appletId as string } },
+    { skip: !appletId },
+  );
 
   const activities: Activity[] = useMemo(
-    () => fetchedActivities?.data?.result.activitiesDetails ?? [],
+    () => fetchedActivities?.activitiesDetails ?? [],
     [fetchedActivities],
   );
 
@@ -94,12 +95,6 @@ export const useAssignmentsTab = ({
       ),
     [metadata?.data.result.activitiesOrFlows],
   );
-
-  useEffect(() => {
-    if (!appletId) return;
-
-    fetchActivities({ params: { appletId } });
-  }, [appletId, fetchActivities]);
 
   const handleCloseDrawer = (shouldRefetch?: boolean) => {
     setShowActivityAssign(false);

--- a/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ByParticipant.test.tsx
+++ b/src/modules/Dashboard/features/Participant/Assignments/ByParticipant/ByParticipant.test.tsx
@@ -167,9 +167,6 @@ const preloadedState: (role?: Roles) => PreloadedState<RootState> = (role) => ({
   ...getPreloadedState(role),
   users: {
     respondentDetails: mockSchema(null),
-    allRespondents: mockSchema(null, {
-      status: 'idle',
-    }),
     subjectDetails: mockSchema({
       result: mockedOwnerSubjectWithDataAccess,
     }),

--- a/src/modules/Dashboard/features/Participants/Participants.test.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.test.tsx
@@ -67,7 +67,9 @@ const mockUseFeatureFlags = jest.mocked(useFeatureFlags);
 const RESPONDENTS_ENDPOINT = `/workspaces/${mockedOwnerId}/applets/${mockedAppletId}/respondents`;
 // Mock responses for requests made both by Participants table and ActivityAssignDrawer
 const mockedResponses = {
-  [`/activities/applet/${mockedAppletId}`]: mockSuccessfulHttpResponse({ result: [] }),
+  [`/activities/applet/${mockedAppletId}`]: mockSuccessfulHttpResponse({
+    result: { activitiesDetails: [], appletDetail: mockedApplet },
+  }),
   [`/workspaces/${mockedOwnerId}/applets/${mockedAppletId}/managers`]: mockSuccessfulHttpResponse({
     result: [],
   }),
@@ -323,15 +325,17 @@ describe('Participants component tests', () => {
     searchInput && fireEvent.change(searchInput, { target: { value: mockedSearchValue } });
 
     await waitFor(() => {
-      expect(mockAxios.get).toHaveBeenCalledWith(RESPONDENTS_ENDPOINT, {
-        params: {
-          limit: 20,
-          page: 1,
-          search: mockedSearchValue,
-          ordering: '-isPinned,+tags',
-        },
-        signal: undefined,
-      });
+      expect(mockAxios.get).toHaveBeenCalledWith(
+        RESPONDENTS_ENDPOINT,
+        expect.objectContaining({
+          params: {
+            limit: 20,
+            page: 1,
+            search: mockedSearchValue,
+            ordering: '-isPinned,+tags',
+          },
+        }),
+      );
     });
   });
 });

--- a/src/modules/Dashboard/features/Participants/Participants.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.tsx
@@ -290,10 +290,9 @@ export const Participants = () => {
     updateSubjectsPin({ ownerId, userId: subjectId });
   };
 
-  const addParticipantOnClose = (shouldRefetch: boolean) => {
+  const addParticipantOnClose = () => {
     handleToggleAddParticipant();
     setChosenAppletData(null);
-    shouldRefetch && handleReload();
   };
 
   const editRespondentOnClose = () => {
@@ -306,10 +305,9 @@ export const Participants = () => {
     setChosenAppletData(null);
   };
 
-  const handleUpgradeAccountPopupClose = (shouldRefetch?: boolean) => {
+  const handleUpgradeAccountPopupClose = () => {
     setInvitationPopupVisible(false);
     setParticipantDetails(null);
-    shouldRefetch && handleReload();
   };
 
   const formatRow = (user: ParticipantWithDataAccess): Row => {

--- a/src/modules/Dashboard/features/Participants/Participants.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.tsx
@@ -28,6 +28,8 @@ import {
 } from 'modules/Dashboard/components';
 import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 import { useLazyGetWorkspaceRespondentsQuery } from 'modules/Dashboard/api/apiSlice';
+import { useAppDispatch } from 'redux/store';
+import { apiSlice } from 'shared/api/apiSlice';
 
 import { AddParticipantButton, ParticipantsTable } from './Participants.styles';
 import {
@@ -59,6 +61,7 @@ export const Participants = () => {
   const timeAgo = useTimeAgo();
   const { featureFlags } = useFeatureFlags();
   const [showActivityAssign, setShowActivityAssign] = useState(false);
+  const dispatch = useAppDispatch();
 
   const rolesData = workspaces.useRolesData();
   const roles = appletId ? rolesData?.data?.[appletId] : undefined;
@@ -92,6 +95,9 @@ export const Participants = () => {
     useLazyGetWorkspaceRespondentsQuery();
 
   const getWorkspaceRespondents = (args?: GetAppletsParams) => {
+    // Keep cache in sync with any changes to participants to ensure lists are all aligned
+    dispatch(apiSlice.util.invalidateTags([{ type: 'Subject', id: 'LIST' }]));
+
     // Always sort by pinned first
     const ordering = ['-isPinned'];
     ordering.push(args?.params.ordering ?? '+tags,+secretIds');

--- a/src/modules/Dashboard/features/Participants/Participants.tsx
+++ b/src/modules/Dashboard/features/Participants/Participants.tsx
@@ -296,16 +296,14 @@ export const Participants = () => {
     shouldRefetch && handleReload();
   };
 
-  const editRespondentOnClose = (shouldRefetch: boolean) => {
+  const editRespondentOnClose = () => {
     setEditRespondentPopupVisible(false);
     setChosenAppletData(null);
-    shouldRefetch && handleReload();
   };
 
-  const removeRespondentAccessOnClose = (shouldRefetch?: boolean) => {
+  const removeRespondentAccessOnClose = () => {
     setRemoveAccessPopupVisible(false);
     setChosenAppletData(null);
-    shouldRefetch && handleReload();
   };
 
   const handleUpgradeAccountPopupClose = (shouldRefetch?: boolean) => {

--- a/src/modules/Dashboard/features/Participants/Participants.types.ts
+++ b/src/modules/Dashboard/features/Participants/Participants.types.ts
@@ -1,9 +1,4 @@
-import {
-  Participant,
-  ParticipantDetail,
-  ParticipantStatus,
-  ParticipantWithDataAccess,
-} from 'modules/Dashboard/types';
+import { ParticipantDetail, ParticipantStatus } from 'modules/Dashboard/types';
 import { MenuActionProps } from 'shared/components';
 import { ParticipantTag, Roles } from 'shared/consts';
 import { Encryption } from 'shared/utils';
@@ -53,16 +48,6 @@ export type FilteredApplets = Record<FilteredAppletsKey, ParticipantDetail[]>;
 
 export type FilteredParticipants = {
   [key: string]: FilteredApplets;
-};
-
-export type ParticipantsData = {
-  result: Participant[];
-  count: number;
-  orderingFields?: string[];
-};
-
-export type ParticipantsDataWithDataAccess = Omit<ParticipantsData, 'result'> & {
-  result: ParticipantWithDataAccess[];
 };
 
 export type GetParticipantActionsProps = {

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.test.tsx
@@ -10,8 +10,6 @@ import {
   mockedApplet,
   mockedAppletId,
   mockedCurrentWorkspace,
-  mockedFullParticipant1,
-  mockedFullParticipant2,
   mockedFullSubjectId1,
 } from 'shared/mock';
 import { DateFormats, Roles, JEST_TEST_TIMEOUT, MAX_LIMIT, ParticipantTag } from 'shared/consts';
@@ -51,13 +49,6 @@ const preloadedState: PreloadedState<RootState> = {
     },
   },
   users: {
-    allRespondents: {
-      ...initialStateData,
-      data: {
-        result: [mockedFullParticipant1, mockedFullParticipant2],
-        count: 2,
-      },
-    },
     subjectDetails: {
       ...initialStateData,
       data: {

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewMenu/ReviewMenu.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/ReviewMenu/ReviewMenu.test.tsx
@@ -5,13 +5,7 @@ import { PreloadedState } from '@reduxjs/toolkit';
 
 import { page } from 'resources';
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
-import {
-  mockedAppletId,
-  mockedCurrentWorkspace,
-  mockedFullParticipant1,
-  mockedFullParticipant2,
-  mockedFullSubjectId1,
-} from 'shared/mock';
+import { mockedAppletId, mockedCurrentWorkspace, mockedFullSubjectId1 } from 'shared/mock';
 import { ParticipantTag, Roles } from 'shared/consts';
 import { initialStateData } from 'shared/state';
 import { RootState } from 'redux/store';
@@ -39,13 +33,6 @@ const preloadedState: PreloadedState<RootState> = {
     workspacesRoles: initialStateData,
   },
   users: {
-    allRespondents: {
-      ...initialStateData,
-      data: {
-        result: [mockedFullParticipant1, mockedFullParticipant2],
-        count: 2,
-      },
-    },
     respondentDetails: {
       ...initialStateData,
     },

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/ReportMenu/StickyHeader/StickyHeader.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/ReportMenu/StickyHeader/StickyHeader.test.tsx
@@ -13,11 +13,6 @@ import { StickyHeader } from './StickyHeader';
 const preloadedState = {
   ...getPreloadedState(),
   users: {
-    allRespondents: {
-      data: {
-        result: [],
-      },
-    },
     subjectDetails: {
       ...initialStateData,
       data: {

--- a/src/modules/Dashboard/features/Respondents/Popups/EditRespondentPopup/EditRespondentPopup.test.tsx
+++ b/src/modules/Dashboard/features/Respondents/Popups/EditRespondentPopup/EditRespondentPopup.test.tsx
@@ -97,6 +97,8 @@ describe('EditRespondentPopup component tests', () => {
       nickname: 'respondentNickname',
       lastSeen: null,
       tag: chosenAppletData.subjectTag,
+      firstName: null,
+      lastName: null,
     };
 
     mockAxios.put.mockResolvedValueOnce({
@@ -193,7 +195,7 @@ describe('EditRespondentPopup component tests', () => {
           secretUserId: chosenAppletData.respondentSecretId,
           tag: 'Parent',
         },
-        { signal: undefined },
+        { signal: expect.anything() },
       );
     });
   });

--- a/src/modules/Dashboard/features/Respondents/Popups/EditRespondentPopup/EditRespondentPopup.types.ts
+++ b/src/modules/Dashboard/features/Respondents/Popups/EditRespondentPopup/EditRespondentPopup.types.ts
@@ -10,6 +10,6 @@ export type EditRespondentForm = {
 
 export type EditRespondentPopupProps = {
   popupVisible: boolean;
-  onClose: (isSuccessVisible: boolean) => void;
+  onClose: () => void;
   chosenAppletData: ChosenAppletData | null;
 };

--- a/src/modules/Dashboard/features/Respondents/Popups/RemoveRespondentPopup/RemoveRespondentPopup.test.tsx
+++ b/src/modules/Dashboard/features/Respondents/Popups/RemoveRespondentPopup/RemoveRespondentPopup.test.tsx
@@ -4,6 +4,7 @@ import mockAxios from 'jest-mock-axios';
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
 import { mockedAppletId, mockedFullSubjectId1 } from 'shared/mock';
 import { page } from 'resources';
+import { mockSuccessfulHttpResponse } from 'shared/utils/axios-mocks';
 
 import { RemoveRespondentPopup } from '.';
 
@@ -63,8 +64,8 @@ describe('RemoveRespondentPopup component tests', () => {
   });
 
   test('RemoveRespondentPopup should remove access with appletId', async () => {
-    mockAxios.post.mockResolvedValueOnce(null);
-    mockAxios.delete.mockResolvedValueOnce(null);
+    mockAxios.post.mockResolvedValueOnce(mockSuccessfulHttpResponse(null));
+    mockAxios.delete.mockResolvedValueOnce(mockSuccessfulHttpResponse(null));
 
     renderWithProviders(<RemoveRespondentPopup {...commonProps} />, {
       route,

--- a/src/modules/Dashboard/features/Respondents/Popups/RemoveRespondentPopup/RemoveRespondentPopup.tsx
+++ b/src/modules/Dashboard/features/Respondents/Popups/RemoveRespondentPopup/RemoveRespondentPopup.tsx
@@ -5,10 +5,10 @@ import { Checkbox, FormControlLabel } from '@mui/material';
 
 import { Modal, EnterAppletPassword } from 'shared/components';
 import { StyledModalWrapper, StyledBodyLarge, theme } from 'shared/styles';
-import { deleteSubjectApi } from 'api';
-import { useSetupEnterAppletPassword, useAsync } from 'shared/hooks';
+import { useSetupEnterAppletPassword } from 'shared/hooks';
 import { workspaces } from 'redux/modules';
 import { isManagerOrOwner, toggleBooleanState } from 'shared/utils';
+import { useDeleteSubjectMutation } from 'modules/Dashboard/api/apiSlice';
 
 import { AppletsSmallTable } from '../../AppletsSmallTable';
 import { RemoveRespondentPopupProps, Steps } from './RemoveRespondentPopup.types';
@@ -49,11 +49,7 @@ export const RemoveRespondentPopup = ({
     return getStep('next');
   };
 
-  const {
-    execute: handleSubjectDelete,
-    error,
-    isLoading,
-  } = useAsync(deleteSubjectApi, deleteSubjectCallback, deleteSubjectCallback);
+  const [deleteSubject, { error, isLoading }] = useDeleteSubjectMutation();
 
   const isRemoved = !error;
   const isFirstStepWithAppletId = !!appletId && step === 1;
@@ -123,10 +119,12 @@ export const RemoveRespondentPopup = ({
     const { subjectId } = chosenAppletData || {};
     if (!subjectId) return;
 
-    await handleSubjectDelete({
+    await deleteSubject({
       subjectId,
       deleteAnswers: removeData,
     });
+
+    deleteSubjectCallback();
   };
 
   const screens = getScreens({

--- a/src/modules/Dashboard/features/Respondents/Popups/RemoveRespondentPopup/RemoveRespondentPopup.types.ts
+++ b/src/modules/Dashboard/features/Respondents/Popups/RemoveRespondentPopup/RemoveRespondentPopup.types.ts
@@ -5,7 +5,7 @@ export type RemoveRespondentPopupProps = {
   popupVisible: boolean;
   tableRows: Row[] | undefined;
   chosenAppletData: ChosenAppletData | null;
-  onClose: (shouldReFetch?: boolean) => void;
+  onClose: () => void;
 };
 
 export type GetScreen = (respondentName: string, appletName: string) => JSX.Element;
@@ -22,7 +22,7 @@ export type ScreensParams = {
   isRemoved: boolean;
   submitPassword: () => void;
   removeAccess: () => void;
-  onClose: (shouldReFetch?: boolean) => void;
+  onClose: () => void;
 };
 
 export type Screen = {

--- a/src/modules/Dashboard/features/Respondents/Popups/RemoveRespondentPopup/RemoveRespondentPopup.utils.tsx
+++ b/src/modules/Dashboard/features/Respondents/Popups/RemoveRespondentPopup/RemoveRespondentPopup.utils.tsx
@@ -105,8 +105,6 @@ export const getScreens = ({
   removeAccess,
   onClose,
 }: ScreensParams): Screen[] => {
-  const onCloseHandler = () => onClose(true);
-
   const getResultScreen = (
     getSuccessScreen: GetScreen,
     getErrorScreen: GetScreen,
@@ -118,8 +116,8 @@ export const getScreens = ({
           buttonText: 'ok',
           hasSecondBtn: false,
           title,
-          submitForm: onCloseHandler,
-          onClose: onCloseHandler,
+          submitForm: onClose,
+          onClose,
         }
       : {
           component: getErrorScreen(respondentName, appletName),

--- a/src/modules/Dashboard/features/Respondents/Popups/SendInvitationPopup/SendInvitationPopup.test.tsx
+++ b/src/modules/Dashboard/features/Respondents/Popups/SendInvitationPopup/SendInvitationPopup.test.tsx
@@ -55,7 +55,7 @@ describe('SendInvitationPopup', () => {
         1,
         `/invitations/${mockedAppletId}/subject`,
         { email: mockedEmail, subjectId: mockedFullSubjectId1 },
-        { signal: undefined },
+        { signal: expect.anything() },
       );
     });
   });
@@ -76,7 +76,7 @@ describe('SendInvitationPopup', () => {
         1,
         `/invitations/${mockedAppletId}/subject`,
         { email: mockedEmail, subjectId: mockedFullSubjectId1 },
-        { signal: undefined },
+        { signal: expect.anything() },
       );
     });
   });

--- a/src/modules/Dashboard/features/Respondents/Popups/SendInvitationPopup/SendInvitationPopup.tsx
+++ b/src/modules/Dashboard/features/Respondents/Popups/SendInvitationPopup/SendInvitationPopup.tsx
@@ -6,10 +6,9 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { Modal, Spinner, SpinnerUiType } from 'shared/components';
 import { StyledBodyLarge, StyledModalWrapper, theme, variables } from 'shared/styles';
 import { getErrorMessage, Mixpanel, MixpanelEventType } from 'shared/utils';
-import { useAsync } from 'shared/hooks/useAsync';
-import { postSubjectInvitationApi } from 'api';
 import { InputController } from 'shared/components/FormComponents';
 import { useFormError } from 'modules/Dashboard/hooks';
+import { useCreateSubjectInvitationMutation } from 'modules/Dashboard/api/apiSlice';
 
 import { AppletsSmallTable } from '../../AppletsSmallTable';
 import { SendInvitationForm, SendInvitationPopupProps } from './SendInvitationPopup.types';
@@ -33,21 +32,23 @@ export const SendInvitationPopup = ({
     defaultValues: { email: email || '' },
   });
 
-  const { execute, error, isLoading } = useAsync(postSubjectInvitationApi, () => {
-    setChosenAppletData(null);
-    onClose(true);
-  });
+  const [execute, { error, isLoading }] = useCreateSubjectInvitationMutation();
 
   const handlePopupClose = () => {
     setChosenAppletData(null);
-    onClose(false);
+    onClose();
   };
 
-  const submitForm = () => {
+  const submitForm = async () => {
     if (!appletId || !subjectId) return;
     Mixpanel.track({ action: MixpanelEventType.SubjectInvitationClick });
     setHasCommonError(false);
-    execute({ appletId, subjectId, email: getValues('email') });
+
+    const response = await execute({ appletId, subjectId, email: getValues('email') });
+
+    if ('data' in response) {
+      handlePopupClose();
+    }
   };
 
   const getTitle = () => {

--- a/src/modules/Dashboard/features/Respondents/Popups/SendInvitationPopup/SendInvitationPopup.types.ts
+++ b/src/modules/Dashboard/features/Respondents/Popups/SendInvitationPopup/SendInvitationPopup.types.ts
@@ -6,7 +6,7 @@ import { ChosenAppletData } from '../../Respondents.types';
 
 export type SendInvitationPopupProps = {
   popupVisible: boolean;
-  onClose: (shouldReFetch: boolean) => void;
+  onClose: () => void;
   tableRows?: Row[];
   chosenAppletData: ChosenAppletData | null;
   setChosenAppletData: Dispatch<SetStateAction<ChosenAppletData | null>>;

--- a/src/modules/Dashboard/features/Respondents/Respondents.test.tsx
+++ b/src/modules/Dashboard/features/Respondents/Respondents.test.tsx
@@ -215,15 +215,14 @@ describe('Respondents component tests', () => {
     await waitFor(() => {
       expect(mockAxios.get).toHaveBeenLastCalledWith(
         `/workspaces/${mockedOwnerId}/applets/${mockedAppletId}/respondents`,
-        {
+        expect.objectContaining({
           params: {
             limit: 20,
             page: 1,
             search: mockedSearchValue,
             ordering: '-isPinned,+tags',
           },
-          signal: undefined,
-        },
+        }),
       );
     });
   });

--- a/src/modules/Dashboard/features/Respondents/Respondents.tsx
+++ b/src/modules/Dashboard/features/Respondents/Respondents.tsx
@@ -277,16 +277,14 @@ export const Respondents = () => {
     updateSubjectsPin({ ownerId, userId: subjectId });
   };
 
-  const editRespondentOnClose = (shouldReFetch: boolean) => {
+  const editRespondentOnClose = () => {
     setEditRespondentPopupVisible(false);
     setChosenAppletData(null);
-    shouldReFetch && handleReload();
   };
 
-  const removeRespondentAccessOnClose = (shouldReFetch?: boolean) => {
+  const removeRespondentAccessOnClose = () => {
     setRemoveAccessPopupVisible(false);
     setChosenAppletData(null);
-    shouldReFetch && handleReload();
   };
 
   const handleInvitationPopupClose = (shouldReFetch?: boolean) => {

--- a/src/modules/Dashboard/features/Respondents/Respondents.tsx
+++ b/src/modules/Dashboard/features/Respondents/Respondents.tsx
@@ -287,10 +287,9 @@ export const Respondents = () => {
     setChosenAppletData(null);
   };
 
-  const handleInvitationPopupClose = (shouldReFetch?: boolean) => {
+  const handleInvitationPopupClose = () => {
     setInvitationPopupVisible(false);
     setRespondentEmail(null);
-    shouldReFetch && handleReload();
   };
 
   const formatRow = (user: Participant): Row => {

--- a/src/modules/Dashboard/hooks/useFormError.ts
+++ b/src/modules/Dashboard/hooks/useFormError.ts
@@ -1,12 +1,14 @@
 import { Dispatch, ReactNode, SetStateAction, useEffect } from 'react';
 import { FieldValues, Path, UseFormSetError } from 'react-hook-form';
 import { AxiosError } from 'axios';
+import { FetchBaseQueryError } from '@reduxjs/toolkit/query';
+import { SerializedError } from '@reduxjs/toolkit';
 
 import { ApiError, ApiErrorResponse } from 'shared/state';
 import { getErrorData, getErrorMessage } from 'shared/utils';
 
 type UseFormError<T extends FieldValues> = {
-  error: AxiosError<ApiErrorResponse> | null;
+  error?: AxiosError<ApiErrorResponse> | FetchBaseQueryError | SerializedError | null;
   setError: UseFormSetError<T>;
   setHasCommonError: Dispatch<SetStateAction<boolean>>;
   fields: Record<string, string>;

--- a/src/modules/Dashboard/state/Users/Users.reducer.ts
+++ b/src/modules/Dashboard/state/Users/Users.reducer.ts
@@ -4,23 +4,9 @@ import { getPendingData, getFulfilledData, getRejectedData } from 'shared/utils/
 
 import { state as initialState } from './Users.state';
 import { UsersSchema } from './Users.schema';
-import { getAllWorkspaceRespondents, getRespondentDetails, getSubjectDetails } from './Users.thunk';
+import { getRespondentDetails, getSubjectDetails } from './Users.thunk';
 
 export const extraReducers = (builder: ActionReducerMapBuilder<UsersSchema>): void => {
-  getPendingData({ builder, thunk: getAllWorkspaceRespondents, key: 'allRespondents' });
-  getFulfilledData({
-    builder,
-    thunk: getAllWorkspaceRespondents,
-    key: 'allRespondents',
-    initialState,
-  });
-  getRejectedData({
-    builder,
-    thunk: getAllWorkspaceRespondents,
-    key: 'allRespondents',
-    initialState,
-  });
-
   getPendingData({ builder, thunk: getRespondentDetails, key: 'respondentDetails' });
   getFulfilledData({
     builder,

--- a/src/modules/Dashboard/state/Users/Users.schema.ts
+++ b/src/modules/Dashboard/state/Users/Users.schema.ts
@@ -1,8 +1,7 @@
 import { BaseSchema } from 'shared/state/Base';
-import { Participant, SubjectDetails, SubjectDetailsWithDataAccess } from 'modules/Dashboard/types';
+import { SubjectDetails, SubjectDetailsWithDataAccess } from 'modules/Dashboard/types';
 
 export type UsersSchema = {
-  allRespondents: BaseSchema<{ result: Participant[]; count: number } | null>;
   respondentDetails: BaseSchema<{ result: SubjectDetails } | null>;
   subjectDetails: BaseSchema<{ result: SubjectDetailsWithDataAccess } | null>;
 };

--- a/src/modules/Dashboard/state/Users/Users.state.ts
+++ b/src/modules/Dashboard/state/Users/Users.state.ts
@@ -3,7 +3,6 @@ import { initialStateData } from 'shared/state';
 import { UsersSchema } from './Users.schema';
 
 export const state: UsersSchema = {
-  allRespondents: initialStateData,
   respondentDetails: initialStateData,
   subjectDetails: initialStateData,
 };

--- a/src/modules/Dashboard/state/Users/Users.thunk.ts
+++ b/src/modules/Dashboard/state/Users/Users.thunk.ts
@@ -3,33 +3,12 @@ import { AxiosError } from 'axios';
 
 import { ApiErrorResponse } from 'shared/state/Base';
 import {
-  getWorkspaceRespondentsApi,
-  GetAppletsParams,
   getRespondentDetailsApi,
   GetRespondentDetailsParams,
   SubjectId,
   getSubjectDetailsApi,
 } from 'api';
-import { MAX_LIMIT } from 'shared/consts';
 import { getApiErrorResult } from 'shared/utils/errors';
-
-export const getAllWorkspaceRespondents = createAsyncThunk(
-  'users/getAllWorkspaceRespondents',
-  async ({ params }: GetAppletsParams, { rejectWithValue, signal }) => {
-    try {
-      const { data } = await getWorkspaceRespondentsApi(
-        { params: { ...params, limit: MAX_LIMIT } },
-        signal,
-      );
-
-      return { data };
-    } catch (exception) {
-      const errorResult = getApiErrorResult(exception as AxiosError<ApiErrorResponse>);
-
-      return rejectWithValue(errorResult);
-    }
-  },
-);
 
 export const getRespondentDetails = createAsyncThunk(
   'users/getRespondentDetails',

--- a/src/modules/Dashboard/state/Users/index.ts
+++ b/src/modules/Dashboard/state/Users/index.ts
@@ -20,22 +20,6 @@ export const users = {
   thunk,
   slice,
   actions: slice.actions,
-  useAllRespondentsData: (): UsersSchema['allRespondents']['data'] =>
-    useAppSelector(
-      ({
-        users: {
-          allRespondents: { data },
-        },
-      }) => data,
-    ),
-  useAllRespondentsStatus: (): UsersSchema['allRespondents']['status'] =>
-    useAppSelector(
-      ({
-        users: {
-          allRespondents: { status },
-        },
-      }) => status,
-    ),
   useRespondent: (): UsersSchema['respondentDetails']['data'] | undefined =>
     useAppSelector(
       ({

--- a/src/redux/store/reducers.ts
+++ b/src/redux/store/reducers.ts
@@ -13,6 +13,7 @@ import { reportConfig } from 'modules/Builder/state/ReportConfig';
 import { auth } from 'modules/Auth/state';
 import { workspaces } from 'shared/state/Workspaces';
 import { forbiddenState } from 'shared/state/ForbiddenState';
+import { apiSlice } from 'shared/api/apiSlice';
 
 export const rootReducer = combineReducers({
   alerts: alerts.slice.reducer,
@@ -28,4 +29,5 @@ export const rootReducer = combineReducers({
   users: users.slice.reducer,
   workspaces: workspaces.slice.reducer,
   forbiddenState: forbiddenState.slice.reducer,
+  [apiSlice.reducerPath]: apiSlice.reducer,
 });

--- a/src/redux/store/store.ts
+++ b/src/redux/store/store.ts
@@ -1,6 +1,8 @@
 import { PreloadedState, configureStore } from '@reduxjs/toolkit';
 import { RenderOptions } from '@testing-library/react';
 
+import { apiSlice } from 'shared/api/apiSlice';
+
 import { rootReducer } from './reducers';
 
 export const setupStore = (preloadedState?: PreloadedState<RootState>) =>
@@ -18,7 +20,7 @@ export const setupStore = (preloadedState?: PreloadedState<RootState>) =>
             /^calendarEvents\.(events\.data|processedEvents\.data\.eventsToShow)\.\d+\.end$/,
           ],
         },
-      }),
+      }).concat(apiSlice.middleware),
     preloadedState,
   });
 

--- a/src/shared/api/apiSlice.ts
+++ b/src/shared/api/apiSlice.ts
@@ -95,5 +95,5 @@ export const apiSlice = createApi({
   reducerPath: 'api',
   baseQuery: axiosBaseQuery,
   tagTypes: ['Applet', 'Subject', 'User'],
-  endpoints: (builder) => ({}),
+  endpoints: (_builder) => ({}),
 });

--- a/src/shared/api/apiSlice.ts
+++ b/src/shared/api/apiSlice.ts
@@ -1,0 +1,99 @@
+import { BaseQueryFn, createApi, FetchBaseQueryError } from '@reduxjs/toolkit/query/react';
+import { AxiosError, AxiosRequestConfig, Method } from 'axios';
+
+import { authApiClient } from './apiConfig';
+
+/**
+ * Base query adapter to allow RTK Query to use existing Axios infrastruction instead of fetch.
+ */
+const axiosBaseQuery: BaseQueryFn<
+  {
+    url: string;
+    method?: AxiosRequestConfig['method'];
+    body?: AxiosRequestConfig['data'];
+    params?: AxiosRequestConfig['params'];
+    headers?: AxiosRequestConfig['headers'];
+  },
+  unknown,
+  FetchBaseQueryError
+> = async ({ url, method: methodProp, body, params, headers }, { signal }) => {
+  // Choose the axios function based on the method prop, defaulting to get
+  const method = (methodProp?.toLowerCase() ?? 'get') as Lowercase<Method>;
+
+  try {
+    let promise;
+
+    // Use appropriate axios method to preserve support for mockAxios spies in unit tests
+    switch (method) {
+      case 'get':
+        promise = authApiClient.get(url, { params, headers, data: body, signal });
+        break;
+      case 'delete':
+        promise = authApiClient.delete(url, { params, headers, data: body, signal });
+        break;
+      case 'head':
+        promise = authApiClient.head(url, { params, headers, data: body, signal });
+        break;
+      case 'options':
+        promise = authApiClient.options(url, { params, headers, data: body, signal });
+        break;
+      case 'post':
+        promise = authApiClient.post(url, body, { params, headers, signal });
+        break;
+      case 'put':
+        promise = authApiClient.put(url, body, { params, headers, signal });
+        break;
+      case 'patch':
+        promise = authApiClient.patch(url, body, { params, headers, signal });
+        break;
+      default:
+        promise = authApiClient.request({ url, method, data: body, params, headers, signal });
+    }
+
+    const returnVal = await promise;
+
+    // TODO: Some unit tests currently mock an incorrect return type ({ payload: … }), so to
+    // allow them to continue passing, we need to implement a workaround. Eventually unit tests
+    // should be fixed to mock Axios calls correctly.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const innerResponse = (returnVal as any).payload?.response;
+    if (innerResponse?.status >= 400) {
+      const error = new Error() as AxiosError;
+      error.status = innerResponse.status;
+      error.response = innerResponse;
+      throw error;
+    }
+
+    return {
+      data: returnVal.data,
+      meta: {
+        response: {
+          status: returnVal.status,
+          headers: returnVal.headers,
+        },
+      },
+    };
+  } catch (axiosError) {
+    const { response, message } = axiosError as AxiosError;
+
+    return {
+      error: {
+        status: response?.status,
+        data: response?.data ?? message,
+      } as FetchBaseQueryError,
+      meta: {
+        response: {
+          status: response?.status,
+          headers: response?.headers,
+        },
+      },
+    };
+  }
+};
+
+export const apiSlice = createApi({
+  reducerPath: 'api',
+  baseQuery: axiosBaseQuery,
+  tagTypes: ['Applet', 'Subject', 'User'],
+  endpoints: (builder) => ({}),
+});

--- a/src/shared/components/Pin/Pin.styles.tsx
+++ b/src/shared/components/Pin/Pin.styles.tsx
@@ -18,13 +18,13 @@ export const StyledPinButton = styled(Button, shouldForwardProp)`
   :focus {
     background: ${variables.palette.on_surface_variant_alfa8};
 
-    svg {
+    && svg {
       fill: ${({ isPinned = false }: { isPinned?: boolean }) =>
         isPinned ? variables.palette.on_surface_variant : variables.palette.outline_variant};
     }
   }
 
-  svg {
+  && svg {
     fill: ${({ isPinned = false }: { isPinned?: boolean }) =>
       isPinned ? variables.palette.on_surface_variant : variables.palette.surface_variant};
   }

--- a/src/shared/hooks/useAsync/useAsync.ts
+++ b/src/shared/hooks/useAsync/useAsync.ts
@@ -14,6 +14,11 @@ import {
 /**
  * Utility hook to handle async operations with loading state, error state, and callbacks.
  *
+ * @deprecated This is legacy code used for handling API calls, but notably lacks caching support
+ * and uses awkward syntax that requires bulky code in components. From now on, please use RTK Query
+ * querying and mutation functions, found in `apiSlice.ts` files corresponding to each module.
+ * Use of this hook is now discouraged and existing usage will be replaced over time.
+ *
  * @param asyncFunction Async function to be called
  * @param options Options object with the following properties:
  * - `successCallback`: Callback to be called on success

--- a/src/shared/hooks/usePermissions.tsx
+++ b/src/shared/hooks/usePermissions.tsx
@@ -22,8 +22,8 @@ export const usePermissions = (
 
   const handlePermissionCheck = (response: FunctionResponse) => {
     if (
-      response?.response?.status === ApiResponseCodes.Forbidden ||
-      response?.status === ApiResponseCodes.Forbidden ||
+      ('status' in response && response.status === ApiResponseCodes.Forbidden) ||
+      ('response' in response && response.response?.status === ApiResponseCodes.Forbidden) ||
       (Array.isArray(response) &&
         response.some((data) => data.type === ErrorResponseType.AccessDenied))
     ) {
@@ -39,9 +39,9 @@ export const usePermissions = (
     (async () => {
       try {
         setIsLoading(true);
-        const { payload } = await asyncFunc();
+        const { payload, error } = await asyncFunc();
 
-        handlePermissionCheck(payload);
+        handlePermissionCheck(error ?? payload);
       } catch (error) {
         handlePermissionCheck(error as FunctionResponse);
       } finally {

--- a/src/shared/mock.ts
+++ b/src/shared/mock.ts
@@ -276,6 +276,30 @@ export const mockedFullParticipant1WithDataAccess: ParticipantWithDataAccess = {
 
 export const mockedFullParticipantId2 = 'b60a142d-2b7f-4328-841c-ddsdddj4afcf1c7';
 export const mockedFullSubjectId2 = 'subject-id-123';
+
+export const mockedFullParticipant2Details: ParticipantDetail = {
+  appletId: mockedAppletId,
+  appletDisplayName: 'Mocked Applet',
+  appletImage: '',
+  accessId: 'aebf08ab-c781-4229-a625-271838ebdff4',
+  respondentNickname: 'Test Respondent',
+  respondentSecretId: 'testSecretId',
+  hasIndividualSchedule: false,
+  encryption: mockedEncryption,
+  subjectId: mockedFullSubjectId2,
+  subjectTag: 'Child' as ParticipantTag,
+  subjectFirstName: 'John',
+  subjectLastName: 'Doe',
+  subjectCreatedAt: '2023-09-26T12:11:46.162083',
+  invitation: null,
+  roles: [Roles.Respondent],
+};
+
+export const mockedFullParticipant2DetailWithDataAccess: ParticipantDetailWithDataAccess = {
+  ...mockedFullParticipant2Details,
+  teamMemberCanViewData: true,
+};
+
 export const mockedFullParticipant2: Participant = {
   id: mockedFullParticipantId2,
   nicknames: ['Test Respondent'],
@@ -285,25 +309,12 @@ export const mockedFullParticipant2: Participant = {
   isPinned: false,
   status: ParticipantStatus.Invited,
   email: 'resp2@mail.com',
-  details: [
-    {
-      appletId: mockedAppletId,
-      appletDisplayName: 'Mocked Applet',
-      appletImage: '',
-      accessId: 'aebf08ab-c781-4229-a625-271838ebdff4',
-      respondentNickname: 'Test Respondent',
-      respondentSecretId: 'testSecretId',
-      hasIndividualSchedule: false,
-      encryption: mockedEncryption,
-      subjectId: mockedFullSubjectId2,
-      subjectTag: 'Child' as ParticipantTag,
-      subjectFirstName: 'John',
-      subjectLastName: 'Doe',
-      subjectCreatedAt: '2023-09-26T12:11:46.162083',
-      invitation: null,
-      roles: [Roles.Respondent],
-    },
-  ],
+  details: [mockedFullParticipant2Details],
+};
+
+export const mockedFullParticipant2WithDataAccess: ParticipantWithDataAccess = {
+  ...mockedFullParticipant2,
+  details: [mockedFullParticipant2DetailWithDataAccess],
 };
 
 export const mockedLimitedSubjectId = 'limited-subject-id-123';

--- a/src/shared/utils/errors.ts
+++ b/src/shared/utils/errors.ts
@@ -1,8 +1,9 @@
+import { FetchBaseQueryError } from '@reduxjs/toolkit/query';
 import axios, { AxiosResponse, AxiosError } from 'axios';
 
 import { ApiErrorResponse, ApiErrorReturn } from 'shared/state/Base';
 
-type ErrorData = Error | AxiosError<ApiErrorResponse> | unknown;
+type ErrorData = Error | AxiosError<ApiErrorResponse> | FetchBaseQueryError | unknown;
 
 export const isError = (error: unknown): error is Error => error instanceof Error;
 
@@ -15,6 +16,10 @@ export const getErrorData = (error: ErrorData) => {
     return error;
   } else if (typeof error === 'object') {
     const err = error as AxiosResponse;
+
+    if (err?.data?.result?.length) {
+      return err?.data?.result[0];
+    }
 
     return err?.data;
   }


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added
- [x] Related documentation has been added / updated

### 📝 Description

> [!IMPORTANT]
> As this is a chunky PR, I took time to meticulously organize the commits into related changes, along with detailed documentation in the form of commit messages, with the hopes that this will help reduce friction for reviewers. Thus, it's **highly recommended** to review [commit by commit](https://github.com/ChildMindInstitute/mindlogger-admin/pull/2021/commits).

🔗 Jira Ticket [M2-8618](https://mindlogger.atlassian.net/browse/M2-8618)

This PR begins the migration from `useAsync` and raw Axios mutation functions to [RTK Query](https://redux-toolkit.js.org/rtk-query/overview), which has been agreed upon as the new paradigm for making API calls in the Admin App.

See this Confluence doc for context:

- [**Improving Endpoint Caching in Admin App**](https://mindlogger.atlassian.net/wiki/spaces/MINDLOGGER1/pages/1036058625/Improving+Endpoint+Caching+in+Admin+App)

In this PR, these endpoints have been fully migrated over to RTK Query, as a sensible starting point for the ongoing overall migration to this framework:

- GET `activities/applet/${appletId}`
- GET `workspaces/${ownerId}/managers`
- GET `workspaces/${ownerId}/applets/${appletId}/managers`
- GET `workspaces/${ownerId}/respondents`
- GET `workspaces/${ownerId}/applets/${appletId}/respondents`
- POST `invitations/${appletId}/${url}`
- POST `invitations/${appletId}/subject`
- POST `invitations/${appletId}/shell-account`
- PUT `subjects/${subjectId}`
- DELETE `subjects/${subjectId}`

#### 👀 Other things worth noting:

- A [custom base query function](https://github.com/ChildMindInstitute/mindlogger-admin/blob/refactor/rtk-query/src/shared/api/apiSlice.ts#L9), `axiosBaseQuery`, has been written, allowing RTK Query to use `axios` instead of `fetch` for its HTTP requests (which it uses by default). Continuing to use `axios` for network requests allows unit tests to remain mostly unaffected by the migrated endpoints (preserving the use of `jest-mock-axios`), as well as the existing authentication stack to be used with no changes needed.
- The Redux infrastructure for `allRespondents`, which has acted as a rudimentary "cache" for participants used by a handful of components, is no longer needed with the migration to RTK Query, as the new querying infra provides the same functionality but more reliably and with more intuitive caching. So the infra related to that portion of Redux state has been removed.

### 🪤 Peer Testing

The app should remain **functionally the same** as before these changes, with the exception of improved performance (demoed <a href="https://mindlogger.atlassian.net/wiki/spaces/MINDLOGGER1/pages/1036058625/Improving+Endpoint+Caching+in+Admin+App#Fix-duplicated-API-Calls" rel="nofollow">here</a>) and a couple minor UX bugs fixed (demoed <a href="https://mindlogger.atlassian.net/wiki/spaces/MINDLOGGER1/pages/1036058625/Improving+Endpoint+Caching+in+Admin+App#Fix-data-becoming-stale%2Fout-of-sync" rel="nofollow">here</a>). So peer testing should be done with the intent of **verifying there are no regressions**.

Below are the screens and components affected by the migrated queries and mutations. When testing, ensure that queried data – including lists of activities, participants, and team members – remains up to date when performing actions that would affect that data.

| Original API function | Affected screens/actions |
| - | - |
| `getAppletActivitiesApi` | <ul><li>**Applet > Activities** list</li><li>**Assign Activity** drawer (accessed either from Applet > Activities or PDP)</li></ul> |
| `getWorkspaceManagersApi` | <ul><li>**Dashboard > Team** table</li><li>**Applet > Team** table</li></ul> |
| `getWorkspaceRespondentsApi` | <ul><li>**Dashboard > Respondents** table</li><li>**Applet > Participants** table</li><li>**Participant dropdowns**, including in:<ul><li>**Take Now** modal</li><li>**Assign Activity** drawer</li></ul></li><li>**Applet > Team** screen: <ul><li>**Add Team Member** > **Reviewer** role > **Select Participants** dropdown</li><li>**Edit Team Member** on "Reviewer" > **Select Respondents** modal</li></ul></li><li>**Applet > Participants > PDP > Schedule**: <ul> <li> **Add individual schedule** </li> <li> **Remove individual schedule** <br>☝️ Confirm page state reflects individual schedule state </li> </ul></li></ul> |
| `postAppletInvitationApi`<br>`postAppletShellAccountApi`<br>`postSubjectInvitationApi` | <ul><li>**Dashboard > Respondents** screen: **Send Invitation** action on limited accounts</li><li>**Applet Overview** screen: **⊕ Add Participant** action</li><li>**Applet > Participants** screen: <ul><li>**Add Participant** action, both limited & full accounts</li><li>**Upgrade to Full Account** action on limited accounts</li></ul></li><li>**Applet > Team** screen: **Add Team Member** action</li></ul> |
| `editSubjectApi`<br>`deleteSubjectApi` | <ul><li>**Applet > Participants** screen:<ul><li>**Edit Participant** action</li><li>**Remove Participant** action</li></ul></li></ul> |

[M2-8618]: https://mindlogger.atlassian.net/browse/M2-8618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ