### PR TITLE
feat: Skippable option for Request Health Record item (M2-9010)

### DIFF
--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/Settings/ItemSettingsController/ItemSettingsController.const.ts
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/Settings/ItemSettingsController/ItemSettingsController.const.ts
@@ -353,7 +353,10 @@ export const itemSettingsOptionsByInputType: ItemSettingsOptionsByInputType = {
   [ItemResponseType.RequestHealthRecordData]: [
     {
       groupName: ItemSettingsGroupNames.ScreenConfigurationsAndTimer,
-      groupOptions: [ItemConfigurationSettings.IsGoBackRemoved],
+      groupOptions: [
+        ItemConfigurationSettings.IsSkippable,
+        ItemConfigurationSettings.IsGoBackRemoved,
+      ],
     },
   ],
   [ItemResponseType.AudioPlayer]: [

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/Settings/ItemSettingsController/ItemSettingsController.test.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/Settings/ItemSettingsController/ItemSettingsController.test.tsx
@@ -1,12 +1,13 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
-import { createRef } from 'react';
-import { screen, fireEvent } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import get from 'lodash.get';
+import { createRef } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
-import { renderWithAppletFormData } from 'shared/utils/renderWithAppletFormData';
+import * as useCurrentActivityHook from 'modules/Builder/hooks/useCurrentActivity';
+import * as useCustomFormContextHook from 'modules/Builder/hooks/useCustomFormContext';
 import { ItemResponseType } from 'shared/consts';
 import {
   mockedAppletFormData,
@@ -18,12 +19,11 @@ import {
   mockedSliderRowsFormValues,
   mockedTextFormValues,
 } from 'shared/mock';
-import * as useCustomFormContextHook from 'modules/Builder/hooks/useCustomFormContext';
-import * as useCurrentActivityHook from 'modules/Builder/hooks/useCurrentActivity';
+import { renderWithAppletFormData } from 'shared/utils/renderWithAppletFormData';
 
+import { ItemConfigurationSettings } from '../../ItemConfiguration.types';
 import { ItemSettingsController } from './ItemSettingsController';
 import { ItemSettingsGroupNames } from './ItemSettingsController.const';
-import { ItemConfigurationSettings } from '../../ItemConfiguration.types';
 
 const getMockedAppletFormData = (item) => ({
   ...mockedAppletFormData,
@@ -264,6 +264,10 @@ const mockedSettingsByType = {
     ItemConfigurationSettings.HasTimer,
     ItemConfigurationSettings.IsGoBackRemoved,
   ],
+  [ItemResponseType.RequestHealthRecordData]: [
+    ItemConfigurationSettings.IsSkippable,
+    ItemConfigurationSettings.IsGoBackRemoved,
+  ],
   [ItemResponseType.AudioPlayer]: [
     ItemConfigurationSettings.IsPlayAudioOnce,
     ItemConfigurationSettings.HasTextInput,
@@ -349,6 +353,7 @@ const mockedSettingGroupsByType = {
     ItemSettingsGroupNames.ScreenConfigurationsAndTimer,
   ],
   [ItemResponseType.Message]: [ItemSettingsGroupNames.ScreenConfigurationsAndTimer],
+  [ItemResponseType.RequestHealthRecordData]: [ItemSettingsGroupNames.ScreenConfigurationsAndTimer],
   [ItemResponseType.AudioPlayer]: [
     ItemSettingsGroupNames.AudioPlayerOptions,
     ItemSettingsGroupNames.AdditionalResponseOptions,
@@ -399,6 +404,7 @@ describe('ItemSettingsController', () => {
     ${ItemResponseType.Geolocation}             | ${'settings and order for Geolocation are correct'}
     ${ItemResponseType.Audio}                   | ${'settings and order for Audio are correct'}
     ${ItemResponseType.Message}                 | ${'settings and order for Message are correct'}
+    ${ItemResponseType.RequestHealthRecordData} | ${'settings and order for RequestHealthRecordData are correct'}
     ${ItemResponseType.AudioPlayer}             | ${'settings and order for AudioPlayer are correct'}
     ${ItemResponseType.Time}                    | ${'settings and order for Time are correct'}
   `('$description', ({ inputType }) => {
@@ -442,6 +448,7 @@ describe('ItemSettingsController', () => {
     ${ItemResponseType.Geolocation}             | ${'setting groups and order for Geolocation are correct'}
     ${ItemResponseType.Audio}                   | ${'setting groups and order for Audio are correct'}
     ${ItemResponseType.Message}                 | ${'setting groups and order for Message are correct'}
+    ${ItemResponseType.RequestHealthRecordData} | ${'setting groups and order for RequestHealthRecordData are correct'}
     ${ItemResponseType.AudioPlayer}             | ${'setting groups and order for AudioPlayer are correct'}
     ${ItemResponseType.Time}                    | ${'setting groups and order for Time are correct'}
   `('$description', ({ inputType }) => {

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/Settings/ItemSettingsController/ItemSettingsController.test.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/Settings/ItemSettingsController/ItemSettingsController.test.tsx
@@ -448,7 +448,6 @@ describe('ItemSettingsController', () => {
     ${ItemResponseType.Geolocation}             | ${'setting groups and order for Geolocation are correct'}
     ${ItemResponseType.Audio}                   | ${'setting groups and order for Audio are correct'}
     ${ItemResponseType.Message}                 | ${'setting groups and order for Message are correct'}
-    ${ItemResponseType.RequestHealthRecordData} | ${'setting groups and order for RequestHealthRecordData are correct'}
     ${ItemResponseType.AudioPlayer}             | ${'setting groups and order for AudioPlayer are correct'}
     ${ItemResponseType.Time}                    | ${'setting groups and order for Time are correct'}
   `('$description', ({ inputType }) => {

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/Settings/ItemSettingsController/ItemSettingsController.test.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/Settings/ItemSettingsController/ItemSettingsController.test.tsx
@@ -448,6 +448,7 @@ describe('ItemSettingsController', () => {
     ${ItemResponseType.Geolocation}             | ${'setting groups and order for Geolocation are correct'}
     ${ItemResponseType.Audio}                   | ${'setting groups and order for Audio are correct'}
     ${ItemResponseType.Message}                 | ${'setting groups and order for Message are correct'}
+    ${ItemResponseType.RequestHealthRecordData} | ${'setting groups and order for RequestHealthRecordData are correct'}
     ${ItemResponseType.AudioPlayer}             | ${'setting groups and order for AudioPlayer are correct'}
     ${ItemResponseType.Time}                    | ${'setting groups and order for Time are correct'}
   `('$description', ({ inputType }) => {


### PR DESCRIPTION
- [X] Tests for the changes have been added
- [X] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

🔗 [Jira Ticket M2-9010](https://mindlogger.atlassian.net/browse/M2-9010)

This PR adds the "Skippable Item" option to the Request Health Record Data item type, following the changes added in [this BE PR](https://github.com/ChildMindInstitute/mindlogger-backend-refactor/pull/1824)

### 📸 Screenshots

![28223](https://github.com/user-attachments/assets/f19fe0d2-60a8-44f7-862b-471501933c3f)

### 🪤 Peer Testing

To test this feature, the `enableEHRHealthData` feature flag must be set to `"active"`. Once the value is set, add a "Request Health Record Data" item to any activity. When opening the Settings pane, the "Skippable Item" option should be visible and available to be selected. 

### ✏️ Notes

This rides on the changes implemented in the aforementioned BE PR. If it hasn't been merged, just point local to the corresponding [BE branch](https://github.com/ChildMindInstitute/mindlogger-backend-refactor/tree/feat/M2-9039-skippable-ehr) to test.
