### PR TITLE
feat: New score calculation behaviour for skipped items (M2-8684)

### DIFF
--- a/src/modules/Dashboard/features/Respondents/Popups/DataExportPopup/DataExportPopup.hooks.tsx
+++ b/src/modules/Dashboard/features/Respondents/Popups/DataExportPopup/DataExportPopup.hooks.tsx
@@ -22,9 +22,7 @@ export const useMultipleDecryptWorkers = ({
   const limitRef = useRef(1);
   const finishedPagesRef = useRef<Set<number>>(new Set());
   const encryptionInfoFromServer = getParsedEncryptionFromServer(encryption);
-  const {
-    featureFlags: { enableDataExportRenaming },
-  } = useFeatureFlags();
+  const { featureFlags } = useFeatureFlags();
 
   const shouldLogDataInDebugMode =
     !isProduction && sessionStorage.getItem(SessionStorageKeys.DebugMode) === 'true';
@@ -41,7 +39,7 @@ export const useMultipleDecryptWorkers = ({
       setCurrentPage,
       limitRef,
       finishedPagesRef,
-      enableDataExportRenaming,
+      featureFlags,
     ),
   ).current;
 

--- a/src/modules/Dashboard/features/Respondents/Popups/DataExportPopup/DataExportPopup_old.tsx
+++ b/src/modules/Dashboard/features/Respondents/Popups/DataExportPopup/DataExportPopup_old.tsx
@@ -44,9 +44,7 @@ export const DataExportPopup = ({
   'data-testid': dataTestid,
 }: DataExportPopupProps) => {
   const dataExportingRef = useRef(false);
-  const {
-    featureFlags: { enableDataExportRenaming },
-  } = useFeatureFlags();
+  const { featureFlags } = useFeatureFlags();
   const { getValues } = useFormContext<ExportDataFormValues>() ?? {};
   const { t } = useTranslation('app');
   const [dataIsExporting, setDataIsExporting] = useState(false);
@@ -78,6 +76,16 @@ export const DataExportPopup = ({
   const showEnterPwdScreen = !!chosenAppletData && !dataIsExporting && !hasEncryptionCheck;
   const getDecryptedAnswers = useDecryptedActivityData(appletId, encryption);
 
+  const handlePopupClose = useCallback(() => {
+    setChosenAppletData?.(null);
+    setPopupVisible(false);
+  }, [setChosenAppletData, setPopupVisible]);
+
+  const handleRetry = () => {
+    setActiveModal(Modals.DataExport);
+    handleDataExportSubmit();
+  };
+
   const executeAllPagesOfExportData = useCallback(
     async ({ appletId, targetSubjectIds }: ExecuteAllPagesOfExportData) => {
       try {
@@ -104,7 +112,7 @@ export const DataExportPopup = ({
           getDecryptedAnswers,
           suffix: pageLimit > 1 ? getExportDataSuffix(1) : '',
           filters,
-          enableDataExportRenaming,
+          flags: featureFlags,
         })(firstPageData);
 
         if (pageLimit > 1) {
@@ -122,7 +130,7 @@ export const DataExportPopup = ({
               getDecryptedAnswers,
               suffix: getExportDataSuffix(page),
               filters,
-              enableDataExportRenaming,
+              flags: featureFlags,
             })(nextPageData);
           }
         }
@@ -142,17 +150,8 @@ export const DataExportPopup = ({
         setDataIsExporting(false);
       }
     },
-    [getDecryptedAnswers],
+    [featureFlags, filters, getDecryptedAnswers, getValues, handlePopupClose],
   );
-
-  const handlePopupClose = () => {
-    setChosenAppletData?.(null);
-    setPopupVisible(false);
-  };
-  const handleRetry = () => {
-    setActiveModal(Modals.DataExport);
-    handleDataExportSubmit();
-  };
 
   const renderDataExportContent = () => {
     if (dataIsExporting) {

--- a/src/modules/Dashboard/features/Respondents/Popups/DataExportPopup/DataExportWorkersManager/DataExportWorkersManager.ts
+++ b/src/modules/Dashboard/features/Respondents/Popups/DataExportPopup/DataExportWorkersManager/DataExportWorkersManager.ts
@@ -6,6 +6,7 @@ import { ExportDataFilters, exportDecryptedDataSucceed } from 'shared/utils/expo
 import { ItemResponseType } from 'shared/consts';
 import { Mixpanel } from 'shared/utils/mixpanel/mixpanel';
 import { MixpanelEventType, MixpanelProps } from 'shared/utils/mixpanel/mixpanel.types';
+import { FeatureFlags } from 'shared/types/featureFlags';
 
 import DecryptionWorker from '../DataExportWorker/DataExportWorker.worker';
 import { IdleWorker } from '../DataExportPopup.types';
@@ -29,7 +30,7 @@ export class DataExportWorkersManager {
     private setCurrentPage: Dispatch<SetStateAction<number>>,
     private limitRef: MutableRefObject<number>,
     private finishedPagesRef: MutableRefObject<Set<number>>,
-    private enableDataExportRenaming: boolean,
+    private flags: FeatureFlags,
   ) {
     this.initializeWorkers();
   }
@@ -69,7 +70,7 @@ export class DataExportWorkersManager {
       exportDecryptedDataSucceed({
         suffix: hasSuffix ? getExportDataSuffix(page) : '',
         filters,
-        enableDataExportRenaming: this.enableDataExportRenaming,
+        flags: this.flags,
       })(decryptedData).then(() => {
         this.finishedPagesRef.current.add(page);
         this.handleAllTasksCompleted();

--- a/src/shared/types/featureFlags.ts
+++ b/src/shared/types/featureFlags.ts
@@ -21,6 +21,7 @@ export const FeatureFlagsKeys = {
   enableMeritActivityType: 'enableMeritActivityType',
   enableCahmiSubscaleScoring: 'enableCahmiSubscaleScoring',
   enableDataExportRenaming: 'enableDataExportRenaming',
+  enableSubscaleNullWhenSkipped: 'enableSubscaleNullWhenSkipped',
 };
 
 export type FeatureFlags = Partial<Record<keyof typeof FeatureFlagsKeys, LDFlagValue>>;

--- a/src/shared/utils/exportData/exportDataSucceed.test.ts
+++ b/src/shared/utils/exportData/exportDataSucceed.test.ts
@@ -13,6 +13,11 @@ import * as exportTemplateUtils from '../exportTemplate';
 import * as exportCsvZipUtils from './exportCsvZip';
 import * as exportMediaZipUtils from './exportMediaZip';
 
+const mockFlags = {
+  enableDataExportRenaming: false,
+  enableSubscaleNullWhenSkipped: false,
+};
+
 describe('exportDataSucceed', () => {
   beforeAll(() => {
     jest.useFakeTimers();
@@ -110,6 +115,7 @@ describe('exportDataSucceed', () => {
     await exportEncryptedDataSucceed({
       getDecryptedAnswers: mockedGetDecryptedAnswers,
       suffix: '',
+      flags: mockFlags,
     })(undefined);
 
     expect(prepareDataUtils.prepareEncryptedData).not.toHaveBeenCalled();
@@ -118,6 +124,7 @@ describe('exportDataSucceed', () => {
   test('exportDecryptedDataSucceed: check actions with empty data', async () => {
     await exportDecryptedDataSucceed({
       suffix: '',
+      flags: mockFlags,
     })(undefined);
 
     expect(prepareDataUtils.prepareDecryptedData).not.toHaveBeenCalled();
@@ -127,12 +134,13 @@ describe('exportDataSucceed', () => {
     await exportEncryptedDataSucceed({
       getDecryptedAnswers: mockedGetDecryptedAnswers,
       suffix: '-test',
+      flags: mockFlags,
     })(mockedExportData);
 
     expect(prepareDataUtils.prepareEncryptedData).toHaveBeenCalledWith(
       mockedExportData,
       mockedGetDecryptedAnswers,
-      undefined,
+      mockFlags,
       undefined,
     );
 
@@ -142,11 +150,12 @@ describe('exportDataSucceed', () => {
   test('exportDecryptedDataSucceed: check actions with default data with legacy naming', async () => {
     await exportDecryptedDataSucceed({
       suffix: '-test',
+      flags: mockFlags,
     })(mockedDecryptedExportData);
 
     expect(prepareDataUtils.prepareDecryptedData).toHaveBeenCalledWith(
       mockedDecryptedExportData,
-      undefined,
+      mockFlags,
       undefined,
     );
 
@@ -157,14 +166,14 @@ describe('exportDataSucceed', () => {
     await exportEncryptedDataSucceed({
       getDecryptedAnswers: mockedGetDecryptedAnswers,
       suffix: '-test',
-      enableDataExportRenaming: true,
+      flags: { ...mockFlags, enableDataExportRenaming: true },
     })(mockedExportData);
 
     expect(prepareDataUtils.prepareEncryptedData).toHaveBeenCalledWith(
       mockedExportData,
       mockedGetDecryptedAnswers,
+      { ...mockFlags, enableDataExportRenaming: true },
       undefined,
-      true,
     );
 
     checkCommonActions(true);
@@ -173,13 +182,13 @@ describe('exportDataSucceed', () => {
   test('exportDecryptedDataSucceed: check actions with default data with new naming', async () => {
     await exportDecryptedDataSucceed({
       suffix: '-test',
-      enableDataExportRenaming: true,
+      flags: { ...mockFlags, enableDataExportRenaming: true },
     })(mockedDecryptedExportData);
 
     expect(prepareDataUtils.prepareDecryptedData).toHaveBeenCalledWith(
       mockedDecryptedExportData,
+      { ...mockFlags, enableDataExportRenaming: true },
       undefined,
-      true,
     );
 
     checkCommonActions(true);
@@ -196,6 +205,7 @@ describe('exportDataSucceed', () => {
     await exportEncryptedDataSucceed({
       getDecryptedAnswers: mockedGetDecryptedAnswers,
       suffix: '',
+      flags: mockFlags,
     })(mockedExportData);
 
     checkExportTemplateDefaultData();
@@ -213,6 +223,7 @@ describe('exportDataSucceed', () => {
     );
     await exportDecryptedDataSucceed({
       suffix: '',
+      flags: mockFlags,
     })(mockedDecryptedExportData);
 
     checkExportTemplateDefaultData();

--- a/src/shared/utils/exportData/getReportAndMediaData.test.ts
+++ b/src/shared/utils/exportData/getReportAndMediaData.test.ts
@@ -235,7 +235,10 @@ describe('getReportAndMediaData', () => {
     test('should return filtered out array with items without empty answers', () => {
       //eslint-disable-next-line @typescript-eslint/ban-ts-comment
       //@ts-ignore
-      const result = getReportData([], rawAnswersObject, decryptedAnswers);
+      const result = getReportData([], rawAnswersObject, decryptedAnswers, {
+        enableDataExportRenaming: false,
+        enableSubscaleNullWhenSkipped: false,
+      });
       expect(result).toEqual([
         {
           id: undefined,
@@ -284,7 +287,10 @@ describe('getReportAndMediaData', () => {
       );
       //eslint-disable-next-line @typescript-eslint/ban-ts-comment
       //@ts-ignore
-      const result = getReportData([], rawAnswersObject, decryptedAnswers);
+      const result = getReportData([], rawAnswersObject, decryptedAnswers, {
+        enableDataExportRenaming: false,
+        enableSubscaleNullWhenSkipped: false,
+      });
       expect(result).toEqual([
         {
           activity_flow_submission_id: '',
@@ -404,14 +410,10 @@ describe('getReportAndMediaData', () => {
         mockedDecryptedAnswersWithSubscales,
         (item) => item.activityItem.name,
       );
-      //eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      //@ts-ignore
-      const result = getReportData(
-        [],
-        rawAnswersObject,
-        mockedDecryptedAnswersWithSubscales,
-        false,
-      );
+      const result = getReportData([], rawAnswersObject, mockedDecryptedAnswersWithSubscales, {
+        enableDataExportRenaming: false,
+        enableSubscaleNullWhenSkipped: false,
+      });
       expect(result).toEqual([
         {
           'Final SubScale Score': 5,
@@ -610,9 +612,10 @@ describe('getReportAndMediaData', () => {
         mockedDecryptedAnswersWithSubscales,
         (item) => item.activityItem.name,
       );
-      //eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      //@ts-ignore
-      const result = getReportData([], rawAnswersObject, mockedDecryptedAnswersWithSubscales, true);
+      const result = getReportData([], rawAnswersObject, mockedDecryptedAnswersWithSubscales, {
+        enableDataExportRenaming: true,
+        enableSubscaleNullWhenSkipped: false,
+      });
       expect([result[0], result[1]]).toEqual([
         {
           target_id: '116d59c1-2bb5-405b-8503-cb6c1e6b7620',

--- a/src/shared/utils/exportData/getReportAndMediaData.ts
+++ b/src/shared/utils/exportData/getReportAndMediaData.ts
@@ -17,6 +17,7 @@ import { getFileExtension, getMediaFileName } from 'shared/utils/exportData/getR
 import { ItemsWithFileResponses } from 'shared/consts';
 import { getJourneyCSVObject, getSplashScreen } from 'shared/utils/exportData/getJourneyCSVObject';
 import { getDrawingUrl, getMediaUrl } from 'shared/utils/exportData/getUrls';
+import { FeatureFlags } from 'shared/types/featureFlags';
 
 import { getObjectFromList } from '../getObjectFromList';
 
@@ -44,7 +45,7 @@ export const getReportData = (
   reportData: AppletExportData['reportData'],
   rawAnswersObject: Record<string, DecryptedAnswerData>,
   decryptedAnswers: DecryptedAnswerData[],
-  enableDataExportRenaming: boolean,
+  flags: FeatureFlags,
 ) => {
   const answers = decryptedAnswers.reduce(
     (filteredAcc, item, index) => {
@@ -56,7 +57,7 @@ export const getReportData = (
           item,
           rawAnswersObject,
           index,
-          enableDataExportRenaming,
+          enableDataExportRenaming: flags.enableDataExportRenaming,
         }),
       );
     },
@@ -67,7 +68,7 @@ export const getReportData = (
   if (subscaleSetting?.subscales?.length) {
     answers.splice(0, 1, {
       ...answers[0],
-      ...getSubscales(subscaleSetting, rawAnswersObject, enableDataExportRenaming),
+      ...getSubscales(subscaleSetting, rawAnswersObject, flags),
     });
   }
 
@@ -122,7 +123,7 @@ export const getActivityJourneyData = (
   rawAnswersObject: Record<string, DecryptedAnswerData>,
   decryptedAnswers: DecryptedAnswerData[],
   decryptedEvents: EventDTO[],
-  enableDataExportRenaming: boolean,
+  { enableDataExportRenaming }: FeatureFlags,
 ) => {
   const decryptedFilteredEvents = decryptedEvents.filter(isSuccessEvent);
   const hasMigratedAnswers = checkIfHasMigratedAnswers(decryptedAnswers);

--- a/src/shared/utils/exportData/getSubscales.test.ts
+++ b/src/shared/utils/exportData/getSubscales.test.ts
@@ -9,7 +9,7 @@ import {
 import { ItemResponseType } from 'shared/consts';
 
 import {
-  getSubScaleScore,
+  getSubscaleScore,
   parseSex,
   calcScores,
   calcTotalScore,
@@ -141,7 +141,7 @@ describe('getSubscales', () => {
     `(
       'returns "$expected" when subscalesSum="$subscalesSum", type="$type"',
       ({ subscalesSum, type, length, expected }) => {
-        expect(getSubScaleScore(subscalesSum, type, length)).toBe(expected);
+        expect(getSubscaleScore(subscalesSum, type, length)).toBe(expected);
       },
     );
   });
@@ -185,7 +185,11 @@ describe('getSubscales', () => {
       ${subscaleWithoutTypeItems} | ${mockedTotalScoresTableData}  | ${itemsWithoutTypeExpected}         | ${'should return score=0'}
     `('$description', ({ subscaleItems, subscaleTableData, expected }) => {
       const subscaleData = { ...data, subscaleTableData, items: subscaleItems };
-      expect(calcScores(subscaleData, activityItems, subscaleObject, {})).toEqual(expected);
+      expect(
+        calcScores(subscaleData, activityItems, subscaleObject, {
+          enableSubscaleNullWhenSkipped: false,
+        }),
+      ).toEqual(expected);
     });
   });
 
@@ -199,9 +203,11 @@ describe('getSubscales', () => {
       ${subscaleWithoutTypeItems} | ${mockedTotalScoresTableData} | ${itemsWithoutTypeExpected}                            | ${'should return score=0'}
     `('$description', ({ subscaleItems, subscaleTableData, expected }) => {
       const subscaleData = { ...data, subscaleTableData, items: subscaleItems };
-      expect(calcScores(subscaleData, activityItemsWithoutHiddenItems, subscaleObject, {})).toEqual(
-        expected,
-      );
+      expect(
+        calcScores(subscaleData, activityItemsWithoutHiddenItems, subscaleObject, {
+          enableSubscaleNullWhenSkipped: false,
+        }),
+      ).toEqual(expected);
     });
   });
 
@@ -215,7 +221,12 @@ describe('getSubscales', () => {
       ${{}}                                          | ${{}}            | ${{}}                                             | ${'should return empty object'}
       ${null}                                        | ${null}          | ${{}}                                             | ${'should return empty object'}
     `('$description', ({ subscaleSetting, activityItems, expected }) => {
-      expect(calcTotalScore(subscaleSetting, activityItems, false)).toEqual(expected);
+      expect(
+        calcTotalScore(subscaleSetting, activityItems, {
+          enableDataExportRenaming: false,
+          enableSubscaleNullWhenSkipped: false,
+        }),
+      ).toEqual(expected);
     });
   });
 
@@ -234,7 +245,12 @@ describe('getSubscales', () => {
         ...mockedSubscaleSetting,
         subscales,
       };
-      expect(getSubscales(settings, activityItems, false)).toEqual(expected);
+      expect(
+        getSubscales(settings, activityItems, {
+          enableDataExportRenaming: false,
+          enableSubscaleNullWhenSkipped: false,
+        }),
+      ).toEqual(expected);
     });
   });
 
@@ -253,7 +269,12 @@ describe('getSubscales', () => {
         ...mockedSubscaleSetting,
         subscales,
       };
-      expect(getSubscales(settings, activityItems, true)).toEqual(expected);
+      expect(
+        getSubscales(settings, activityItems, {
+          enableDataExportRenaming: true,
+          enableSubscaleNullWhenSkipped: false,
+        }),
+      ).toEqual(expected);
     });
   });
 });

--- a/src/shared/utils/exportData/getSubscales.ts
+++ b/src/shared/utils/exportData/getSubscales.ts
@@ -263,18 +263,20 @@ export const getSubscales = (
   const cleanName = (name: string) => name.replace(/[^a-zA-Z0-9-]/g, '_');
 
   const parsedSubscales = subscaleSetting.subscales.reduce((acc: ParsedSubscale, item) => {
-    const calculatedSubscale = calcScores(item, activityItems, subscalesObject, flags);
+    const calculatedSubscale = calcScores(item, activityItems, subscalesObject, flags)[item.name];
+    if (!calculatedSubscale) return acc;
+
     const cleanedName = cleanName(item.name);
 
     if (flags.enableDataExportRenaming) {
-      acc[`subscale_name_${cleanedName}`] = calculatedSubscale[item.name].score;
-      if (calculatedSubscale?.[item.name]?.optionText) {
-        acc[`subscale_lookup_text_${cleanedName}`] = calculatedSubscale[item.name].optionText;
+      acc[`subscale_name_${cleanedName}`] = calculatedSubscale?.score;
+      if (calculatedSubscale?.optionText) {
+        acc[`subscale_lookup_text_${cleanedName}`] = calculatedSubscale.optionText;
       }
     } else {
-      acc[item.name] = calculatedSubscale[item.name].score;
-      if (calculatedSubscale?.[item.name]?.optionText) {
-        acc[`Optional text for ${item.name}`] = calculatedSubscale[item.name].optionText;
+      acc[item.name] = calculatedSubscale?.score;
+      if (calculatedSubscale?.optionText) {
+        acc[`Optional text for ${item.name}`] = calculatedSubscale.optionText;
       }
     }
 

--- a/src/shared/utils/exportData/parseResponseValue.ts
+++ b/src/shared/utils/exportData/parseResponseValue.ts
@@ -134,7 +134,7 @@ export const parseResponseValueRaw = <T extends DecryptedAnswerData>(
     case ItemResponseType.ABTrails:
       return getABTrailsCsvName(index, item);
     case ItemResponseType.SingleSelectionPerRow: {
-      const rows = activityItem?.responseValues.rows;
+      const { rows } = activityItem.responseValues;
 
       return rows
         .map(
@@ -146,19 +146,21 @@ export const parseResponseValueRaw = <T extends DecryptedAnswerData>(
         .join('\n');
     }
     case ItemResponseType.MultipleSelectionPerRow: {
-      const rows = activityItem?.responseValues.rows;
+      const { rows } = activityItem.responseValues;
 
       return rows
         .map(
           (row, index) =>
             `${row.rowName}: ${
-              (value as DecryptedMultiSelectionPerRowAnswer['value'])[index]?.join(', ') ?? ''
+              value === 'null'
+                ? ''
+                : (value as DecryptedMultiSelectionPerRowAnswer['value'])[index]?.join(', ') ?? ''
             }`,
         )
         .join('\n');
     }
     case ItemResponseType.SliderRows: {
-      const rows = activityItem?.responseValues.rows;
+      const { rows } = activityItem.responseValues;
 
       return rows
         .map(

--- a/src/shared/utils/exportData/prepareData.test.ts
+++ b/src/shared/utils/exportData/prepareData.test.ts
@@ -4,6 +4,11 @@ import { prepareDecryptedData, prepareEncryptedData } from './prepareData';
 import * as getParsedAnswersFunctions from '../getParsedAnswers';
 import { mockedParsedAnswers } from '../../mock';
 
+const mockFlags = {
+  enableDataExportRenaming: false,
+  enableSubscaleNullWhenSkipped: false,
+};
+
 const mockedExportDataResult = {
   reportData: [
     {
@@ -396,12 +401,12 @@ describe('prepareData', () => {
       .spyOn(getParsedAnswersFunctions, 'getParsedAnswers')
       .mockImplementationOnce(() => mockedParsedAnswers);
 
-    const result = await prepareEncryptedData(data, getDecryptedAnswers);
+    const result = await prepareEncryptedData(data, getDecryptedAnswers, mockFlags);
     expect(result).toEqual(mockedExportDataResult);
   });
 
   test('prepareDecryptedData should return filled in reportData', async () => {
-    const result = await prepareDecryptedData(mockedParsedAnswers);
+    const result = await prepareDecryptedData(mockedParsedAnswers, mockFlags);
     expect(result).toEqual(mockedExportDataResult);
   });
 });

--- a/src/shared/utils/exportData/prepareData.ts
+++ b/src/shared/utils/exportData/prepareData.ts
@@ -5,6 +5,7 @@ import {
   ExtendedExportAnswerWithoutEncryption,
 } from 'shared/types/answer';
 import { useDecryptedActivityData } from 'modules/Dashboard/hooks';
+import { FeatureFlags } from 'shared/types/featureFlags';
 
 import { getObjectFromList } from '../getObjectFromList';
 import {
@@ -57,8 +58,8 @@ export const getParsedAnswersFilterFn = (filters?: ExportDataFilters) => {
 
 export const prepareDecryptedData = async (
   parsedAnswers: DecryptedActivityData<ExtendedExportAnswerWithoutEncryption>[],
+  flags: FeatureFlags,
   filters?: ExportDataFilters,
-  enableDataExportRenaming?: boolean,
 ) => {
   logDataInDebugMode({ parsedAnswersWithoutHiddenItems: parsedAnswers });
   const filteredParsedAnswers = parsedAnswers.filter(getParsedAnswersFilterFn(filters));
@@ -76,7 +77,7 @@ export const prepareDecryptedData = async (
       acc.reportData,
       rawAnswersObject,
       data.decryptedAnswers,
-      !!enableDataExportRenaming,
+      flags,
     );
     const mediaData = getMediaData(acc.mediaData, data.decryptedAnswers);
     const activityJourneyData = getActivityJourneyData(
@@ -84,7 +85,7 @@ export const prepareDecryptedData = async (
       rawAnswersObject,
       data.decryptedAnswers,
       data.decryptedEvents,
-      !!enableDataExportRenaming,
+      flags,
     );
     const drawingItemsData = await getDrawingItemsData(acc.drawingItemsData, data.decryptedAnswers);
     const stabilityTrackerItemsData = await getStabilityTrackerItemsData(
@@ -114,10 +115,10 @@ export const prepareDecryptedData = async (
 export const prepareEncryptedData = async (
   data: ExportDataResult,
   getDecryptedAnswers: ReturnType<typeof useDecryptedActivityData>,
+  flags: FeatureFlags,
   filters?: ExportDataFilters,
-  enableDataExportRenaming?: boolean,
 ) => {
   const parsedAnswers = await getParsedAnswers(data, getDecryptedAnswers);
 
-  return prepareDecryptedData(parsedAnswers, filters, enableDataExportRenaming);
+  return prepareDecryptedData(parsedAnswers, flags, filters);
 };


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-8684](https://mindlogger.atlassian.net/browse/M2-8684)

With the Report Server now interpreting skipped answers as `null` rather than `0` (with the `enable-subscale-null-when-skipped` feature flag enabled), it's important for Dataviz and Data Export to align with this new interpretation as well – specifically around scoring calculations.

This task is to bring the Admin Panel inline with the changes to the Report Server to ensure that, when the feature flag is enabled, score calculations based on missing responses:

-   if **all items** associated with a score calculation (either subscale score, or activity total score) were skipped:
    -   do not have a corresponding data point in Dataviz
    -   do not have a value in the corresponding column of the exported data
-   if **any item** associated with an **average** score calculation (either subscale score, or activity total score) is skipped, it is **excluded** from the average score calculation

### 🪤 Peer Testing

#### Preconditions:

-   Applet containing activity with **two skippable items** that have scoring enabled, with each one configured to be able to produce a score of `0` or `10` based on the response
-   Activity is configured with a subscale calculated as an **average** of both items, with lookup table that has these raw score ⇒ T-score mappings: `0 ⇒ 0`, `5 ⇒ 10`, `10 ⇒ 20`
-   Subscale has **Calculate total score** enabled, using **Average of Item Scores**:
    <img src="https://github.com/user-attachments/assets/3b5a3de2-b816-4ee8-a2df-0746ca30714a" width="300">

#### Testing procedure:

**New behaviour:** _Skipped items are excluded from scores_
1. Add this to line 26 of `useFeatureFlags.ts` (feature flag **enabled**):
    ```ts
    features.enableSubscaleNullWhenSkipped = true;
    ```
2. As an eligible subject, perform an assessment of the activity in the Web App, skipping all items.
3. In the Admin App in another tab, open the PDP for that subject and click View Data to access Dataviz.
4. Adjust the date to restrict results to today's date, and inspect the subscale score chart.
    **Expected outcome:** No subscale or `activity_score` data points for the most recent submission should be on the chart.
5. Perform another assessment of the activity in the Web App, this time **choosing a response for the first item** that scores `10`, and **skipping the second item**.
6. Refresh Dataviz, restrict results to today's date, and inspect the subscale score chart.
    **Expected outcome:** There should be 2 data points for the most recent submission:
      - for the subscale, the data point should be `20` (the average of all responses' raw scores = single score of `10` = average score of `10` ⇒ T-score of `20`)
      - for the `activity_score`, the data point should be `10` (the average of all responses' raw scores = single score of `10` = average score of `10`)
7. Export the data from the last 24 hours and inspect the CSV file.
    **Expected outcome:** Find each group of rows representing **each submission**, and look at the **topmost row** of each group:
      - For the **1st submission**: the `activity_score` column should be **empty**, and the `subscale_name_[your subscale name]__Average` column should be **empty**
      - For the **2nd submission**: the `activity_score` column should contain `10` and the `subscale_name_[your subscale name]__Average` column should contain `20`

**Confirm legacy behaviour:** _Skipped items have a score of `0`_

1. Edit line 26 of `useFeatureFlags.ts` (feature flag **disabled**):
    ```ts
    features.enableSubscaleNullWhenSkipped = false;
    ```
2. Refresh Dataviz, restrict results to today's date, and inspect the subscale score chart.
    **Expected outcome:**
      - There should be 2 data points for the 1st submission, both with a value of `0` (skipped scores default to `0`)
      - There should be 2 data points for the 2nd submission:
        - for the subscale, the data point should be `10` (the average of all responses' raw scores = [`10`, `0`] = average score of `5` ⇒ T-score of `10`)
        - for the `activity_score`, the data point should be `5` (the average of all responses' raw scores = [`10`, `0`] = average score of `5`)
3. Export the data from the last 24 hours and inspect the CSV file.
    **Expected outcome:** Find each group of rows representing **each submission**, and look at the **topmost row** of each group:
      - For the **1st submission**: the `activity_score` column should contain `0`, and the `subscale_name_[your subscale name]__Average` column should contain `0`
      - For the **2nd submission**: the `activity_score` column should contain `5` and the `subscale_name_[your subscale name]__Average` column should contain `10`
