### PR TITLE
chore: Include JIRA_WEBHOOK_SECRET in webhook call (M2-9291)

### DIFF
--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -16,6 +16,7 @@ jobs:
       JENKINS_USER: ${{ secrets.JENKINS_USER }}
       JENKINS_TOKEN: ${{ secrets.JENKINS_TOKEN }}
       JIRA_WEBHOOK_URL: ${{ secrets.JIRA_WEBHOOK_URL }}
+      JIRA_WEBHOOK_SECRET: ${{ secrets.JIRA_WEBHOOK_SECRET }}
       JENKINS_HOST: ${{ vars.JENKINS_HOST }}
 
       # The max amount of time (in minutes) we should wait for the current Jenkins build to finish. Defaults to 6 hours
@@ -127,7 +128,7 @@ jobs:
               echo "Build successful! Submitting ticket numbers to Jira"
               tickets="${{ steps.jira-tickets.outputs.tickets }}"
               json="{ \"issues\": $(echo "${tickets}" | jq -R -s -c 'split(" ")[:-1]'), \"data\": { \"tag\": \"${currentTag}\", \"repository\": \"${REPO_URL}\" } }"
-              curl -X POST -H 'Content-Type: application/json' --url "${JIRA_WEBHOOK_URL}" --data "$json"
+              curl -X POST -H 'Content-Type: application/json' -H "X-Automation-Webhook-Token: ${JIRA_WEBHOOK_SECRET}" --url "${JIRA_WEBHOOK_URL}" --data "$json"
               break
             elif [[ "$result" != "null" ]]; then
               echo "Build failed, ending workflow"


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-9291](https://mindlogger.atlassian.net/browse/M2-9291)

This change makes room for a `JIRA_WEBHOOK_SECRET` value in the webhook call to Jira. This is necessary because Jira recently updated their webhook URL to one that requires a secret header.

<img width="1058" alt="image" src="https://github.com/user-attachments/assets/5cde788a-d903-4f48-988d-57d9d06d2172" />

To complete this change, we need to do the following:
- [x] Update the value of the webhook URL in JIRA_WEBHOOK_URL
- [x] Add a GitHub actions secret value for JIRA_WEBHOOK_SECRET

### 🪤 Peer Testing

If you really want to test this, you can contact me for the values mentioned above, then make the curl call with:
- The old URL, and an empty value for the secret header
- The new URL and the valid secret value

### ✏️ Notes

N/A