### PR TITLE
fix: Support possible empty nickname for Team Members (M2-8757)

### DIFF
--- a/src/modules/Dashboard/components/ParticipantDropdown/ParticipantDropdown.test.tsx
+++ b/src/modules/Dashboard/components/ParticipantDropdown/ParticipantDropdown.test.tsx
@@ -1,8 +1,13 @@
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
 import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
+import {
+  mockedFullParticipant1WithDataAccess,
+  mockedOwnerParticipantWithDataAccess,
+} from 'shared/mock';
 
 import { ParticipantDropdown } from './ParticipantDropdown';
 import { ParticipantDropdownOption } from './ParticipantDropdown.types';
+import { participantToOption } from './ParticipantDropdown.utils';
 
 jest.mock('shared/hooks/useFeatureFlags');
 
@@ -80,5 +85,46 @@ describe('ParticipantDropdown', () => {
     );
 
     expect(queryByDisplayValue(testValue.secretId as string)).toBeInTheDocument();
+  });
+});
+
+describe('participantToOption', () => {
+  test('converts regular participant to option correctly', () => {
+    const result = participantToOption(mockedFullParticipant1WithDataAccess);
+
+    expect(result).toEqual({
+      id: 'subject-id-987',
+      userId: 'b60a142d-2b7f-4328-841c-dbhjhj4afcf1c7',
+      secretId: 'mockedSecretId',
+      nickname: 'Mocked Respondent',
+      tag: 'Child',
+      isTeamMember: false,
+      roles: ['respondent'],
+    });
+  });
+
+  test('handles team member correctly', () => {
+    const result = participantToOption(mockedOwnerParticipantWithDataAccess);
+
+    expect(result.isTeamMember).toBe(true);
+    expect(result.roles).toEqual(['owner', 'respondent']);
+  });
+
+  test('handles team member with missing nickname', () => {
+    const teamMemberWithoutNickname = {
+      ...mockedOwnerParticipantWithDataAccess,
+      nicknames: [],
+    };
+
+    const result = participantToOption(teamMemberWithoutNickname);
+
+    expect(result.nickname).toBe('Jane Doe');
+    expect(result.isTeamMember).toBe(true);
+  });
+
+  test('handles participant with tag', () => {
+    const result = participantToOption(mockedFullParticipant1WithDataAccess);
+
+    expect(result.tag).toBe('Child');
   });
 });

--- a/src/modules/Dashboard/components/ParticipantDropdown/ParticipantDropdown.utils.ts
+++ b/src/modules/Dashboard/components/ParticipantDropdown/ParticipantDropdown.utils.ts
@@ -6,7 +6,19 @@ import { TEAM_MEMBER_ROLES } from 'shared/consts';
 import { ParticipantDropdownOption } from './ParticipantDropdown.types';
 
 export const participantToOption = (participant: Participant): ParticipantDropdownOption => {
-  const stringNicknames = joinWihComma(participant.nicknames, true);
+  const isTeamMember = participant.details[0].roles.some((role) =>
+    TEAM_MEMBER_ROLES.includes(role),
+  );
+
+  let stringNicknames = joinWihComma(participant.nicknames, true);
+  // Due to a BE bug, for certain edge cases, it's possible for Team Members to lack nicknames; if
+  // so, fall back to full name (which is what the BE should be doing consistently).
+  if (!stringNicknames && isTeamMember) {
+    stringNicknames = joinWihComma(
+      participant.details.map((d) => `${d.subjectFirstName} ${d.subjectLastName}`),
+      true,
+    );
+  }
   const stringSecretIds = joinWihComma(participant.secretIds, true);
 
   return {
@@ -15,7 +27,7 @@ export const participantToOption = (participant: Participant): ParticipantDropdo
     secretId: stringSecretIds,
     nickname: stringNicknames,
     tag: participant.details[0].subjectTag,
-    isTeamMember: participant.details[0].roles.some((role) => TEAM_MEMBER_ROLES.includes(role)),
+    isTeamMember,
     roles: participant.details[0].roles,
   };
 };


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-8757](https://mindlogger.atlassian.net/browse/M2-8757)

It's possible to add a Team Member that lacks a nickname field by adding them as a Full Account first. Normally, the BE auto-populates the subject record's `nickname` with `[first name] [last name]`, but this procedure bypasses that.

This is a problem because the nickname field is the only thing shown in participant dropdowns (used by Take Now and Assign Activity) for Team Members, and if that field is empty (along with missing the Team tag, which is a related bug that will be taken care of in a separate BE ticket), those rows can end up being empty.

### 📸 Screenshots

(FYI, the participants listed are indeed team members despite their "Full" account names.)

| Before                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| ![CleanShot 2025-02-26 at 17 55 17@2x](https://github.com/user-attachments/assets/cbab3ba9-0b6b-4a8e-9100-a8692a176e11) | ![CleanShot 2025-02-26 at 17 55 43@2x](https://github.com/user-attachments/assets/8607c3c6-9508-4300-9c97-5b65b29cff5f) |

### 🪤 Peer Testing

1.  Create a new applet.
2.  From **Applet > Participants**, click **Add Participant** > **Full Account** > fill in only required fields using a known accessible email address. Leave Nickname and Tag blank, and submit the form.
3.  Accept the invitation from the email so that the Full Account is now added to the applet.
4.  From **Applet > Team**, click **Add Team Member** > fill in required fields using the **same email address** as in step 1.
5.  Accept the invitation from the email so that the account has not been converted into a Team Member.
6.  On the **Applet > Participants** tab, observe the **Nickname** column for the row associated with the new Team Member account.
    -   **Expected outcome:** Nickname should be `[first name] [last name]`. (Ignore the fact that it's missing the Team tag; this task is not intended to fix that separate issue.)
7.  From **Applet > Activities**, open the **Take Now** modal for any activity, and observe the contents of the dropdowns.
    -   **Expected outcome:** There should be no blank rows in the dropdowns; the new Team Member should be listed as `[first name] [last name]`. (Ignore the fact that it's missing the Team tag; this task is not intended to fix that separate issue.)