### PR TITLE
fix: Allow Navigation to dataviz response from alert notification (M2-8489)

### DIFF
--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.test.tsx
@@ -133,11 +133,6 @@ describe('RespondentDataReview', () => {
       expect(screen.getByTestId(`${dataTestid}-menu`)).toBeInTheDocument();
       expect(screen.getByTestId(`${dataTestid}-container`)).toBeInTheDocument();
       expect(screen.getByTestId(`${dataTestid}-feedback-button`)).toBeInTheDocument();
-      expect(
-        screen.getByText(
-          'Select the date, Activity Flow or Activity, and response time to review the response data.',
-        ),
-      ).toBeInTheDocument();
     });
 
     test('handles date picker interactions correctly', async () => {

--- a/src/shared/layouts/BaseLayout/components/TopBar/Notifications/Notification/Notification.test.tsx
+++ b/src/shared/layouts/BaseLayout/components/TopBar/Notifications/Notification/Notification.test.tsx
@@ -98,7 +98,7 @@ describe('Notification', () => {
     await userEvent.click(button);
 
     expect(mockedUseNavigate).toBeCalledWith(
-      `/dashboard/2e46fa32-ea7c-4a76-b49b-1c97d795bb9a/participants/${mockedFullSubjectId1}`,
+      `/dashboard/2e46fa32-ea7c-4a76-b49b-1c97d795bb9a/participants/${mockedFullSubjectId1}/activities/${mockedAlert.activityId}/responses`,
     );
   });
 
@@ -125,7 +125,7 @@ describe('Notification', () => {
     await userEvent.click(button);
 
     expect(mockedUseNavigate).toBeCalledWith(
-      `/dashboard/2e46fa32-ea7c-4a76-b49b-1c97d795bb9a/participants/${mockedFullSubjectId1}`,
+      `/dashboard/2e46fa32-ea7c-4a76-b49b-1c97d795bb9a/participants/${mockedFullSubjectId1}/activities/${mockedAlert.activityId}/responses`,
     );
   });
 });

--- a/src/shared/layouts/BaseLayout/components/TopBar/Notifications/Notification/Notification.tsx
+++ b/src/shared/layouts/BaseLayout/components/TopBar/Notifications/Notification/Notification.tsx
@@ -42,6 +42,8 @@ export const Notification = ({
   isWatched,
   subjectId,
   type,
+  activityId,
+  answerId,
 }: NotificationProps) => {
   const { t } = useTranslation('app');
   const dispatch = useAppDispatch();
@@ -73,9 +75,11 @@ export const Notification = ({
 
   const navigateToResponseData = () => {
     navigate(
-      generatePath(page.appletParticipantDetails, {
+      generatePath(page.appletParticipantActivityDetailsDataReview, {
         appletId,
         subjectId,
+        activityId,
+        answerId,
       }),
     );
   };


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-8489](https://mindlogger.atlassian.net/browse/M2-8489)

This PR updates the navigation from alert notifications to the dataviz response screen.

### 📸 Screenshots

#### Before

https://github.com/user-attachments/assets/33cfa548-b8b3-4dcf-938f-1f9406206d0d

#### After

https://github.com/user-attachments/assets/d6753a81-73ad-4b3d-8e21-ac3848cfd58c


### 🪤 Peer Testing

1. Create an applet with an alert on one of the activity items
2. Complete the activity in the web app taking care to trigger the alert
3. Click on the alert notification in the admin panel
4. Confirm that navigation takes place as expected

### ✏️ Notes

N/A
