### PR TITLE
fix: update date parsing from backend (M2-8720)

### DIFF
--- a/src/modules/Builder/pages/BuilderApplet/BuilderApplet.utils.tsx
+++ b/src/modules/Builder/pages/BuilderApplet/BuilderApplet.utils.tsx
@@ -788,7 +788,7 @@ const formatTime = (hours: number, minutes: number) => {
   return `${formattedHours}:${formattedMinutes}`;
 };
 
-const formatDate = (dateValue: string) => {
+const parseDate = (dateValue: string) => {
   const date = dateValue ? parseISO(dateValue) : undefined;
 
   return date;

--- a/src/modules/Builder/pages/BuilderApplet/BuilderApplet.utils.tsx
+++ b/src/modules/Builder/pages/BuilderApplet/BuilderApplet.utils.tsx
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { ColorResult } from 'react-color';
 import get from 'lodash.get';
 import * as yup from 'yup';
+import { parseISO } from 'date-fns';
 
 import i18n from 'i18n';
 import { page } from 'resources';
@@ -44,7 +45,6 @@ import {
   getTextBetweenBrackets,
   INTERVAL_SYMBOL,
   isSystemItem,
-  parseDateToMidnightUTC,
   Path,
   pluck,
 } from 'shared/utils';
@@ -789,7 +789,7 @@ const formatTime = (hours: number, minutes: number) => {
 };
 
 const formatDate = (dateValue: string) => {
-  const date = dateValue ? parseDateToMidnightUTC(dateValue) : undefined;
+  const date = dateValue ? parseISO(dateValue) : undefined;
 
   return date;
 };

--- a/src/modules/Builder/pages/BuilderApplet/BuilderApplet.utils.tsx
+++ b/src/modules/Builder/pages/BuilderApplet/BuilderApplet.utils.tsx
@@ -801,7 +801,7 @@ const getConditionPayload = (item: Item, condition: Condition) => {
 
     return {
       ...conditionPayload,
-      date: formatDate(conditionPayload.date),
+      date: parseDate(conditionPayload.date),
     };
   }
   if (DATE_INTERVAL_CONDITION_TYPES.includes(conditionType)) {
@@ -809,8 +809,8 @@ const getConditionPayload = (item: Item, condition: Condition) => {
 
     return {
       ...conditionPayload,
-      minDate: formatDate(conditionPayload.minDate),
-      maxDate: formatDate(conditionPayload.maxDate),
+      minDate: parseDate(conditionPayload.minDate),
+      maxDate: parseDate(conditionPayload.maxDate),
     };
   }
   if (TIME_SINGLE_CONDITION_TYPES.includes(conditionType)) {


### PR DESCRIPTION
### 📝 Description

Changed how dates are parsed from the backend. 

🔗 [Jira Ticket M2-8720](https://mindlogger.atlassian.net/browse/M2-8720)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| ![CleanShot 2025-02-20 at 12 47 48](https://github.com/user-attachments/assets/7fe0cd2e-fc52-42bc-a821-0faf79f1962e) | ![CleanShot 2025-02-20 at 12 47 04](https://github.com/user-attachments/assets/1b85bbb5-7709-4dfe-8d15-ba7ec9e960d2) |

### 🪤 Peer Testing

- Create an activity with 2 items, Date + other item types.
- Add conditional logic using the Date as condition
- Select a date
- **Date should be the same** after closing the Date Picker
- Save applet
- **Date should remain the same** as previously selected
- Refreshing the page **should show the same date**