### PR TITLE
fix: Error on Dataviz first load (M2-8779)

### DIFF
--- a/src/modules/Dashboard/pages/Applet/AppletMultiInformant.tsx
+++ b/src/modules/Dashboard/pages/Applet/AppletMultiInformant.tsx
@@ -1,5 +1,4 @@
-import { useEffect, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { useState } from 'react';
 import { Outlet, useLocation, useParams } from 'react-router-dom';
 import { Tooltip } from '@mui/material';
 
@@ -15,7 +14,7 @@ import {
 } from 'shared/styles';
 import { applet } from 'shared/state';
 import { useAppDispatch } from 'redux/store';
-import { usePermissions, useRemoveAppletData } from 'shared/hooks';
+import { usePermissions } from 'shared/hooks';
 import { palette } from 'shared/styles/variables/palette';
 import { ExportDataSetting } from 'shared/features/AppletSettings';
 import { StyledPanel } from 'shared/components/Tabs/TabPanel/TabPanel.style';
@@ -24,7 +23,6 @@ import { useMultiInformantAppletTabs } from './Applet.hooks';
 
 export const AppletMultiInformant = () => {
   const [isExportOpen, setIsExportOpen] = useState<boolean>(false);
-  const { t } = useTranslation('app');
 
   const dispatch = useAppDispatch();
   const location = useLocation();
@@ -34,16 +32,15 @@ export const AppletMultiInformant = () => {
 
   const { result: appletData } = applet.useAppletData() ?? {};
   const appletLoadingStatus = applet.useResponseStatus();
-  const removeAppletData = useRemoveAppletData();
 
   const hiddenHeader = location.pathname.includes('dataviz');
   const { getApplet } = applet.thunk;
 
-  const { isForbidden, noPermissionsComponent } = usePermissions(() =>
-    appletId ? dispatch(getApplet({ appletId })) : undefined,
+  const { isForbidden, noPermissionsComponent } = usePermissions(
+    () => (appletId ? dispatch(getApplet({ appletId })) : undefined),
+    // Refetch applet data when appletId changes
+    [appletId],
   );
-
-  useEffect(() => removeAppletData, []);
 
   if (isForbidden) return noPermissionsComponent;
 

--- a/src/shared/utils/exportData/getSubscales.ts
+++ b/src/shared/utils/exportData/getSubscales.ts
@@ -104,34 +104,36 @@ export const calcScores = <T>(
 
     let value: number | null = null;
 
-    if (typedOptions && 'options' in typedOptions && typedOptions.options.length) {
-      // Single & Multiple Select
-      const scoresObject = typedOptions.options.reduce((acc: ScoresObject, item) => {
-        if (item.value !== undefined && item.score !== undefined) {
-          acc[item.value as keyof ScoresObject] = item.score;
+    if (typedOptions) {
+      if ('options' in typedOptions && typedOptions.options.length) {
+        // Single & Multiple Select
+        const scoresObject = typedOptions.options.reduce((acc: ScoresObject, item) => {
+          if (item.value !== undefined && item.score !== undefined) {
+            acc[item.value as keyof ScoresObject] = item.score;
+          }
+
+          return acc;
+        }, {});
+
+        if (Array.isArray(answer?.value)) {
+          value =
+            answer?.value.reduce((result: null | number, val) => {
+              if (scoresObject[val] === null) return result;
+
+              return (result ?? 0) + scoresObject[val];
+            }, null) ?? null;
+        } else {
+          value = (answer && scoresObject[answer.value]) ?? null;
         }
+      } else if ('scores' in typedOptions && typedOptions.scores?.length) {
+        // Slider
+        const min = Number(typedOptions.minValue);
+        const max = Number(typedOptions.maxValue);
+        const scores = typedOptions.scores;
+        const options = createArrayFromMinToMax(min, max);
 
-        return acc;
-      }, {});
-
-      if (Array.isArray(answer?.value)) {
-        value =
-          answer?.value.reduce((result: null | number, val) => {
-            if (scoresObject[val] === null) return result;
-
-            return (result ?? 0) + scoresObject[val];
-          }, null) ?? null;
-      } else {
-        value = (answer && scoresObject[answer.value]) ?? null;
+        value = scores[options.findIndex((item) => item === answer?.value)] ?? null;
       }
-    } else if (typedOptions && 'scores' in typedOptions && typedOptions.scores?.length) {
-      // Slider
-      const min = Number(typedOptions.minValue);
-      const max = Number(typedOptions.maxValue);
-      const scores = typedOptions.scores;
-      const options = createArrayFromMinToMax(min, max);
-
-      value = scores[options.findIndex((item) => item === answer?.value)] ?? null;
     }
 
     // New feature-flagged behaviour also treats skipped responses as null.

--- a/src/shared/utils/exportData/getSubscales.ts
+++ b/src/shared/utils/exportData/getSubscales.ts
@@ -104,7 +104,7 @@ export const calcScores = <T>(
 
     let value: number | null = null;
 
-    if ('options' in typedOptions && typedOptions.options.length) {
+    if (typedOptions && 'options' in typedOptions && typedOptions.options.length) {
       // Single & Multiple Select
       const scoresObject = typedOptions.options.reduce((acc: ScoresObject, item) => {
         if (item.value !== undefined && item.score !== undefined) {
@@ -124,7 +124,7 @@ export const calcScores = <T>(
       } else {
         value = (answer && scoresObject[answer.value]) ?? null;
       }
-    } else if ('scores' in typedOptions && typedOptions.scores?.length) {
+    } else if (typedOptions && 'scores' in typedOptions && typedOptions.scores?.length) {
       // Slider
       const min = Number(typedOptions.minValue);
       const max = Number(typedOptions.maxValue);


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-8779](https://mindlogger.atlassian.net/browse/M2-8779)

The Dashboard > Applet screen was deleting the Redux-stored applet data after it was unmounted, causing moments during navigation to subscreens when the required encryption data was not available to be able to decrypt answers. This resulted in an error when navigating to Dataviz for the first time, but only when there are subscales and there is reasonable network latency.

It appears that applet data was being removed in the `AppletMultiInformant` screen as a manual approach to invalidating cache, ensuring it's refreshed in case `appletId` changes. However, the better approach is to include `appletId` as a dependency on the fetching callback, which is possible by passing it as an optional dep to the `usePermissions` hook.

Also, updated the `calcScores` function to handle the possibility that the answer data is unavailable to prevent displaying a JS error in the React UI.

### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

| Before                       | After                                 |
| -------------------------------------- | ------------------------------------- |
| <video src="https://github.com/user-attachments/assets/c6cb9b39-9572-4df4-bd13-f86ca5401a93"></video> | <video src="https://github.com/user-attachments/assets/64eca661-ca4c-410d-b129-dcbe21649469"></video> |

### 🪤 Peer Testing

**Preconditions**

1.  Create an activity with an item that has scoring enabled.
2.  Add a subscale calculated from that item (no lookup table needed).

**Steps to Reproduce the Issue**

1.  In the Web App, submit an activity assessment.
2.  Start a new login session in the Admin App.
3.  Open DevTools (command+option+I), navigate to the **Network** tab, choose **Slow 4G** from the throttling dropdown. (**Fast 4G** often works as well, but less consistently.)
    <img src="https://github.com/user-attachments/assets/a145806d-f116-404d-91a0-82422e10ef91" width="450">
4.  Navigate to the Applet Overview screen, and click the most recent submission in the list.
    **Expected outcome:** Dataviz should render correctly.
