### PR TITLE
feat: Request Health Record Data item type (available setup) (M2-8927)

### DIFF
--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/GroupedSelectSearchController/GroupedSelectSearchController.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/GroupedSelectSearchController/GroupedSelectSearchController.tsx
@@ -128,7 +128,7 @@ export const GroupedSelectSearchController = <T extends FieldValues>({
         name={name}
         control={control}
         render={({ field: { onChange, value }, fieldState: { error } }) => {
-          const handleOnSelectChange = (event: SelectChangeEvent<unknown>, _: ReactNode) => {
+          const handleOnSelectChange = (event: SelectChangeEvent<unknown>, child: ReactNode) => {
             const newValue = event.target.value as ItemResponseType;
 
             if (onBeforeChange && !onBeforeChange(newValue)) {
@@ -137,14 +137,14 @@ export const GroupedSelectSearchController = <T extends FieldValues>({
 
             if (checkIfSelectChangePopupIsVisible) {
               checkIfSelectChangePopupIsVisible(() => {
-                onChange(event);
+                onChange(event, child);
                 processItemType(event as ChangeEvent<HTMLInputElement>);
               });
 
               return;
             }
 
-            onChange(event);
+            onChange(event, child);
             processItemType(event as ChangeEvent<HTMLInputElement>);
           };
 

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/GroupedSelectSearchController/GroupedSelectSearchController.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/GroupedSelectSearchController/GroupedSelectSearchController.tsx
@@ -1,5 +1,13 @@
-import { Box, BoxProps, FormControl, FormHelperText, InputLabel, TextField } from '@mui/material';
-import { ChangeEvent, MouseEvent, useState } from 'react';
+import {
+  Box,
+  BoxProps,
+  FormControl,
+  FormHelperText,
+  InputLabel,
+  SelectChangeEvent,
+  TextField,
+} from '@mui/material';
+import { ChangeEvent, MouseEvent, ReactNode, useState } from 'react';
 import { Controller, FieldValues } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
@@ -120,8 +128,8 @@ export const GroupedSelectSearchController = <T extends FieldValues>({
         name={name}
         control={control}
         render={({ field: { onChange, value }, fieldState: { error } }) => {
-          const handleOnSelectChange = (...props: unknown[]) => {
-            const newValue = (props[0] as { target: { value: ItemResponseType } }).target.value;
+          const handleOnSelectChange = (event: SelectChangeEvent<unknown>, _: ReactNode) => {
+            const newValue = event.target.value as ItemResponseType;
 
             if (onBeforeChange && !onBeforeChange(newValue)) {
               return;
@@ -129,15 +137,15 @@ export const GroupedSelectSearchController = <T extends FieldValues>({
 
             if (checkIfSelectChangePopupIsVisible) {
               checkIfSelectChangePopupIsVisible(() => {
-                onChange(...props);
-                processItemType(props[0] as ChangeEvent<HTMLInputElement>);
+                onChange(event);
+                processItemType(event as ChangeEvent<HTMLInputElement>);
               });
 
               return;
             }
 
-            onChange(...props);
-            processItemType(props[0] as ChangeEvent<HTMLInputElement>);
+            onChange(event);
+            processItemType(event as ChangeEvent<HTMLInputElement>);
           };
 
           return (

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/GroupedSelectSearchController/GroupedSelectSearchController.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/GroupedSelectSearchController/GroupedSelectSearchController.tsx
@@ -1,27 +1,27 @@
-import { ChangeEvent, MouseEvent, useState } from 'react';
-import { useTranslation } from 'react-i18next';
-import { Controller, FieldValues } from 'react-hook-form';
 import { Box, BoxProps, FormControl, FormHelperText, InputLabel, TextField } from '@mui/material';
+import { ChangeEvent, MouseEvent, useState } from 'react';
+import { Controller, FieldValues } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 
-import { Svg } from 'shared/components/Svg';
-import { StyledClearedButton, StyledFlexTopCenter, theme } from 'shared/styles';
-import { falseReturnFunc, getIsMobileOnly, getIsWebOnly } from 'shared/utils';
-import { ItemResponseType, itemsTypeIcons } from 'shared/consts';
 import { ItemResponseTypeNoPerfTasks } from 'modules/Builder/types';
 import { Chip, ChipShape, OptionalTooltipWrapper } from 'shared/components';
+import { Svg } from 'shared/components/Svg';
+import { ItemResponseType, itemsTypeIcons } from 'shared/consts';
 import { useFeatureFlags } from 'shared/hooks';
+import { StyledClearedButton, StyledFlexTopCenter, theme } from 'shared/styles';
+import { falseReturnFunc, getIsMobileOnly, getIsWebOnly } from 'shared/utils';
 
-import { GroupedSelectControllerProps } from './GroupedSelectSearchController.types';
+import { getItemsTypeChip } from '../ItemConfiguration.utils';
+import { selectDropdownStyles } from './GroupedSelectSearchController.const';
+import { useItemTypeSelectSetup } from './GroupedSelectSearchController.hooks';
 import {
   StyledListSubheader,
   StyledMenuItem,
   StyledSelect,
 } from './GroupedSelectSearchController.styles';
-import { ItemTypeTooltip } from './ItemTypeTooltip';
-import { selectDropdownStyles } from './GroupedSelectSearchController.const';
+import { GroupedSelectControllerProps } from './GroupedSelectSearchController.types';
 import { handleSearchKeyDown } from './GroupedSelectSearchController.utils';
-import { useItemTypeSelectSetup } from './GroupedSelectSearchController.hooks';
-import { getItemsTypeChip } from '../ItemConfiguration.utils';
+import { ItemTypeTooltip } from './ItemTypeTooltip';
 
 const dataTestid = 'builder-activity-items-item-configuration-response-type';
 
@@ -64,6 +64,7 @@ export const GroupedSelectSearchController = <T extends FieldValues>({
   options,
   setValue,
   fieldName,
+  onBeforeChange,
   checkIfSelectChangePopupIsVisible,
 }: GroupedSelectControllerProps<T>) => {
   const { t } = useTranslation('app');
@@ -120,6 +121,12 @@ export const GroupedSelectSearchController = <T extends FieldValues>({
         control={control}
         render={({ field: { onChange, value }, fieldState: { error } }) => {
           const handleOnSelectChange = (...props: unknown[]) => {
+            const newValue = (props[0] as { target: { value: ItemResponseType } }).target.value;
+
+            if (onBeforeChange && !onBeforeChange(newValue)) {
+              return;
+            }
+
             if (checkIfSelectChangePopupIsVisible) {
               checkIfSelectChangePopupIsVisible(() => {
                 onChange(...props);

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/GroupedSelectSearchController/GroupedSelectSearchController.types.ts
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/GroupedSelectSearchController/GroupedSelectSearchController.types.ts
@@ -1,5 +1,7 @@
 import { FieldValues, UseControllerProps, UseFormSetValue } from 'react-hook-form';
 
+import { ItemResponseType } from 'shared/consts';
+
 import { ItemsOptionGroup } from '../ItemConfiguration.types';
 
 export type FormInputProps = {
@@ -7,6 +9,7 @@ export type FormInputProps = {
   checkIfSelectChangePopupIsVisible?: (handleOnChange: () => void) => void;
   fieldName: string;
   setValue: UseFormSetValue<FieldValues>;
+  onBeforeChange?: (newValue: ItemResponseType) => boolean;
 };
 
 export type GroupedSelectControllerProps<T extends FieldValues> = FormInputProps &

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/ItemConfiguration.hooks.ts
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/ItemConfiguration.hooks.ts
@@ -82,36 +82,30 @@ export const useGetAvailableItemTypeOptions = (name: string) => {
               value !== ItemResponseType.ParagraphText || featureFlags.enableParagraphTextItem,
           ),
         import: (options: ItemsOption[]) => {
-          const filteredOptions = options.filter(
-            ({ value }) => value !== ItemResponseType.RequestHealthRecordData,
+          const shouldUseHealthOption = options.some(
+            ({ value }) =>
+              value === ItemResponseType.RequestHealthRecordData &&
+              !!featureFlags.enableEhrHealthData &&
+              featureFlags.enableEhrHealthData !== 'unavailable',
           );
 
-          const processedHealthOption = options.find(
-            ({ value }) => value === ItemResponseType.RequestHealthRecordData,
-          );
-
-          // This should always be true, doing this for type safety
-          if (processedHealthOption) {
+          if (shouldUseHealthOption) {
             if (hasExistingHealthRecordItem) {
-              return [
-                ...filteredOptions,
-                {
-                  ...processedHealthOption,
-                  disabled: true,
-                  tooltip: t('requestHealthRecordDataSettings.disabledTooltip'),
-                },
-              ];
+              return options.map((option) =>
+                option.value === ItemResponseType.RequestHealthRecordData
+                  ? {
+                      ...option,
+                      disabled: true,
+                      tooltip: t('requestHealthRecordDataSettings.disabledTooltip'),
+                    }
+                  : option,
+              );
             }
 
-            if (
-              featureFlags.enableEhrHealthData === 'active' ||
-              featureFlags.enableEhrHealthData === 'available'
-            ) {
-              return [...filteredOptions, processedHealthOption];
-            }
+            return options;
           }
 
-          return filteredOptions;
+          return options.filter(({ value }) => value !== ItemResponseType.RequestHealthRecordData);
         },
       };
 

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/ItemConfiguration.utils.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/ItemConfiguration.utils.tsx
@@ -1,29 +1,29 @@
-import { v4 as uuidv4 } from 'uuid';
 import get from 'lodash.get';
 import { ReactNode } from 'react';
+import { v4 as uuidv4 } from 'uuid';
 
 import i18n from 'i18n';
-import { ItemResponseType } from 'shared/consts';
-import { createArray, getObjectFromList, getTextBetweenBrackets } from 'shared/utils';
-import { ItemFormValues, ItemResponseTypeNoPerfTasks } from 'modules/Builder/types';
-import { Config, SliderItemResponseValues, SliderRowsItemResponseValues } from 'shared/state';
 import {
+  DEFAULT_NUMBER_SELECT_MAX_VALUE,
+  DEFAULT_NUMBER_SELECT_MIN_VALUE,
   DEFAULT_SLIDER_MAX_VALUE,
   DEFAULT_SLIDER_MIN_NUMBER,
-  DEFAULT_NUMBER_SELECT_MIN_VALUE,
-  DEFAULT_NUMBER_SELECT_MAX_VALUE,
 } from 'modules/Builder/consts';
-import { FeatureFlags } from 'shared/types/featureFlags';
+import { ItemFormValues, ItemResponseTypeNoPerfTasks } from 'modules/Builder/types';
 import { Chip, ChipShape } from 'shared/components';
+import { ItemResponseType } from 'shared/consts';
+import { Config, SliderItemResponseValues, SliderRowsItemResponseValues } from 'shared/state';
+import { FeatureFlags } from 'shared/types/featureFlags';
+import { createArray, getObjectFromList, getTextBetweenBrackets } from 'shared/utils';
 
+import { getEmptyCondition } from '../../ActivityItemsFlow/ItemFlow/ItemFlow.utils';
 import {
+  DEFAULT_AUDIO_DURATION_SEC,
   DEFAULT_EMPTY_SLIDER,
   DEFAULT_EMPTY_SLIDER_ROWS,
-  DEFAULT_AUDIO_DURATION_SEC,
   SELECTION_OPTIONS_COLOR_PALETTE,
 } from './ItemConfiguration.const';
-import { getEmptyCondition } from '../../ActivityItemsFlow/ItemFlow/ItemFlow.utils';
-import { ItemConfigurationSettings, GetEmptyAlert } from './ItemConfiguration.types';
+import { GetEmptyAlert, ItemConfigurationSettings } from './ItemConfiguration.types';
 
 const { t } = i18n;
 
@@ -57,16 +57,31 @@ export const getItemsTypeChip = ({
 }: {
   value: ItemResponseType;
   featureFlags: FeatureFlags;
-}): ReactNode =>
-  value === ItemResponseType.RequestHealthRecordData &&
-  featureFlags.enableEhrHealthData === 'active' ? (
-    <Chip
-      title={t('active')}
-      color="success"
-      shape={ChipShape.RectangularLarge}
-      canRemove={false}
-    />
-  ) : undefined;
+}): ReactNode => {
+  if (value === ItemResponseType.RequestHealthRecordData) {
+    if (featureFlags.enableEhrHealthData === 'active') {
+      return (
+        <Chip
+          title={t('requestHealthRecordDataSettings.chipLabels.active')}
+          color="success"
+          shape={ChipShape.RectangularLarge}
+          canRemove={false}
+        />
+      );
+    }
+
+    if (featureFlags.enableEhrHealthData === 'available') {
+      return (
+        <Chip
+          title={t('requestHealthRecordDataSettings.chipLabels.available')}
+          color="infoAlt"
+          shape={ChipShape.RectangularLarge}
+          canRemove={false}
+        />
+      );
+    }
+  }
+};
 
 export const getEmptySliderOption = ({
   isMultiple,

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -1318,7 +1318,7 @@
     "modal": {
       "title": "Request Health Record Data",
       "content": "<0>Now it is possible to import participants' Electronic Health Care Data, and use that data with what you collect in your Mindlogger Activities.</0> <1>Please check out the website for more information.</1>",
-      "cta": "Go to website"
+      "cta": "Go to Website"
     }
   },
   "requestTransferOwnershipSuccess": "<0>Your request has been successfully sent to <1>{{email}}</1>. Please wait for receiver to accept your request.</0>",

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -1317,7 +1317,7 @@
     },
     "modal": {
       "title": "Request Health Record Data",
-      "content": "<0>Now it is possible to import participants' Electronic Health Care Data, and use that data with what you collect in your Mindlogger Activities.</0> <1>Please check out the website for more information.</1>",
+      "content": "<0>Now it is possible to import participants' Electronic Health Care Data, and use that data with what you collect in your MindLogger Activities.</0> <1>Please check out the website for more information.</1>",
       "cta": "Go to Website"
     }
   },

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -360,6 +360,7 @@
   "clearFlow": "Clear Flow",
   "clearIndividualScheduleSuccess": "<0>Please note that Respondent <1>{{name}}</1> is still using an <3>individual schedule</3>.</0> <1>You may revert this Respondent back to the <1>default schedule</1> by pressing the trash icon on the top-left.</1>",
   "clearScheduledEvents": "Clear All Scheduled Events from Calendar",
+  "close": "Close",
   "colorPalette": "Color Palette",
   "combineReportsIntoSingleFile": "Combine reports into a single file",
   "compliance": "Compliance",
@@ -1309,6 +1310,15 @@
     "placeholders": {
       "opt_in": "Text",
       "opt_out": "Text"
+    },
+    "chipLabels": {
+      "active": "Active",
+      "available": "Premium"
+    },
+    "modal": {
+      "title": "Request Health Record Data",
+      "content": "<0>Now it is possible to import participants' Electronic Health Care Data, and use that data with what you collect in your Mindlogger Activities.</0> <1>Please check out the website for more information.</1>",
+      "cta": "Go to website"
     }
   },
   "requestTransferOwnershipSuccess": "<0>Your request has been successfully sent to <1>{{email}}</1>. Please wait for receiver to accept your request.</0>",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -360,6 +360,7 @@
   "clearFlow": "Effacer le flux",
   "clearIndividualScheduleSuccess": "<0>Veuillez noter que Le participant <1>{{name}}</1> utilise toujours un <3>programme individuel</3>.</0> <1>Vous pouvez refaire passer cette personne au <1>programme par défaut</1> en appuyant sur l'icône de corbeille en haut à gauche.</1>",
   "clearScheduledEvents": "Effacer tous les événements programmés du calendrier",
+  "close": "Fermer",
   "colorPalette": "Palette de couleurs",
   "combineReportsIntoSingleFile": "Combiner les rapports en un seul fichier",
   "compliance": "Conformité",
@@ -1308,6 +1309,15 @@
     "placeholders": {
       "opt_in": "Texte",
       "opt_out": "Texte"
+    },
+    "chipLabels": {
+      "active": "Actif",
+      "available": "Premium"
+    },
+    "modal": {
+      "title": "Demander des données de santé",
+      "content": "<0>Il est maintenant possible d'importer les données de soins de santé des participants, et d'utiliser ces données avec celles que vous collectez dans vos activités MindLogger.</0> <1>Veuillez consulter le site Web pour plus d'informations.</1>",
+      "cta": "Aller sur le site Web"
     }
   },
   "requestTransferOwnershipSuccess": "<0>Votre demande a été envoyée avec succès à <1>{{email}}</1>. Veuillez attendre que le destinataire accepte votre demande.</0>",

--- a/src/shared/components/Modal/EHRModals/EHRAvailableModal.tsx
+++ b/src/shared/components/Modal/EHRModals/EHRAvailableModal.tsx
@@ -1,0 +1,49 @@
+import { Box } from '@mui/material';
+import { Trans, useTranslation } from 'react-i18next';
+
+import { variables } from 'shared/styles';
+
+import { Modal } from '../Modal';
+import { EHRAvailableModalProps } from './EHRAvailableModal.types';
+import { EHR_GO_TO_WEBSITE_URL } from './EHRModals.const';
+
+export const EHRAvailableModal = ({ open, onClose }: EHRAvailableModalProps) => {
+  const { t } = useTranslation();
+
+  const handleGoToWebsite = () => {
+    window.open(EHR_GO_TO_WEBSITE_URL, '_blank');
+  };
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      hasCloseIcon={false}
+      title={t('requestHealthRecordDataSettings.modal.title')}
+      buttonText={t('requestHealthRecordDataSettings.modal.cta')}
+      onSubmit={handleGoToWebsite}
+      hasSecondBtn
+      secondBtnText={t('close')}
+      onSecondBtnSubmit={onClose}
+      width="61"
+      data-testid="ehr-available-modal"
+      sxProps={{
+        '.MuiPaper-root': {
+          backgroundColor: variables.palette.surface3,
+        },
+      }}
+    >
+      <Box sx={{ px: 3.2 }}>
+        <Trans i18nKey="requestHealthRecordDataSettings.modal.content">
+          <p style={{ marginTop: 20 }}>
+            Now it is possible to import participants' Electronic Health Care Data, and use that
+            data with what you collect in your Mindlogger Activities.
+          </p>
+          <p style={{ marginTop: 24, marginBottom: 18 }}>
+            Please check out the website for more information.
+          </p>
+        </Trans>
+      </Box>
+    </Modal>
+  );
+};

--- a/src/shared/components/Modal/EHRModals/EHRAvailableModal.tsx
+++ b/src/shared/components/Modal/EHRModals/EHRAvailableModal.tsx
@@ -1,8 +1,6 @@
 import { Box } from '@mui/material';
 import { Trans, useTranslation } from 'react-i18next';
 
-import { variables } from 'shared/styles';
-
 import { Modal } from '../Modal';
 import { EHRAvailableModalProps } from './EHRAvailableModal.types';
 import { EHR_GO_TO_WEBSITE_URL } from './EHRModals.const';
@@ -27,11 +25,6 @@ export const EHRAvailableModal = ({ open, onClose }: EHRAvailableModalProps) => 
       onSecondBtnSubmit={onClose}
       width="61"
       data-testid="ehr-available-modal"
-      sxProps={{
-        '.MuiPaper-root': {
-          backgroundColor: variables.palette.surface3,
-        },
-      }}
     >
       <Box sx={{ px: 3.2 }}>
         <Trans i18nKey="requestHealthRecordDataSettings.modal.content">

--- a/src/shared/components/Modal/EHRModals/EHRAvailableModal.types.ts
+++ b/src/shared/components/Modal/EHRModals/EHRAvailableModal.types.ts
@@ -1,0 +1,4 @@
+export interface EHRAvailableModalProps {
+  open: boolean;
+  onClose: () => void;
+}

--- a/src/shared/components/Modal/EHRModals/EHRModals.const.ts
+++ b/src/shared/components/Modal/EHRModals/EHRModals.const.ts
@@ -1,0 +1,3 @@
+// TODO: Replace with actual link once microsite is ready
+// https://mindlogger.atlassian.net/browse/M2-8965
+export const EHR_GO_TO_WEBSITE_URL = 'https://mindlogger.org/';

--- a/src/shared/components/Modal/EHRModals/index.ts
+++ b/src/shared/components/Modal/EHRModals/index.ts
@@ -1,0 +1,2 @@
+export * from './EHRAvailableModal';
+export * from './EHRAvailableModal.types';

--- a/src/shared/styles/theme.tsx
+++ b/src/shared/styles/theme.tsx
@@ -1,12 +1,12 @@
-import { SelectClasses, createTheme, Theme } from '@mui/material';
+import { createTheme, SelectClasses, Theme } from '@mui/material';
 import { OverridesStyleRules } from '@mui/material/styles/overrides';
 import 'react-datepicker/dist/react-datepicker.min.css';
 
 import { Svg } from 'shared/components/Svg';
+import { getChipStyleOverrides } from 'shared/styles/theme.utils';
 import { typography } from 'shared/styles/typography';
 import { variables } from 'shared/styles/variables';
 import { blendColorsNormal } from 'shared/utils/colors';
-import { getChipStyleOverrides } from 'shared/styles/theme.utils';
 
 declare module '@mui/system/createTheme/createBreakpoints' {
   interface BreakpointOverrides {
@@ -892,6 +892,7 @@ export const theme = createTheme({
       main: variables.palette.purple,
       dark: blendColorsNormal(variables.palette.purple, variables.palette.light_alfa8),
       light: blendColorsNormal(variables.palette.purple, variables.palette.light_alfa12),
+      contrastText: variables.palette.on_secondary_container,
     },
     success: {
       main: variables.palette.green,
@@ -938,6 +939,12 @@ declare module '@mui/material/styles' {
 
 declare module '@mui/material/Alert' {
   interface AlertPropsColorOverrides {
+    infoAlt: true;
+  }
+}
+
+declare module '@mui/material/Chip' {
+  interface ChipPropsColorOverrides {
     infoAlt: true;
   }
 }

--- a/src/shared/styles/theme.utils.ts
+++ b/src/shared/styles/theme.utils.ts
@@ -67,6 +67,16 @@ export const getChipStyleOverrides = ({
           backgroundColor: isFilled ? variables.palette.on_surface_variant_alfa8 : undefined,
         },
       };
+    case 'infoAlt':
+      return {
+        color: variables.palette.on_secondary_container,
+        [key]: variables.palette.purple_alfa30,
+
+        '&[tabindex="0"]:hover': {
+          borderColor: variables.palette.purple_alfa30,
+          backgroundColor: isFilled ? variables.palette.purple_alfa30 : undefined,
+        },
+      };
     default:
       return {};
   }


### PR DESCRIPTION
- [ ] Tests for the changes have been added
- [ ] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

🔗 [Jira Ticket M2-8927](https://mindlogger.atlassian.net/browse/M2-8927)

This PR completes the work related to the "Request Health Record Data" item type introduced in #2061.

The focus of this PR is to handle the scenario where the `enable-ehr-health-data` feature flag is **enabled**, but not for the current workspace (`'available'` value).

- A new custom `EHRAvaiableModal` component was created to handle the desired functionality.
- New color option for `Chip` component (`'infoAlt'`)
- New `onBeforeChange` handler for `GroupedSelectSearchController` component.

### 📸 Screenshots



### 🪤 Peer Testing

In order to test this, the `enableEhrHealthData` feature flag should be set to `'available'`.

When creating an activity item, the `Request Health Record Data` option should be visible, with a purple `'Premium'` chip beside it. Clicking it should **not** select the item, but rather open a modal titled 'Request Health Record Data', with a button leading to MindLogger's site in a new tab.
