### PR TITLE
feat: Rebrand banner URL (M2-9258)

### DIFF
--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -1264,7 +1264,7 @@
   "quote": "Quote",
   "random": "Random",
   "rangeOfScores": "Possible Range of Scores",
-  "rebrandBanner": "<0>We are rebranding!</0> <1>Design updates are on the way — same great app, fresh new look.</1>",
+  "rebrandBanner": "<0>We are rebranding! </0> <1>Design updates are on the way — same great app, fresh new look. Curious? </1><2>Click to learn more.</2>",
   "record": "Record",
   "recordAudio": "Record <br /> Audio",
   "redo": "Redo",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -1262,7 +1262,7 @@
   "quote": "Citation",
   "random": "Aléatoire",
   "rangeOfScores": "Plage possible de scores",
-  "rebrandBanner": "<0>Nous changeons de marque!</0> <1>Des mises à jour de design sont en cours — même application géniale, nouveau look frais.</1>",
+  "rebrandBanner": "<0>Nous changeons de marque! </0> <1>Des mises à jour de design sont en cours — même application géniale, nouveau look frais. Curieux? </1><2>Cliquez pour en savoir plus.</2>",
   "record": "Enregistrer",
   "recordAudio": "Enregistrer <br /> Audio",
   "redo": "Refaire",

--- a/src/shared/components/Banners/RebrandBanner/RebrandBanner.tsx
+++ b/src/shared/components/Banners/RebrandBanner/RebrandBanner.tsx
@@ -8,7 +8,9 @@ import { auth } from 'redux/modules';
 import { variables } from 'shared/styles';
 
 import { Banner, BannerProps } from '../Banner';
-import { StyledImg } from './RebrandBanner.styles';
+import { StyledImg, StyledLink } from './RebrandBanner.styles';
+
+const CURIOUS_REBRAND_URL = 'https://www.gettingcurious.com/rebrand';
 
 /**
  * Returns a unique key for the rebrand banner dismiss state
@@ -96,14 +98,10 @@ export const RebrandBanner = (props: BannerProps) => {
           >
             <Trans i18nKey="rebrandBanner">
               <strong>We are rebranding! </strong>
-              <>Design updates are on the way — same great app, fresh new look. </>
-              {/* 
-								Uncomment once the URL is available
-								https://mindlogger.atlassian.net/browse/M2-9258
-							*/}
-              {/* <StyledLink href={CURIOUS_REBRAND_URL} target="_blank">
+              <>Design updates are on the way — same great app, fresh new look. Curious? </>
+              <StyledLink href={CURIOUS_REBRAND_URL} target="_blank">
                 Click to learn more.
-              </StyledLink> */}
+              </StyledLink>
             </Trans>
           </Banner>
         )}


### PR DESCRIPTION
- [X] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

🔗 [Jira Ticket M2-9258](https://mindlogger.atlassian.net/browse/M2-9258)

This PR adds a link to the brand update banner, leading to brand change explanation.

### 📸 Screenshots

![64207](https://github.com/user-attachments/assets/ac479eaa-f627-4e85-bdd7-ac8c81f84de4)

### 🪤 Peer Testing

Pretty simple. Just check the brand change banner has a "Click to learn more" link. Should also be there when using French.
