### PR TITLE
feat: add events tracking for Prolific

### DIFF
--- a/src/modules/Builder/features/BuilderAppletSettings/IntegrationsListSetting/Integrations/ProlificIntegration/ProlificIntegration.test.tsx
+++ b/src/modules/Builder/features/BuilderAppletSettings/IntegrationsListSetting/Integrations/ProlificIntegration/ProlificIntegration.test.tsx
@@ -4,7 +4,7 @@ import { Provider } from 'react-redux';
 import { createStore } from '@reduxjs/toolkit';
 
 import { mockedApplet } from 'shared/mock';
-import { getUserDetailsApi } from 'api';
+import { auth } from 'redux/modules';
 
 import { ProlificIntegration } from './ProlificIntegration';
 import { prolificIntegrationExists } from './ProlificIntegration.utils';
@@ -13,9 +13,7 @@ jest.mock('./ProlificIntegration.utils', () => ({
   prolificIntegrationExists: jest.fn(),
 }));
 
-jest.mock('api', () => ({
-  getUserDetailsApi: jest.fn(),
-}));
+jest.mock('redux/modules');
 
 const preloadedStateWithoutIntegration = {
   applet: {
@@ -44,7 +42,7 @@ describe('ProlificIntegration', () => {
 
   test('should render the ProlificIntegration component when api token does not exist', () => {
     (prolificIntegrationExists as jest.Mock).mockResolvedValue(false);
-    (getUserDetailsApi as jest.Mock).mockResolvedValue({ data: { result: { id: '123' } } });
+    (auth.useData as jest.Mock).mockResolvedValue({ user: { id: '123' } });
 
     renderWithStore(preloadedStateWithoutIntegration);
 
@@ -59,7 +57,7 @@ describe('ProlificIntegration', () => {
 
   test('should render the ProlificIntegration connected component when api token exists', async () => {
     (prolificIntegrationExists as jest.Mock).mockResolvedValue(true);
-    (getUserDetailsApi as jest.Mock).mockResolvedValue({ data: { result: { id: '123' } } });
+    (auth.useData as jest.Mock).mockResolvedValue({ user: { id: '123' } });
 
     renderWithStore(preloadedStateWithoutIntegration);
 

--- a/src/modules/Builder/features/BuilderAppletSettings/IntegrationsListSetting/Integrations/ProlificIntegration/ProlificIntegration.test.tsx
+++ b/src/modules/Builder/features/BuilderAppletSettings/IntegrationsListSetting/Integrations/ProlificIntegration/ProlificIntegration.test.tsx
@@ -4,12 +4,17 @@ import { Provider } from 'react-redux';
 import { createStore } from '@reduxjs/toolkit';
 
 import { mockedApplet } from 'shared/mock';
+import { getUserDetailsApi } from 'api';
 
 import { ProlificIntegration } from './ProlificIntegration';
 import { prolificIntegrationExists } from './ProlificIntegration.utils';
 
 jest.mock('./ProlificIntegration.utils', () => ({
   prolificIntegrationExists: jest.fn(),
+}));
+
+jest.mock('api', () => ({
+  getUserDetailsApi: jest.fn(),
 }));
 
 const preloadedStateWithoutIntegration = {
@@ -39,6 +44,7 @@ describe('ProlificIntegration', () => {
 
   test('should render the ProlificIntegration component when api token does not exist', () => {
     (prolificIntegrationExists as jest.Mock).mockResolvedValue(false);
+    (getUserDetailsApi as jest.Mock).mockResolvedValue({ data: { result: { id: '123' } } });
 
     renderWithStore(preloadedStateWithoutIntegration);
 
@@ -53,6 +59,7 @@ describe('ProlificIntegration', () => {
 
   test('should render the ProlificIntegration connected component when api token exists', async () => {
     (prolificIntegrationExists as jest.Mock).mockResolvedValue(true);
+    (getUserDetailsApi as jest.Mock).mockResolvedValue({ data: { result: { id: '123' } } });
 
     renderWithStore(preloadedStateWithoutIntegration);
 

--- a/src/modules/Builder/features/BuilderAppletSettings/IntegrationsListSetting/Integrations/ProlificIntegration/ProlificIntegration.tsx
+++ b/src/modules/Builder/features/BuilderAppletSettings/IntegrationsListSetting/Integrations/ProlificIntegration/ProlificIntegration.tsx
@@ -15,7 +15,7 @@ import {
   theme,
   variables,
 } from 'shared/styles';
-import { getUserDetailsApi } from 'api';
+import { auth } from 'redux/modules';
 
 import { ConfigurationPopup } from './ConfigurationPopup/ConfigurationPopup';
 import { DisconnectionPopup } from './DisconnectionPopup/DisconnectionPopup';
@@ -81,6 +81,8 @@ const ProlifcIntegrationApplet = ({ appletData }: ProlificIntegrationAppletProps
     trackProlificEvent(MixpanelEventType.ProlificConnectSuccessful, userId);
   };
 
+  const user = auth.useData()?.user;
+
   useEffect(() => {
     const checkProlificApiToken = async () => {
       const hasLocalProlificIntegration =
@@ -95,17 +97,10 @@ const ProlifcIntegrationApplet = ({ appletData }: ProlificIntegrationAppletProps
       }));
     };
 
-    const getCurrentUser = async () => {
-      const user = await getUserDetailsApi();
-
-      if (user.data?.result) {
-        setState((prevState) => ({ ...prevState, userId: user.data.result.id }));
-      }
-    };
-
     checkProlificApiToken();
-    getCurrentUser();
-  }, [appletData.id, appletData.integrations]);
+
+    setState((prevState) => ({ ...prevState, userId: user?.id ?? null }));
+  }, [appletData.id, appletData.integrations, user]);
 
   const { t } = useTranslation('app');
 

--- a/src/modules/Builder/features/BuilderAppletSettings/IntegrationsListSetting/Integrations/ProlificIntegration/ProlificIntegration.utils.ts
+++ b/src/modules/Builder/features/BuilderAppletSettings/IntegrationsListSetting/Integrations/ProlificIntegration/ProlificIntegration.utils.ts
@@ -3,6 +3,13 @@ import { AxiosError } from 'axios';
 
 import { authApiClient } from 'shared/api/apiConfig';
 import { IntegrationTypes } from 'shared/consts';
+import {
+  Mixpanel,
+  MixpanelEventType,
+  MixpanelProps,
+  ProlificConnectClickEvent,
+  ProlificConnectSuccessfulEvent,
+} from 'shared/utils';
 
 export const createProlificIntegration = async (apiToken: string, appletId?: string) => {
   try {
@@ -61,4 +68,17 @@ export const deleteProlificIntegration = async (appletId: string) => {
   if (response.status !== 204) {
     throw new Error('Failed to delete Prolific API Token');
   }
+};
+
+type ProlificEvent = ProlificConnectClickEvent | ProlificConnectSuccessfulEvent;
+type ProlificEventType =
+  | MixpanelEventType.ProlificConnectClick
+  | MixpanelEventType.ProlificConnectSuccessful;
+
+export const trackProlificEvent = (action: ProlificEventType, userId: string | null) => {
+  if (!userId) return;
+  const event: ProlificEvent = { action };
+  event[MixpanelProps.UserId] = userId;
+
+  Mixpanel.track(event);
 };

--- a/src/shared/utils/mixpanel/mixpanel.types.ts
+++ b/src/shared/utils/mixpanel/mixpanel.types.ts
@@ -5,6 +5,7 @@ export enum MixpanelProps {
   AppletId = 'Applet ID',
   ActivityId = 'Activity ID',
   ActivityFlowId = 'Activity Flow ID',
+  UserId = 'User ID',
   AverageItemsPerPhraseBuilder = 'Average Items per Phrase Builder',
   AverageLineBreaksPerPhraseBuilder = 'Average Line Breaks per Phrase Builder',
   AverageTextBoxesPerPhraseBuilder = 'Average Text Boxes per Phrase Builder',
@@ -99,6 +100,8 @@ export enum MixpanelEventType {
   ConfirmAssignActivityOrFlow = 'Confirm Assign Activity/Flow',
   StartUnassignActivityOrFlow = 'Start Unassign Activity/Flow',
   ConfirmUnassignActivityOrFlow = 'Confirm Unassign Activity/Flow',
+  ProlificConnectClick = 'Prolific Connect clicked',
+  ProlificConnectSuccessful = 'Prolific Connect successful',
 }
 
 export type MixpanelAppletSaveEventType =
@@ -126,6 +129,7 @@ export const MixpanelCalendarEvent = {
 } as const;
 
 type WithAppletId<T> = T & { [MixpanelProps.AppletId]?: string | null };
+type WithUserId<T> = T & { [MixpanelProps.UserId]?: string | null };
 
 export type WithFeature<T = object> = T & {
   [MixpanelProps.Feature]?: MixpanelFeature[];
@@ -479,6 +483,14 @@ export type ConfirmUnAssignActivityOrFlowEvent = WithAppletId<{
   [MixpanelProps.MultiInformantAssignmentCount]?: number;
 }>;
 
+export type ProlificConnectClickEvent = WithUserId<{
+  action: MixpanelEventType.ProlificConnectClick;
+}>;
+
+export type ProlificConnectSuccessfulEvent = WithUserId<{
+  action: MixpanelEventType.ProlificConnectSuccessful;
+}>;
+
 export type MixpanelEvent =
   | MixpanelInvitationSentEvent
   | LoginSuccessfulEvent
@@ -543,4 +555,6 @@ export type MixpanelEvent =
   | StartAssignActivityOrFlowEvent
   | ConfirmAssignActivityOrFlowEvent
   | StartUnassignActivityOrFlowEvent
-  | ConfirmUnAssignActivityOrFlowEvent;
+  | ConfirmUnAssignActivityOrFlowEvent
+  | ProlificConnectClickEvent
+  | ProlificConnectSuccessfulEvent;


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to MindLogger [open source credit page](https://mindlogger.atlassian.net/wiki/spaces/MINDLOGGER1/pages/263127186/Admin+Panel+Applet+Builder+Library)
- [ ] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description
This PR adds a tracking of prolific events on the Admin panel. The following two events are now tracked:
- ProlificConnectClick
- ProlificConnectSuccessful

Data sent includes:
- UserId

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-8751](https://mindlogger.atlassian.net/browse/M2-8751)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Changes include:

- Retrieval of the `UserId` on mount.
- Addition of Prolific Event Types
