### PR TITLE
feat: Add EHR export event tracking (M2-9454)

### DIFF
--- a/src/shared/utils/exportData/exporters/EHRDataExporter.ts
+++ b/src/shared/utils/exportData/exporters/EHRDataExporter.ts
@@ -39,7 +39,7 @@ export class EHRDataExporter {
     flowIds,
     respondentIds,
     subjectIds,
-  }: EHRDataExporterOptions) {
+  }: EHRDataExporterOptions): Promise<{ size?: number }> {
     // Build the URL with query parameters
     const queryParams = new URLSearchParams();
     if (fromDate) queryParams.append('fromDate', fromDate);
@@ -72,7 +72,7 @@ export class EHRDataExporter {
     if (!response.ok) throw new Error(`EHR data download failed for ${url}`);
 
     // No EHR data matching the query parameters found
-    if (response.status === 204) return;
+    if (response.status === 204) return {};
 
     // Get the filename from the Content-Disposition header or use default
     const contentDisposition = response.headers.get('Content-Disposition');
@@ -90,5 +90,7 @@ export class EHRDataExporter {
     a.click();
     window.URL.revokeObjectURL(downloadUrl);
     document.body.removeChild(a);
+
+    return { size: blob.size };
   }
 }

--- a/src/shared/utils/mixpanel/mixpanel.types.ts
+++ b/src/shared/utils/mixpanel/mixpanel.types.ts
@@ -32,11 +32,13 @@ export enum MixpanelProps {
   AutoAssignedFlowCount = 'Auto-assigned flow count',
   ManuallyAssignedActivityCount = 'Manually-assigned activity count',
   ManuallyAssignedFlowCount = 'Manually-assigned flow count',
+  EHRFileSize = 'EHR File Size',
 }
 
 export enum MixpanelFeature {
   MultiInformant = 'Multi-informant',
   SSI = 'SSI',
+  EHR = 'EHR',
 }
 
 export enum MixpanelEventType {
@@ -373,6 +375,8 @@ export type EditLimitedAccountClickedEvent = WithAppletId<{
 
 export type ExportDataSuccessfulEvent = WithAppletId<{
   action: MixpanelEventType.ExportDataSuccessful;
+  [MixpanelProps.Feature]?: MixpanelFeature[];
+  [MixpanelProps.EHRFileSize]?: number;
 }>;
 
 export type FullAccountEditedSuccessfullyEvent = WithAppletId<{


### PR DESCRIPTION

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-9454](https://mindlogger.atlassian.net/browse/M2-9454)

Adds these custom properties to the existing `Export Data Successful` Mixpanel event when an `EHR.zip` file is successfully downloaded to the user's computer:
- `Feature: ["EHR"]`
- `EHR File Size: <size of EHR.zip in bytes>`

### 📸 Screenshots

![CleanShot 2025-06-25 at 18 31 42@2x](https://github.com/user-attachments/assets/11b9ab40-0591-43bd-b8e4-138d800f122b)

### 🪤 Peer Testing

**Preconditions:**
- An activity where you have previously ingested EHRs.

**Steps:**

1. From the Admin App, open the Export modal from any context where EHRs should be included, choose **Responses & EHR Data** from the dropdown, then click **Download**.
2. Log into Mixpanel and open the **Mindlogger Analytics Dev** project. Check the most recent events (refresh after a minute or so) and locate the **[Admin] Export Data Successful** event. Expand the **Your Properties** tab.
    **Expected outcome:** The properties `Feature: ["EHR"]` and `EHR File Size: <size of EHR.zip in bytes>` should be present.
3. From the Admin App, open the Export modal from any context where there should be **no EHR data**, choose **Responses & EHR Data** from the dropdown (or choose **Responses only**), then click **Download**.
4. Check the most recent **[Admin] Export Data Successful** event in Mixpanel.
    **Expected outcome:** The properties `Feature: ["EHR"]` and `EHR File Size: <size of EHR.zip in bytes>` should **not** be present.
