### PR TITLE
fix: Error state on Item Card (M2-9441)

### DIFF
--- a/src/modules/Builder/features/ActivityItems/LeftBar/Item/Item.styles.ts
+++ b/src/modules/Builder/features/ActivityItems/LeftBar/Item/Item.styles.ts
@@ -37,8 +37,8 @@ export const StyledItem = styled(StyledFlexTopCenter, shouldForwardProp)`
         stroke: ${variables.palette.on_surface_variant};
       }
 
-      ${isActive && `background-color: ${variables.palette.secondary_container};`}
-      ${hasError && `background-color: ${variables.palette.error_container};`}
+      ${isActive && `background-color: ${variables.palette.secondary_container}`};
+      ${hasError && `background-color: ${variables.palette.error_container}`};
       ${
         isDragging &&
         `background-color: ${blendColorsNormal(


### PR DESCRIPTION
- [X] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

🔗 [Jira Ticket M2-9441](https://mindlogger.atlassian.net/browse/M2-9441)

This PR fixes an issue where after clicking "Save & Publish" on the applet editor screen, editing items, if an item had errors, the corresponding card wouldn't reflect this in its styling


### 🪤 Peer Testing

1. Login to the admin panel.
2. Start editing any applet.
3. Edit the applet's items.
4. Perform any update that will result in error (e.g. Add an empty item).
5. Switch to a valid item.
6. Click Save & Publish.
7. **Expected:** A modal specifying the error should show up & the faulty item's card on the left bar should be marked as with error (background color should be `error_container` (`error[90]`))
	![93966](https://github.com/user-attachments/assets/cb8c9f08-616d-4978-9ef7-a69a2e35268e)

