### PR TITLE
fix: update minDate conditional logic (M2-8317, M2-8275, M2-8032)

### DIFF
--- a/src/modules/Builder/components/ConditionRow/Condition/SwitchCondition/SwitchCondition.tsx
+++ b/src/modules/Builder/components/ConditionRow/Condition/SwitchCondition/SwitchCondition.tsx
@@ -245,6 +245,7 @@ export const SwitchCondition = ({
                 onCloseCallback={onCloseStartDateCallback}
                 data-testid={`${dataTestid}-start-date-value`}
                 skipMinDate
+                maxDate={maxDateValue}
                 {...commonDateInputProps}
               />
               <StyledBodyLarge sx={{ m: theme.spacing(0, 0.4) }}>{t('and')}</StyledBodyLarge>

--- a/src/modules/Builder/components/ConditionRow/Condition/SwitchCondition/SwitchCondition.tsx
+++ b/src/modules/Builder/components/ConditionRow/Condition/SwitchCondition/SwitchCondition.tsx
@@ -251,7 +251,7 @@ export const SwitchCondition = ({
               <DatePicker
                 name={maxDateValueName}
                 key={`max-date-value-${isRangeValueShown}`}
-                minDate={minValue as Date}
+                minDate={minDateValue}
                 data-testid={`${dataTestid}-end-date-value`}
                 {...commonDateInputProps}
               />

--- a/src/modules/Builder/pages/BuilderApplet/BuilderApplet.const.ts
+++ b/src/modules/Builder/pages/BuilderApplet/BuilderApplet.const.ts
@@ -28,6 +28,16 @@ export const TIME_INTERVAL_CONDITION_TYPES = [
   ConditionType.BetweenTimesRange,
   ConditionType.OutsideOfTimesRange,
 ];
+export const DATE_SINGLE_CONDITION_TYPES = [
+  ConditionType.GreaterThanDate,
+  ConditionType.LessThanDate,
+  ConditionType.EqualToDate,
+  ConditionType.NotEqualToDate,
+];
+export const DATE_INTERVAL_CONDITION_TYPES = [
+  ConditionType.BetweenDates,
+  ConditionType.OutsideOfDates,
+];
 export const SLIDER_ROWS_CONDITION_TYPES = [
   ConditionType.GreaterThanSliderRows,
   ConditionType.LessThanSliderRows,

--- a/src/modules/Builder/pages/BuilderApplet/BuilderApplet.utils.tsx
+++ b/src/modules/Builder/pages/BuilderApplet/BuilderApplet.utils.tsx
@@ -44,6 +44,7 @@ import {
   getTextBetweenBrackets,
   INTERVAL_SYMBOL,
   isSystemItem,
+  parseDateToMidnightUTC,
   Path,
   pluck,
 } from 'shared/utils';
@@ -788,7 +789,7 @@ const formatTime = (hours: number, minutes: number) => {
 };
 
 const formatDate = (dateValue: string) => {
-  const date = dateValue ? new Date(`${dateValue}T00:00:00`) : undefined;
+  const date = dateValue ? parseDateToMidnightUTC(dateValue) : undefined;
 
   return date;
 };

--- a/src/modules/Builder/pages/BuilderApplet/BuilderApplet.utils.tsx
+++ b/src/modules/Builder/pages/BuilderApplet/BuilderApplet.utils.tsx
@@ -33,6 +33,8 @@ import {
   TimeRangeIntervalValueCondition,
   TimeSingleValueCondition,
   TimeRangeSingleValueCondition,
+  DateSingleValueCondition,
+  DateRangeValueCondition,
 } from 'shared/state';
 import {
   createArray,
@@ -96,6 +98,8 @@ import {
 import {
   ALLOWED_TYPES_IN_VARIABLES,
   CONDITION_TYPES_TO_HAVE_OPTION_ID,
+  DATE_INTERVAL_CONDITION_TYPES,
+  DATE_SINGLE_CONDITION_TYPES,
   defaultFlankerBtnObj,
   ordinalStrings,
   SAMPLE_SIZE,
@@ -783,8 +787,31 @@ const formatTime = (hours: number, minutes: number) => {
   return `${formattedHours}:${formattedMinutes}`;
 };
 
+const formatDate = (dateValue: string) => {
+  const date = dateValue ? new Date(`${dateValue}T00:00:00`) : undefined;
+
+  return date;
+};
+
 const getConditionPayload = (item: Item, condition: Condition) => {
   const conditionType = condition.type as ConditionType;
+  if (DATE_SINGLE_CONDITION_TYPES.includes(conditionType)) {
+    const conditionPayload = condition.payload as DateSingleValueCondition['payload'];
+
+    return {
+      ...conditionPayload,
+      date: formatDate(conditionPayload.date),
+    };
+  }
+  if (DATE_INTERVAL_CONDITION_TYPES.includes(conditionType)) {
+    const conditionPayload = condition.payload as DateRangeValueCondition['payload'];
+
+    return {
+      ...conditionPayload,
+      minDate: formatDate(conditionPayload.minDate),
+      maxDate: formatDate(conditionPayload.maxDate),
+    };
+  }
   if (TIME_SINGLE_CONDITION_TYPES.includes(conditionType)) {
     const conditionPayload = condition.payload as
       | TimeSingleValueCondition<string>['payload']

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.tsx
@@ -23,6 +23,7 @@ import { useAsync } from 'shared/hooks';
 import { StyledContainer, theme } from 'shared/styles';
 import { users } from 'redux/modules';
 import { page } from 'resources';
+import { parseDateToMidnightUTC } from 'shared/utils';
 
 import { Feedback } from './Feedback';
 import { ActivityResponses } from './ActivityResponses';
@@ -143,8 +144,7 @@ export const RespondentDataReview = () => {
     const datesResult = data?.result;
     if (!datesResult) return;
 
-    // Map each date string to a Date object, appending 'T00:00:00' to remove timezone offset
-    const submitDates = datesResult.dates.map((date: string) => new Date(`${date}T00:00:00`));
+    const submitDates = datesResult.dates.map(parseDateToMidnightUTC);
     setResponseDates(submitDates);
   });
 
@@ -235,8 +235,7 @@ export const RespondentDataReview = () => {
     const lastActivityCompletedDate = lastActivityCompleted && new Date(lastActivityCompleted);
 
     if (selectedDateParam) {
-      // Map the date string to a Date object, appending 'T00:00:00' to remove timezone offset
-      const selectedDate = new Date(`${selectedDateParam}T00:00:00`);
+      const selectedDate = parseDateToMidnightUTC(selectedDateParam);
       if (isValid(selectedDate)) {
         handleSetInitialDate(selectedDate);
 

--- a/src/modules/Dashboard/state/CalendarEvents/CalendarEvents.utils.test.ts
+++ b/src/modules/Dashboard/state/CalendarEvents/CalendarEvents.utils.test.ts
@@ -3,7 +3,7 @@
 import { addDays, endOfYear, setHours, setMinutes, setSeconds } from 'date-fns';
 
 import { Periodicity, TimerType } from 'modules/Dashboard/api';
-import { formatToYearMonthDate } from 'shared/utils/dateFormat';
+import { formatToYearMonthDate, parseDateToMidnightUTC } from 'shared/utils/dateFormat';
 
 import {
   getEventsWithHiddenInTimeView,
@@ -325,9 +325,9 @@ describe('getEventEndDateTime', () => {
   const dateString = '2023-12-15';
   const dateStringNextYear = '2024-07-15';
   const endTime = '16:30:00';
-  const eventStart = new Date(`${dateString}T00:00:00`);
+  const eventStart = parseDateToMidnightUTC(dateString);
+  const eventStartNextYear = parseDateToMidnightUTC(dateStringNextYear);
   const eventStartWithTime = new Date(`${dateString}T${endTime}`);
-  const eventStartNextYear = new Date(`${dateStringNextYear}T00:00:00`);
   const currentYear = '2023';
 
   test.each`

--- a/src/shared/utils/dateFormat.test.ts
+++ b/src/shared/utils/dateFormat.test.ts
@@ -6,6 +6,7 @@ import {
   getDayName,
   getMonthName,
   getMoreText,
+  parseDateToMidnightUTC,
 } from './dateFormat';
 
 const firstDate = new Date('2023-10-22T12:00:00Z');
@@ -55,5 +56,37 @@ describe('getMonthName', () => {
     ${firstDate} | ${NameLength.Short} | ${'Oct'}     | ${'should be correct short month name'}
   `('$description', ({ date, length, expected }) => {
     expect(getMonthName(date, length)).toBe(expected);
+  });
+});
+
+describe('parseDateToMidnightUTC', () => {
+  it('should return a Date object for a valid date string', () => {
+    const dateStr = '2025-01-01';
+    const result = parseDateToMidnightUTC(dateStr);
+    expect(result).toBeInstanceOf(Date);
+    expect(result.toISOString()).toBe('2025-01-01T00:00:00.000Z');
+  });
+
+  test('should throw error for invalid formats', () => {
+    expect(() => parseDateToMidnightUTC('2025/01/01')).toThrow(
+      '[parseDateToMidnightUTC] Invalid date string format',
+    );
+    expect(() => parseDateToMidnightUTC('2025-01')).toThrow(
+      '[parseDateToMidnightUTC] Invalid date string format',
+    );
+    expect(() => parseDateToMidnightUTC('invalid-date')).toThrow(
+      '[parseDateToMidnightUTC] Invalid date string format',
+    );
+    expect(() => parseDateToMidnightUTC('')).toThrow(
+      '[parseDateToMidnightUTC] Invalid date string format',
+    );
+  });
+
+  it('should handle timezone inconsistencies correctly', () => {
+    const dateStr = '2024-06-15';
+    const result = parseDateToMidnightUTC(dateStr);
+    expect(result.getUTCDate()).toBe(15);
+    expect(result.getUTCMonth()).toBe(5);
+    expect(result.getUTCFullYear()).toBe(2024);
   });
 });

--- a/src/shared/utils/dateFormat.ts
+++ b/src/shared/utils/dateFormat.ts
@@ -19,3 +19,26 @@ export const getMonthName = (date: Date, length?: NameLength) =>
   date.toLocaleString(i18n.language, { month: length || NameLength.Long });
 
 export const formatToNumberDate = (date: Date) => format(new Date(date), DateFormats.YearMonthDay);
+
+/**
+ * Parses a date string to a Date object, appending 'T00:00:00Z' to remove timezone offset
+ *
+ * @param {String} dateStr - The date string from which to extract the raw hours and minutes.
+ * @returns {Date} An object containing the extracted raw hours and minutes.
+ * @throws {Error} Throws an error if the date string format is invalid.
+ *
+ * @example
+ * const dateStr = '2025-01-01';
+ * const date = parseDateToMidnightUTC(dateStr);
+ * // date: 2025-01-01T00:00:00.000Z
+ */
+
+export const parseDateToMidnightUTC = (dateStr: string): Date => {
+  const dateMatch = dateStr.match(/(\d{4})-(\d{2})-(\d{2})/);
+
+  if (!dateMatch) {
+    throw new Error('[parseDateToMidnightUTC] Invalid date string format');
+  }
+
+  return new Date(`${dateStr}T00:00:00Z`);
+};

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -44,3 +44,4 @@ export * from './nullReturnFunc';
 export * from './isObject';
 export * from './responseType';
 export * from './regex';
+export * from './dateFormat';


### PR DESCRIPTION
### 📝 Description

Fix `minDate` condition when selecting `BETWEEN_DATES` or `OUTSIDE_OF_DATES` conditional logic by using the correct value and addressing a date parsing issue.

🔗 [Jira Ticket M2-8317](https://mindlogger.atlassian.net/browse/M2-8317)
🔗 [Jira Ticket M2-8275](https://mindlogger.atlassian.net/browse/M2-8275)
🔗 [Jira Ticket M2-8032](https://mindlogger.atlassian.net/browse/M2-8032)

Changes include:

- Use `minDateValue` instead of `minValue` when setting up `DatePicker`
- Update date parsing to remove timezone offset effect
- Additionally prevents setting a `minDate` greater than `maxDate`

### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

### Case 1 (M2-8317):
**Before:** It's not possible to select a date prior to "today" in the second DatePicker when selecting Outside/Between conditional logic

https://github.com/user-attachments/assets/e15f37f9-4cd6-402a-a335-e116e55cea62

**After:** It's now possible to select a date prior to "today" but greater than the first date when selecting Outside/Between conditional logic

 https://github.com/user-attachments/assets/329c79e3-6b61-40b2-896c-41252a453236

### Case 2 (M2-8275):
Date parsing error after saving 

**Before:** 
- After selecting a date and pressing "Save", the date would change depending on the timezone (29 -> 28 in the video.)
- Clicking "Save" a second time would display an error due to a date parsing issue

https://github.com/user-attachments/assets/cf67f1ec-bc8a-45ab-8b96-3ecdd4d03706

**After:**
- Selecting a date and clicking "Save" results in the date not changing
- Date parsing error no longer appears, clicking Save a second time correctly reports no changes

https://github.com/user-attachments/assets/ae237a87-3e55-4b72-bf20-89678f288b09


### 🪤 Peer Testing

- Create an applet with 2 or more items, first item should be "Date" type
- Create conditional logic using the date item in the top row
- Select different values between Greater Than, Less Than, Outside or Between
  - For Outside/Between dates condition, it should be possible to select a date before "today" but greater than the first date.
- Applet should save correctly

### ✏️ Notes

- The `enableItemFlowItemsG2` and `enableItemFlowExtendedItems` feature flags need to be enabled in order to test **Date** conditional logic.

- ~Web app conditional logic for Date/Time is currently not working as expected, will be addressed by M2 8302~
- Web app conditional logic can be tested with this PR/Amplify environment https://github.com/ChildMindInstitute/mindlogger-web-refactor/pull/573