### PR TITLE
feat: Update EHR Banner links (M2-8965)

### DIFF
--- a/src/shared/components/Banners/EHRBanners/EHRBanners.const.ts
+++ b/src/shared/components/Banners/EHRBanners/EHRBanners.const.ts
@@ -1,4 +1,3 @@
-// TODO: Replace with actual links when microsite is ready
-// https://mindlogger.atlassian.net/browse/M2-8823
-export const EHR_LEARN_MORE_URL = 'https://mindlogger.org/';
-export const EHR_CONTACT_URL = 'https://mindlogger.org/';
+export const EHR_LEARN_MORE_URL =
+  'https://mindlogger.atlassian.net/servicedesk/customer/portal/3/article/1238368259';
+export const EHR_CONTACT_URL = 'mailto:partnerships@gettingcurious.com';

--- a/src/shared/components/Modal/EHRModals/EHRModals.const.ts
+++ b/src/shared/components/Modal/EHRModals/EHRModals.const.ts
@@ -1,3 +1,2 @@
-// TODO: Replace with actual link once microsite is ready
-// https://mindlogger.atlassian.net/browse/M2-8965
-export const EHR_GO_TO_WEBSITE_URL = 'https://mindlogger.org/';
+export const EHR_GO_TO_WEBSITE_URL =
+  'https://mindlogger.atlassian.net/servicedesk/customer/portal/3/article/1238368259';


### PR DESCRIPTION
- [X] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

🔗 [Jira Ticket M2-8965](https://mindlogger.atlassian.net/browse/M2-8965)

This PR updates the links for both EHR banners (available & active status) and the EHR Available Modal, leading to the corresponding references.

### 🪤 Peer Testing

EHR Available banner & modal link should lead to [this URL](https://mindlogger.atlassian.net/servicedesk/customer/portal/3/article/1238368259)

EHR Active banner (Contact Us) should be a mailto reference for [partnerships@gettingcurious.com](mailto:partnerships@gettingcurious.com)
