### PR TITLE
[WIP] feat: Add activity/flow id to dates endpoint (M2-8221)

### DIFF
--- a/src/modules/Dashboard/api/api.types.ts
+++ b/src/modules/Dashboard/api/api.types.ts
@@ -531,6 +531,7 @@ export type AppletSubmitDateList = AppletId &
   TargetSubjectId & {
     fromDate: string;
     toDate: string;
+    activityOrFlowId: string;
   };
 
 export type EventId = { eventId: string };

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.tsx
@@ -149,7 +149,8 @@ export const RespondentDataReview = () => {
   });
 
   const handleGetSubmitDates = (date: Date) => {
-    if (!appletId || !subjectId) return;
+    const activityOrFlowId = activityId || activityFlowId;
+    if (!appletId || !subjectId || !activityOrFlowId) return;
 
     const fromDate = startOfMonth(date).getTime().toString();
     const toDate = endOfMonth(date).getTime().toString();
@@ -159,6 +160,7 @@ export const RespondentDataReview = () => {
       targetSubjectId: subjectId,
       fromDate,
       toDate,
+      activityOrFlowId,
     });
   };
 


### PR DESCRIPTION
- [X] Tests for the changes have been added
- [ ] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

🔗 [Jira Ticket M2-8221](https://mindlogger.atlassian.net/browse/M2-8221)
🔗 [Jira Ticket M2-8215](https://mindlogger.atlassian.net/browse/M2-8215) (BE ticket with whole context)

This PR propagates the changes added [this BE PR](https://github.com/ChildMindInstitute/mindlogger-backend-refactor/pull/1726), which adds the `activityOrFlowId` parameter to the `/answers/applet/{answer-id}/dates` endpoint for activity or flow filtering, ensuring only responses from the selected activity/flow show up in the `"Responses"` view.

### 🪤 Peer Testing

When accessing Participant > Responses > Data Viz, only items for the selected activity/flow should appear as active in the calendar and should show responses.