### PR TITLE
fix: Clear previous applet data when creating new applet (M2-8920)

### DIFF
--- a/src/modules/Builder/pages/BuilderApplet/BuilderApplet.tsx
+++ b/src/modules/Builder/pages/BuilderApplet/BuilderApplet.tsx
@@ -31,7 +31,11 @@ export const BuilderApplet = () => {
   const hiddenHeader = !!params.activityId || !!params.activityFlowId;
   const dispatch = useAppDispatch();
   const { appletId } = useParams();
+  const removeAppletData = useRemoveAppletData();
   const isNewApplet = useCheckIfNewApplet();
+  if (isNewApplet) {
+    removeAppletData();
+  }
   const redirectedFromBuilder = forbiddenState.useData()?.redirectedFromBuilder ?? {};
   const { result: appletData } = applet.useAppletData() ?? {};
   const { getAppletWithItems } = applet.thunk;
@@ -44,7 +48,6 @@ export const BuilderApplet = () => {
     appletResponseType === 'applet/getAppletWithItems' &&
     !isNewApplet;
   const { ownerId } = workspaces.useData() || {};
-  const removeAppletData = useRemoveAppletData();
   const [isAppletInitialized, setAppletInitialized] = useState(false);
   const { data: dataFromLibrary, isFromLibrary } = location.state ?? {};
   const hasLibraryData = isFromLibrary && !!dataFromLibrary;

--- a/src/modules/Builder/pages/BuilderApplet/BuilderApplet.tsx
+++ b/src/modules/Builder/pages/BuilderApplet/BuilderApplet.tsx
@@ -31,13 +31,10 @@ export const BuilderApplet = () => {
   const hiddenHeader = !!params.activityId || !!params.activityFlowId;
   const dispatch = useAppDispatch();
   const { appletId } = useParams();
-  const removeAppletData = useRemoveAppletData();
   const isNewApplet = useCheckIfNewApplet();
-  if (isNewApplet) {
-    removeAppletData();
-  }
   const redirectedFromBuilder = forbiddenState.useData()?.redirectedFromBuilder ?? {};
-  const { result: appletData } = applet.useAppletData() ?? {};
+  const { result: appletDataResult } = applet.useAppletData() ?? {};
+  const appletData = !isNewApplet ? appletDataResult : undefined;
   const { getAppletWithItems } = applet.thunk;
   const { result: themesList = [] } = themes.useThemesData() || {};
   const loadingStatus = applet.useResponseStatus();
@@ -48,6 +45,7 @@ export const BuilderApplet = () => {
     appletResponseType === 'applet/getAppletWithItems' &&
     !isNewApplet;
   const { ownerId } = workspaces.useData() || {};
+  const removeAppletData = useRemoveAppletData();
   const [isAppletInitialized, setAppletInitialized] = useState(false);
   const { data: dataFromLibrary, isFromLibrary } = location.state ?? {};
   const hasLibraryData = isFromLibrary && !!dataFromLibrary;


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-8920](https://mindlogger.atlassian.net/browse/M2-8920)

This PR intercepts the stored applet data on the applet builder screen, and returns an empty object if the user navigated there to create a new applet.

### 📸 Screenshots

**Before**

https://github.com/user-attachments/assets/92fa2508-e55d-496c-838c-d9da6bba9eec

**After**

https://github.com/user-attachments/assets/03525378-4633-460c-9c0e-05aff585cdcc

### 🪤 Peer Testing

1. Log in to the admin panel
2. Without clicking anything else, create an applet and save it
3. Navigate to the applet overview screen
4. Navigate back to the dashboard
5. Click Add applet, then click New
6. Confirm that all fields are empty
7. Fill in the required minimum fields and save the applet
8. Confirm that the applet can be saved

### ✏️ Notes

1. This seems to have existed prior to #2048. That PR just made it more obvious. For example, you could previously produce this using the following steps:
    1. Navigate to the Dashboard
    2. Click on an applet to view the Applet overview screen
    3. Click on a submission to go to the Dataviz summary screen
    4. Navigate back to the Dashboard
    5. Click add applet
    6. Click new
    
    This PR should fix it everywhere
