### PR TITLE
feat: filter skipped responses in dataviz (M2-8669)

### DIFF
--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Report.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/Report.tsx
@@ -25,6 +25,7 @@ import { ReportHeader } from './ReportHeader';
 import { NoData } from './NoData';
 import { EntityResponses } from './EntitiyResponses';
 import { useRespondentDataContext } from '../../RespondentDataContext';
+import { useDatavizSkippedFilter } from '../hooks/useDatavizSkippedFilter';
 
 export const Report = () => {
   const { t } = useTranslation('app');
@@ -45,6 +46,7 @@ export const Report = () => {
   const versions: AutocompleteOption[] = useWatch({
     name: 'versions',
   });
+  const { hideSkipped } = useDatavizSkippedFilter();
 
   const [isLoading, setIsLoading] = useState(false);
   const [currentActivityCompletionData, setCurrentActivityCompletionData] =
@@ -76,12 +78,22 @@ export const Report = () => {
       ? answers?.filter(({ answerId }) => answerId === currentActivityCompletionData.answerId)
       : answers;
 
-    const { subscalesFrequency, formattedResponses } = getFormattedResponses(responses);
+    const filtered = !hideSkipped
+      ? responses
+      : responses
+          .map((response) => {
+            const answerItems = response.decryptedAnswer.filter(({ answer }) => answer);
+
+            return { ...response, decryptedAnswer: answerItems };
+          })
+          .filter(Boolean);
+
+    const { subscalesFrequency, formattedResponses } = getFormattedResponses(filtered);
 
     setResponseOptions(formattedResponses);
     setSubscalesFrequency(subscalesFrequency);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentActivityCompletionData]);
+  }, [currentActivityCompletionData, hideSkipped, answers]);
 
   return (
     <>

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ReportFilters/ReportFilters.styles.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ReportFilters/ReportFilters.styles.ts
@@ -21,3 +21,14 @@ export const StyledMoreFilters = styled(Button)`
   height: 5.5rem;
   margin-left: ${theme.spacing(1.2)};
 `;
+
+export const StyledCheckboxTitle = styled(StyledBodyMedium)`
+  display: flex;
+  align-items: center;
+
+  svg {
+    height: 1.6rem;
+    margin-left: ${theme.spacing(0.4)};
+    margin-top: ${theme.spacing(0.4)};
+  }
+`;

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ReportFilters/ReportFilters.styles.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ReportFilters/ReportFilters.styles.ts
@@ -28,7 +28,6 @@ export const StyledCheckboxTitle = styled(StyledBodyMedium)`
 
   svg {
     height: 1.6rem;
-    margin-left: ${theme.spacing(0.4)};
-    margin-top: ${theme.spacing(0.4)};
+    display: block;
   }
 `;

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ReportFilters/ReportFilters.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ReportFilters/ReportFilters.tsx
@@ -236,7 +236,7 @@ export const ReportFilters = ({
                 data-testid={`${dataTestid}-versions`}
               />
             </Box>
-            <Box sx={{ width: '24rem', ml: theme.spacing(2.4) }}>
+            <Box sx={{ whiteSpace: 'nowrap', ml: 2.4 }}>
               <CheckboxController
                 name="hideSkipped"
                 control={control}
@@ -251,7 +251,7 @@ export const ReportFilters = ({
                   </StyledCheckboxTitle>
                 }
                 data-testid={`${dataTestid}-hide-skipped`}
-                sx={{ mr: theme.spacing(0) }}
+                sx={{ mr: 0 }}
                 onCustomChange={() => setSkipped(!hideSkipped)}
               />
             </Box>

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ReportFilters/ReportFilters.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ReportFilters/ReportFilters.tsx
@@ -1,25 +1,41 @@
-import { ChangeEvent } from 'react';
+import { ChangeEvent, useEffect } from 'react';
 import { Box } from '@mui/material';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { Trans, useTranslation } from 'react-i18next';
 import { addDays } from 'date-fns';
 
-import { DatePicker, TimePicker } from 'shared/components';
-import { StyledBodyLarge, StyledFlexTopCenter, theme, variables } from 'shared/styles';
-import { Switch, TagsAutocompleteController } from 'shared/components/FormComponents';
+import { DatePicker, TimePicker, Tooltip } from 'shared/components';
+import {
+  StyledBodyLarge,
+  StyledFlexTopCenter,
+  StyledTitleTooltipIcon,
+  theme,
+  variables,
+} from 'shared/styles';
+import {
+  CheckboxController,
+  Switch,
+  TagsAutocompleteController,
+} from 'shared/components/FormComponents';
 import { useRespondentDataContext } from 'modules/Dashboard/features/RespondentData/RespondentDataContext';
 import { DEFAULT_END_TIME, DEFAULT_START_TIME } from 'shared/consts';
 
 import { FetchAnswers } from '../../RespondentDataSummary.types';
 import { useRespondentAnswers } from '../../hooks/useRespondentAnswers';
 import { getUniqueIdentifierOptions } from './ReportFilters.utils';
-import { StyledFiltersContainer, StyledMoreFilters, StyledTimeText } from './ReportFilters.styles';
+import {
+  StyledFiltersContainer,
+  StyledMoreFilters,
+  StyledTimeText,
+  StyledCheckboxTitle,
+} from './ReportFilters.styles';
 import {
   FiltersChangeType,
   OnFiltersChangeParams,
   ReportFiltersProps,
 } from './ReportFilters.types';
 import { MIN_DATE } from './ReportFilters.const';
+import { useDatavizSkippedFilter } from '../../hooks/useDatavizSkippedFilter';
 
 export const ReportFilters = ({
   identifiers = [],
@@ -39,6 +55,7 @@ export const ReportFilters = ({
   ] = useWatch({
     name: ['moreFiltersVisible', 'filterByIdentifier', 'startDate', 'endDate'],
   });
+  const { hideSkipped, setSkipped } = useDatavizSkippedFilter();
 
   const versionsOptions = versions.map(({ version }) => ({ label: version, id: version }));
   const identifiersOptions = getUniqueIdentifierOptions(identifiers);
@@ -88,6 +105,11 @@ export const ReportFilters = ({
     await fetchAnswers(fetchParams);
     setIsLoading(false);
   };
+
+  useEffect(() => {
+    setValue('hideSkipped', hideSkipped);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <form>
@@ -212,6 +234,25 @@ export const ReportFilters = ({
                   })
                 }
                 data-testid={`${dataTestid}-versions`}
+              />
+            </Box>
+            <Box sx={{ width: '24rem', ml: theme.spacing(2.4) }}>
+              <CheckboxController
+                name="hideSkipped"
+                control={control}
+                label={
+                  <StyledCheckboxTitle>
+                    {t('hideSkipped')}
+                    <Tooltip tooltipTitle={t('hideSkippedTooltip')}>
+                      <span>
+                        <StyledTitleTooltipIcon id="more-info-outlined" />
+                      </span>
+                    </Tooltip>
+                  </StyledCheckboxTitle>
+                }
+                data-testid={`${dataTestid}-hide-skipped`}
+                sx={{ mr: theme.spacing(0) }}
+                onCustomChange={() => setSkipped(!hideSkipped)}
               />
             </Box>
           </StyledFlexTopCenter>

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ReportFilters/ReportFilters.types.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/Report/ReportFilters/ReportFilters.types.ts
@@ -17,6 +17,7 @@ export enum FiltersChangeType {
   FilterByIdentifier,
   Identifiers,
   Versions,
+  Skipped,
 }
 
 export type OnFiltersChangeParams = {

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/hooks/useDatavizSkippedFilter.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/hooks/useDatavizSkippedFilter.test.tsx
@@ -1,0 +1,96 @@
+import { renderHook } from '@testing-library/react';
+import { FormProvider, useForm } from 'react-hook-form';
+
+import { SessionStorageKeys } from 'shared/utils';
+import { mockedAppletId } from 'shared/mock';
+
+import { useDatavizSkippedFilter } from './useDatavizSkippedFilter';
+
+const mockedUseParams = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => mockedUseParams(),
+}));
+
+jest.mock('react-hook-form', () => ({
+  ...jest.requireActual('react-hook-form'),
+  useFormContext: () => ({
+    useWatch: () => jest.fn(),
+  }),
+}));
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => {
+  const methods = useForm();
+
+  return <FormProvider {...methods}>{children}</FormProvider>;
+};
+
+describe('useDatavizSkippedFilter', () => {
+  const sessionStorageKey = SessionStorageKeys.DatavizHideSkipped;
+  beforeEach(() => {
+    sessionStorage.clear();
+    jest.resetAllMocks();
+    mockedUseParams.mockReturnValue({ appletId: mockedAppletId });
+  });
+
+  it('returns default value when sessionStorage is not available', () => {
+    const { result } = renderHook(() => useDatavizSkippedFilter(), { wrapper: Wrapper });
+
+    expect(result.current.hideSkipped).toBe(false);
+  });
+
+  it('retrieves value from sessionStorage if available', () => {
+    sessionStorage.setItem(sessionStorageKey, JSON.stringify({ [mockedAppletId]: true }));
+    const { result } = renderHook(() => useDatavizSkippedFilter(), { wrapper: Wrapper });
+
+    expect(result.current.hideSkipped).toBe(true);
+  });
+
+  it('updates sessionStorage when value changes', () => {
+    sessionStorage.setItem(sessionStorageKey, JSON.stringify({ [mockedAppletId]: false }));
+
+    const { result, rerender } = renderHook(() => useDatavizSkippedFilter(), { wrapper: Wrapper });
+    result.current.setSkipped(true);
+    rerender();
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(JSON.parse(sessionStorage.getItem(sessionStorageKey)!)).toEqual({
+      [mockedAppletId]: true,
+    });
+  });
+
+  it('should handle multiple appletIds independently', () => {
+    const { result, rerender } = renderHook(() => useDatavizSkippedFilter(), { wrapper: Wrapper });
+
+    expect(result.current.hideSkipped).toBe(false);
+
+    result.current.setSkipped(true);
+    rerender();
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(JSON.parse(sessionStorage.getItem(SessionStorageKeys.DatavizHideSkipped)!)).toEqual({
+      [mockedAppletId]: true,
+    });
+    expect(result.current.hideSkipped).toBe(true);
+
+    // Switching to another applet
+    mockedUseParams.mockReturnValue({ appletId: 'other-applet' });
+    const { result: result2 } = renderHook(() => useDatavizSkippedFilter(), { wrapper: Wrapper });
+
+    expect(result2.current.hideSkipped).toBe(false);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(JSON.parse(sessionStorage.getItem(SessionStorageKeys.DatavizHideSkipped)!)).toEqual({
+      [mockedAppletId]: true,
+      'other-applet': false,
+    });
+  });
+
+  it('handles missing appletId', () => {
+    mockedUseParams.mockReturnValue({ appletId: '' });
+
+    const { result } = renderHook(() => useDatavizSkippedFilter(), { wrapper: Wrapper });
+
+    expect(result.current.hideSkipped).toBe(false);
+  });
+});

--- a/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/hooks/useDatavizSkippedFilter.ts
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataSummary/hooks/useDatavizSkippedFilter.ts
@@ -1,0 +1,68 @@
+import { useState, useEffect } from 'react';
+import { useWatch } from 'react-hook-form';
+import { useParams } from 'react-router-dom';
+
+import { SessionStorageKeys } from 'shared/utils';
+
+type BooleanMap = Record<string, boolean>;
+
+export const useDatavizSkippedFilter = (
+  defaultValue: boolean = false,
+): { hideSkipped: boolean; setSkipped: (skipped: boolean) => void } => {
+  const { appletId = '' } = useParams();
+
+  const getInitialState = (): BooleanMap => {
+    try {
+      const storedValue = sessionStorage.getItem(SessionStorageKeys.DatavizHideSkipped);
+
+      return storedValue ? JSON.parse(storedValue) : {};
+    } catch (error) {
+      console.warn(
+        'Error reading sessionStorage key:',
+        SessionStorageKeys.DatavizHideSkipped,
+        error,
+      );
+
+      return {};
+    }
+  };
+  const [state, setState] = useState<BooleanMap>(getInitialState);
+  const formVal: boolean = useWatch({
+    name: 'hideSkipped',
+    defaultValue: state[appletId] ?? defaultValue,
+  });
+
+  useEffect(() => {
+    try {
+      sessionStorage.setItem(SessionStorageKeys.DatavizHideSkipped, JSON.stringify(state));
+    } catch (error) {
+      console.error(
+        'Error saving to sessionStorage key:',
+        SessionStorageKeys.DatavizHideSkipped,
+        error,
+      );
+    }
+  }, [state]);
+
+  useEffect(() => {
+    if (appletId) {
+      setState((prev) => ({
+        ...prev,
+        [appletId]: formVal,
+      }));
+    }
+  }, [appletId, formVal]);
+
+  const setSkipped = (value: boolean) => {
+    if (appletId) {
+      setState((prev) => ({
+        ...prev,
+        [appletId]: value,
+      }));
+    }
+  };
+
+  const hideSkipped = state[appletId] ?? defaultValue;
+
+  return { hideSkipped, setSkipped };
+};

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -734,6 +734,8 @@
   "hideBadge": "Hide badge",
   "hideBadgeTooltip": "The Activity Flow identifier will be hidden from Respondents",
   "hideFromCalendar": "Hide from calendar",
+  "hideSkipped": "Hide skipped answers",
+  "hideSkippedTooltip": "This filter persists for this applet until logout.",
   "htmlPreview": "Html preview",
   "idleTime": "Idle time",
   "if": "If",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -734,6 +734,8 @@
   "hideBadge": "Cacher le badge",
   "hideBadgeTooltip": "L'identifiant du Flux d'Activité sera caché aux participants",
   "hideFromCalendar": "Cacher dans le calendrier",
+  "hideSkipped": "Masquer les réponses ignorées",
+  "hideSkippedTooltip": "Ce filtre persiste pour cet applet jusqu'à la déconnexion.",
   "htmlPreview": "Aperçu HTML",
   "idleTime": "Temps d'inactivité",
   "if": "Si",

--- a/src/shared/utils/storage.ts
+++ b/src/shared/utils/storage.ts
@@ -12,6 +12,7 @@ export const enum SessionStorageKeys {
   AccessToken = 'accessToken',
   Workspace = 'workspace',
   DebugMode = 'debugMode',
+  DatavizHideSkipped = 'datavizHideSkipped',
 }
 
 export { secureLocalStorage as storage };


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

Adds a toggle to the More Filters section in DataViz which allows hiding skipped answers from data tables. Enabling this option persists the setting per applet in session storage.

🔗 [Jira Ticket M2-8669](https://mindlogger.atlassian.net/browse/M2-8669)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

This setting will only filter answers for item types using DataTables:

- Short Text
- Paragraph Text
- Date
- Time Range

### 📸 Screenshots

* New toggle under "More filters"

![CleanShot 2025-02-19 at 12 11 59](https://github.com/user-attachments/assets/af78f00c-12cc-4c69-ab16-4b35b6293b41)

* Data Tables

| Hide Skipped **Disabled**                      | Hide Skipped **Enabled**                                 |
| -------------------------------------- | ------------------------------------- |
| ![CleanShot 2025-02-19 at 12 12 11](https://github.com/user-attachments/assets/c75e3d7a-4a84-42e5-b83c-556b5392dd13) | ![CleanShot 2025-02-19 at 12 12 19](https://github.com/user-attachments/assets/e58fc89e-6b1d-4e37-b4cb-2304862c66dd) |

* Data Table is omitted if there are no responses

| Hide Skipped **Disabled**                      | Hide Skipped **Enabled**                                 |
| -------------------------------------- | ------------------------------------- |
| ![CleanShot 2025-02-19 at 12 22 31](https://github.com/user-attachments/assets/a538d20d-f70c-437f-9491-00582e2329aa) | ![CleanShot 2025-02-19 at 12 22 36](https://github.com/user-attachments/assets/3cf9a52e-65fb-4aae-9917-0557f88d125d) |


### 🪤 Peer Testing

- Create 2 applets with 1 or more compatible items (Short Text, Paragraph Text, Date, Time Range)
  - At least 1 item should have be skippable, or have conditional logic which causes the item to be skipped
![CleanShot 2025-02-19 at 12 48 49](https://github.com/user-attachments/assets/968afc34-19cc-4e91-89cd-17a7d41498fc)
 
- Submit 1 or more responses for each applet, making sure to skip answering the test item
- Navigate to Participants > View Data
- Click "More Filters" to show the "Hide Skipped" toggle and enable the setting
- Empty answers should be removed from the data tables, including item counts and pagination
  - ❗  Leave the setting **enabled**
- Navigate back to the participant details
- Reopen DataViz, "Hide Skipped" should default to enabled
- Navigate to a different applet and open DataViz
  - ❗   Hide Skipped should be **disabled** (default)
- Logging out will clear the session storage resetting all applets back to default

