### PR TITLE
feat: Export process logging (M2-9624)

### DIFF
--- a/src/shared/utils/exportData/getJourneyCSVObject.ts
+++ b/src/shared/utils/exportData/getJourneyCSVObject.ts
@@ -1,9 +1,11 @@
+// eslint-disable no-console
 import { ActivityStatus } from 'shared/consts';
 import { SingleAndMultipleSelectItemResponseValues, SliderItemResponseValues } from 'shared/state';
 import { AnswerDTO, ExtendedEvent, JourneyCSVReturnProps, UserActionType } from 'shared/types';
 import { SuccessedEventDTO } from 'shared/types/answer';
 import { getDictionaryText } from 'shared/utils/forms';
 
+import { checkIfShouldLogging } from '../logger';
 import { convertDateStampToMs } from './convertDateStampToMs';
 import { parseOptions } from './parseOptions';
 import { parseResponseValue } from './parseResponseValue';
@@ -17,6 +19,14 @@ export const getJourneyCSVReturn = (
   returnProps: JourneyCSVReturnProps,
   enableDataExportRenaming?: boolean,
 ) => {
+  const shouldLogDataInDebugMode = checkIfShouldLogging();
+
+  if (shouldLogDataInDebugMode) {
+    console.log(
+      `[getJourneyCSVReturn] Processing journey CSV return for item: ${returnProps.item}, type: ${returnProps.item_type}`,
+    );
+  }
+
   const {
     id,
     activity_flow_submission_id,
@@ -151,132 +161,62 @@ export const getJourneyCSVReturn = (
 };
 
 export const getSplashScreen = (event: SuccessedEventDTO, nextExtendedEvent: ExtendedEvent) => {
-  const {
-    activityItem,
-    id,
-    scheduledDatetime,
-    startDatetime,
-    endDatetime,
-    respondentSecretId,
-    respondentId,
-    sourceSubjectId,
-    sourceSecretId,
-    sourceUserNickname,
-    sourceUserTag,
-    targetSubjectId,
-    targetSecretId,
-    targetUserNickname,
-    targetUserTag,
-    inputSubjectId,
-    inputSecretId,
-    inputUserNickname,
-    relation,
-    activityId,
-    activityName,
-    flowName,
-    flowId,
-    version,
-    legacyProfileId,
-    submitId,
-  } = nextExtendedEvent;
-  const getTime = getTimeByCondition(event.time.toString());
+  const shouldLogDataInDebugMode = checkIfShouldLogging();
 
-  return getJourneyCSVReturn({
-    id,
-    activity_flow_submission_id: flowId ? submitId : '',
-    activity_scheduled_time: scheduledDatetime
-      ? convertDateStampToMs(scheduledDatetime)
-      : ActivityStatus.NotScheduled,
-    activity_start_time: convertDateStampToMs(startDatetime),
-    activity_end_time: convertDateStampToMs(endDatetime),
-    press_next_time: getTime(event.type === UserActionType.Next),
-    press_popup_skip_time: getTime(event.type === UserActionType.SkipPopupConfirm),
-    press_popup_keep_time: getTime(event.type === UserActionType.SkipPopupCancel),
-    press_back_time: getTime(event.type === UserActionType.Prev),
-    press_undo_time: getTime(event.type === UserActionType.Undo),
-    press_skip_time: getTime(event.type === UserActionType.Skip),
-    press_done_time: getTime(event.type === UserActionType.Done),
-    response_option_selection_time: getTime(event.type === UserActionType.SetAnswer),
-    secret_user_id: respondentSecretId,
-    user_id: respondentId,
-    source_user_subject_id: sourceSubjectId,
-    source_user_secret_id: sourceSecretId,
-    source_user_nickname: sourceUserNickname,
-    source_user_relation: relation,
-    source_user_tag: sourceUserTag,
-    target_user_subject_id: targetSubjectId,
-    target_user_secret_id: targetSecretId,
-    target_user_nickname: targetUserNickname,
-    target_user_tag: targetUserTag,
-    input_user_subject_id: inputSubjectId,
-    input_user_secret_id: inputSecretId,
-    input_user_nickname: inputUserNickname,
-    activity_id: activityId,
-    activity_flow_id: flowId,
-    activity_flow_name: flowName,
-    activity_name: activityName,
-    item: SPLASH_SCREEN_ITEM_NAME,
-    item_id: '',
-    prompt: '',
-    response: '',
-    options: '',
-    version,
-    item_type: activityItem.responseType,
-    event_id: null,
-    timezone_offset: null,
-    legacy_user_id: legacyProfileId,
-  });
-};
+  if (shouldLogDataInDebugMode) {
+    console.log(
+      `[getSplashScreen] Creating splash screen for event at time ${event.time} with next event screen ${nextExtendedEvent.screen}`,
+    );
+  }
 
-export const getJourneyCSVObject = <T>({
-  event,
-  rawAnswersObject,
-  index,
-  enableDataExportRenaming,
-}: {
-  event: ExtendedEvent;
-  rawAnswersObject: Record<string, T & { answer: AnswerDTO }>;
-  index: number;
-  enableDataExportRenaming: boolean;
-}) => {
-  const {
-    activityItem,
-    scheduledDatetime,
-    startDatetime,
-    endDatetime,
-    respondentSecretId,
-    respondentId,
-    sourceSubjectId,
-    sourceSecretId,
-    sourceUserNickname,
-    sourceUserTag,
-    targetSubjectId,
-    targetSecretId,
-    targetUserNickname,
-    targetUserTag,
-    inputSubjectId,
-    inputSecretId,
-    inputUserNickname,
-    relation,
-    activityId,
-    activityName,
-    flowName,
-    flowId,
-    version,
-    legacyProfileId,
-    scheduledEventId,
-    tzOffset,
-    submitId,
-  } = event;
-  if (!activityItem) return;
+  try {
+    const {
+      activityItem,
+      id,
+      scheduledDatetime,
+      startDatetime,
+      endDatetime,
+      respondentSecretId,
+      respondentId,
+      sourceSubjectId,
+      sourceSecretId,
+      sourceUserNickname,
+      sourceUserTag,
+      targetSubjectId,
+      targetSecretId,
+      targetUserNickname,
+      targetUserTag,
+      inputSubjectId,
+      inputSecretId,
+      inputUserNickname,
+      relation,
+      activityId,
+      activityName,
+      flowName,
+      flowId,
+      version,
+      legacyProfileId,
+      submitId,
+    } = nextExtendedEvent;
 
-  const responseValues = activityItem?.responseValues as SingleAndMultipleSelectItemResponseValues &
-    SliderItemResponseValues;
-  const getTime = getTimeByCondition(event.time.toString());
+    const getTime = getTimeByCondition(event.time.toString());
 
-  return getJourneyCSVReturn(
-    {
-      id: event.id,
+    if (!activityItem) {
+      if (shouldLogDataInDebugMode) {
+        console.warn(`[getSplashScreen] No activityItem found in next event, returning undefined`);
+      }
+
+      return undefined;
+    }
+
+    if (shouldLogDataInDebugMode) {
+      console.log(
+        `[getSplashScreen] Creating splash screen with activity: ${activityName}, item: ${SPLASH_SCREEN_ITEM_NAME}`,
+      );
+    }
+
+    return getJourneyCSVReturn({
+      id,
       activity_flow_submission_id: flowId ? submitId : '',
       activity_scheduled_time: scheduledDatetime
         ? convertDateStampToMs(scheduledDatetime)
@@ -309,25 +249,192 @@ export const getJourneyCSVObject = <T>({
       activity_flow_id: flowId,
       activity_flow_name: flowName,
       activity_name: activityName,
-      item: activityItem.name,
-      item_id: activityItem.id,
-      prompt: replaceItemVariableWithName({
-        markdown: getDictionaryText(activityItem.question),
-        items: event.items,
-        rawAnswersObject,
-      }),
-      response: parseResponseValue(event, index, true),
-      options: replaceItemVariableWithName({
+      item: SPLASH_SCREEN_ITEM_NAME,
+      item_id: '',
+      prompt: '',
+      response: '',
+      options: '',
+      version,
+      item_type: activityItem.responseType,
+      event_id: null,
+      timezone_offset: null,
+      legacy_user_id: legacyProfileId,
+    });
+  } catch (error) {
+    console.error(`[getSplashScreen] Error creating splash screen:`, error);
+    if (error instanceof Error && shouldLogDataInDebugMode) {
+      console.error(
+        `[getSplashScreen] Error details: ${error.name}: ${error.message}, Stack: ${error.stack}`,
+      );
+    }
+
+    return undefined;
+  }
+};
+
+export const getJourneyCSVObject = <T>({
+  event,
+  rawAnswersObject,
+  index,
+  enableDataExportRenaming,
+}: {
+  event: ExtendedEvent;
+  rawAnswersObject: Record<string, T & { answer: AnswerDTO }>;
+  index: number;
+  enableDataExportRenaming: boolean;
+}) => {
+  const shouldLogDataInDebugMode = checkIfShouldLogging();
+
+  if (shouldLogDataInDebugMode) {
+    console.log(
+      `[getJourneyCSVObject] Processing event with screen: ${event.screen}, type: ${event.type}, index: ${index}`,
+    );
+  }
+
+  try {
+    const {
+      activityItem,
+      scheduledDatetime,
+      startDatetime,
+      endDatetime,
+      respondentSecretId,
+      respondentId,
+      sourceSubjectId,
+      sourceSecretId,
+      sourceUserNickname,
+      sourceUserTag,
+      targetSubjectId,
+      targetSecretId,
+      targetUserNickname,
+      targetUserTag,
+      inputSubjectId,
+      inputSecretId,
+      inputUserNickname,
+      relation,
+      activityId,
+      activityName,
+      flowName,
+      flowId,
+      version,
+      legacyProfileId,
+      scheduledEventId,
+      tzOffset,
+      submitId,
+    } = event;
+
+    if (!activityItem) {
+      if (shouldLogDataInDebugMode) {
+        console.warn(
+          `[getJourneyCSVObject] No activityItem found for event with screen: ${event.screen}, returning undefined`,
+        );
+      }
+
+      return undefined;
+    }
+
+    const responseValues =
+      activityItem?.responseValues as SingleAndMultipleSelectItemResponseValues &
+        SliderItemResponseValues;
+    const getTime = getTimeByCondition(event.time.toString());
+
+    if (shouldLogDataInDebugMode) {
+      console.log(
+        `[getJourneyCSVObject] Creating journey CSV object for activity: ${activityName}, item: ${activityItem.name}`,
+      );
+    }
+
+    let response, options;
+    try {
+      response = parseResponseValue(event, index, true);
+      options = replaceItemVariableWithName({
         markdown: parseOptions(responseValues, event.activityItem?.responseType) ?? '',
         items: event.items,
         rawAnswersObject,
-      }),
-      version,
-      item_type: activityItem.responseType,
-      event_id: scheduledEventId,
-      timezone_offset: tzOffset,
-      legacy_user_id: legacyProfileId,
-    },
-    enableDataExportRenaming,
-  );
+      });
+
+      if (shouldLogDataInDebugMode) {
+        console.log(
+          `[getJourneyCSVObject] Parsed response value length: ${
+            response ? response.length : 0
+          }, options length: ${options ? options.length : 0}`,
+        );
+      }
+    } catch (parseError) {
+      console.error(`[getJourneyCSVObject] Error parsing response or options:`, parseError);
+      if (parseError instanceof Error && shouldLogDataInDebugMode) {
+        console.error(
+          `[getJourneyCSVObject] Parse error details: ${parseError.name}: ${parseError.message}, Stack: ${parseError.stack}`,
+        );
+      }
+      response = '';
+      options = '';
+    }
+
+    return getJourneyCSVReturn(
+      {
+        id: event.id,
+        activity_flow_submission_id: flowId ? submitId : '',
+        activity_scheduled_time: scheduledDatetime
+          ? convertDateStampToMs(scheduledDatetime)
+          : ActivityStatus.NotScheduled,
+        activity_start_time: convertDateStampToMs(startDatetime),
+        activity_end_time: convertDateStampToMs(endDatetime),
+        press_next_time: getTime(event.type === UserActionType.Next),
+        press_popup_skip_time: getTime(event.type === UserActionType.SkipPopupConfirm),
+        press_popup_keep_time: getTime(event.type === UserActionType.SkipPopupCancel),
+        press_back_time: getTime(event.type === UserActionType.Prev),
+        press_undo_time: getTime(event.type === UserActionType.Undo),
+        press_skip_time: getTime(event.type === UserActionType.Skip),
+        press_done_time: getTime(event.type === UserActionType.Done),
+        response_option_selection_time: getTime(event.type === UserActionType.SetAnswer),
+        secret_user_id: respondentSecretId,
+        user_id: respondentId,
+        source_user_subject_id: sourceSubjectId,
+        source_user_secret_id: sourceSecretId,
+        source_user_nickname: sourceUserNickname,
+        source_user_relation: relation,
+        source_user_tag: sourceUserTag,
+        target_user_subject_id: targetSubjectId,
+        target_user_secret_id: targetSecretId,
+        target_user_nickname: targetUserNickname,
+        target_user_tag: targetUserTag,
+        input_user_subject_id: inputSubjectId,
+        input_user_secret_id: inputSecretId,
+        input_user_nickname: inputUserNickname,
+        activity_id: activityId,
+        activity_flow_id: flowId,
+        activity_flow_name: flowName,
+        activity_name: activityName,
+        item: activityItem.name,
+        item_id: activityItem.id,
+        prompt: replaceItemVariableWithName({
+          markdown: getDictionaryText(activityItem.question),
+          items: event.items,
+          rawAnswersObject,
+        }),
+        response,
+        options,
+        version,
+        item_type: activityItem.responseType,
+        event_id: scheduledEventId,
+        timezone_offset: tzOffset,
+        legacy_user_id: legacyProfileId,
+      },
+      enableDataExportRenaming,
+    );
+  } catch (error) {
+    console.error(`[getJourneyCSVObject] Error creating journey CSV object:`, error);
+    if (error instanceof Error && shouldLogDataInDebugMode) {
+      console.error(
+        `[getJourneyCSVObject] Error details: ${error.name}: ${error.message}, Stack: ${error.stack}`,
+      );
+      console.error(
+        `[getJourneyCSVObject] Event data: screen=${event.screen}, type=${
+          event.type
+        }, activityName=${event.activityName || 'N/A'}`,
+      );
+    }
+
+    return undefined;
+  }
 };

--- a/src/shared/utils/exportTemplate.ts
+++ b/src/shared/utils/exportTemplate.ts
@@ -1,3 +1,6 @@
+// eslint-disable no-console
+import { checkIfShouldLogging } from './logger';
+
 export const exportTemplate = async <T extends unknown[]>({
   data,
   fileName,
@@ -9,26 +12,257 @@ export const exportTemplate = async <T extends unknown[]>({
   isXlsx?: boolean;
   defaultData?: string[] | null;
 }) => {
-  const { writeFile, utils } = await import('xlsx');
-  const workSheet = defaultData ? utils.aoa_to_sheet([defaultData]) : utils.json_to_sheet(data);
-  const workBook = utils.book_new();
+  const shouldLogDataInDebugMode = checkIfShouldLogging();
 
-  utils.book_append_sheet(workBook, workSheet, 'Sheet1');
+  if (shouldLogDataInDebugMode) {
+    console.log(
+      `[ExportTemplate] Starting export for ${fileName} with ${data.length} rows of data`,
+    );
 
-  // Fix for Safari (Allow Multiple File Downloads).
-  // https://stackoverflow.com/questions/61961488/allow-multiple-file-downloads-in-safari
-  // One of the possible options to download multiple files is to add these files to the archive.
-  return new Promise((resolve) => {
-    writeFile(workBook, `${fileName}${isXlsx ? '.xlsx' : '.csv'}`);
+    try {
+      const sampleSize = Math.min(5, data.length);
+      const sampleItems = data.slice(0, sampleSize);
+      const estimatedItemSize = sampleItems.length > 0 ? JSON.stringify(sampleItems[0]).length : 0;
+      const estimatedTotalSize = estimatedItemSize * data.length;
 
-    setTimeout(() => {
-      resolve(true);
-    });
-  });
+      console.log(
+        `[ExportTemplate] Estimated data size for ${fileName}: ~${Math.round(
+          estimatedTotalSize / 1024,
+        )} KB` + ` (${data.length} items, ~${estimatedItemSize} bytes per item)`,
+      );
+
+      if (estimatedTotalSize > 50 * 1024 * 1024) {
+        // 50MB
+        console.warn(
+          `[ExportTemplate] Warning: Large data set detected for ${fileName}. ` +
+            `Estimated size: ${Math.round(estimatedTotalSize / (1024 * 1024))} MB`,
+        );
+      }
+
+      if (data.length > 0) {
+        const firstItem = data[0] as Record<string, unknown>;
+        const lastItem = data[data.length - 1] as Record<string, unknown>;
+        console.log(`[ExportTemplate] First item keys: ${Object.keys(firstItem).join(', ')}`);
+        console.log(`[ExportTemplate] Last item keys: ${Object.keys(lastItem).join(', ')}`);
+
+        const firstItemKeys = Object.keys(firstItem).sort().join(',');
+        const lastItemKeys = Object.keys(lastItem).sort().join(',');
+
+        if (firstItemKeys !== lastItemKeys) {
+          console.warn(
+            `[ExportTemplate] Warning: Inconsistent data structure detected in ${fileName}. ` +
+              `First and last items have different keys.`,
+          );
+        }
+      }
+    } catch (sizeError) {
+      console.error(`[ExportTemplate] Error analyzing data size: ${sizeError}`);
+    }
+  }
+
+  try {
+    if (shouldLogDataInDebugMode) {
+      console.log(`[ExportTemplate] Dynamically importing xlsx library`);
+    }
+
+    const { writeFile, utils } = await import('xlsx');
+
+    if (shouldLogDataInDebugMode) {
+      console.log(`[ExportTemplate] Creating worksheet for ${fileName}`);
+
+      // Log memory usage if available
+      if (typeof window !== 'undefined' && window.performance) {
+        try {
+          // Chrome-specific memory API - use type assertion for safety
+          const perf = window.performance as any;
+          if (perf.memory) {
+            console.log(
+              `[ExportTemplate] Current memory usage: ${Math.round(
+                perf.memory.usedJSHeapSize / (1024 * 1024),
+              )}MB ` + `/ ${Math.round(perf.memory.jsHeapSizeLimit / (1024 * 1024))}MB`,
+            );
+          }
+        } catch (memoryError) {
+          // Silently ignore - memory API might not be available in all browsers
+        }
+      }
+    }
+
+    // Track worksheet creation time for performance monitoring
+    const worksheetStartTime = Date.now();
+
+    try {
+      const workSheet = defaultData ? utils.aoa_to_sheet([defaultData]) : utils.json_to_sheet(data);
+
+      if (shouldLogDataInDebugMode) {
+        const worksheetCreationTime = Date.now() - worksheetStartTime;
+        console.log(
+          `[ExportTemplate] Worksheet created successfully for ${fileName} in ${worksheetCreationTime}ms`,
+        );
+
+        // Check worksheet dimensions
+        if (workSheet['!ref']) {
+          console.log(`[ExportTemplate] Worksheet dimensions: ${workSheet['!ref']}`);
+        }
+      }
+
+      const workBook = utils.book_new();
+      utils.book_append_sheet(workBook, workSheet, 'Sheet1');
+
+      if (shouldLogDataInDebugMode) {
+        console.log(`[ExportTemplate] Writing file ${fileName}${isXlsx ? '.xlsx' : '.csv'}`);
+      }
+
+      return new Promise((resolve) => {
+        try {
+          // Track file writing time
+          const writeStartTime = Date.now();
+
+          writeFile(workBook, `${fileName}${isXlsx ? '.xlsx' : '.csv'}`);
+
+          if (shouldLogDataInDebugMode) {
+            const writeTime = Date.now() - writeStartTime;
+            console.log(
+              `[ExportTemplate] Successfully wrote file ${fileName}${
+                isXlsx ? '.xlsx' : '.csv'
+              } in ${writeTime}ms`,
+            );
+          }
+        } catch (writeError) {
+          console.error(`[ExportTemplate] Error writing file ${fileName}:`, writeError);
+          if (writeError instanceof Error) {
+            console.error(
+              `[ExportTemplate] Error details: ${writeError.name}: ${writeError.message}`,
+            );
+
+            if (shouldLogDataInDebugMode) {
+              console.error(`[ExportTemplate] Stack trace: ${writeError.stack}`);
+
+              // Log more detailed error information based on error type
+              if (
+                writeError.name === 'QuotaExceededError' ||
+                writeError.message.includes('quota') ||
+                writeError.message.includes('storage')
+              ) {
+                console.error(
+                  `[ExportTemplate] Storage quota error detected. This may be due to insufficient disk space.`,
+                );
+              }
+
+              if (writeError.message.includes('permission')) {
+                console.error(
+                  `[ExportTemplate] Permission error detected. Check file system permissions.`,
+                );
+              }
+
+              console.error(
+                `[ExportTemplate] Data statistics: Size=${data.length}, Sample keys=${
+                  data[0] ? Object.keys(data[0]).slice(0, 5).join(', ') : 'N/A'
+                }`,
+              );
+            }
+          }
+        }
+        setTimeout(() => {
+          resolve(true);
+        });
+      });
+    } catch (worksheetError) {
+      console.error(`[ExportTemplate] Error creating worksheet for ${fileName}:`, worksheetError);
+      if (worksheetError instanceof Error) {
+        console.error(
+          `[ExportTemplate] Worksheet error details: ${worksheetError.name}: ${worksheetError.message}`,
+        );
+
+        if (shouldLogDataInDebugMode) {
+          console.error(`[ExportTemplate] Worksheet error stack: ${worksheetError.stack}`);
+
+          // Check for RangeError specifically
+          if (worksheetError.name === 'RangeError') {
+            if (worksheetError.message.includes('array length')) {
+              console.error(
+                `[ExportTemplate] Invalid array length detected. This may be due to data exceeding size limits.`,
+              );
+
+              // Try to identify which part of the data might be causing the issue
+              try {
+                let problematicIndex = -1;
+                let maxLength = 0;
+
+                // Sample data to find potentially problematic items
+                const sampleStep = Math.max(1, Math.floor(data.length / 10));
+                for (let i = 0; i < data.length; i += sampleStep) {
+                  const itemString = JSON.stringify(data[i]);
+                  if (itemString.length > maxLength) {
+                    maxLength = itemString.length;
+                    problematicIndex = i;
+                  }
+                }
+
+                if (problematicIndex >= 0) {
+                  console.error(
+                    `[ExportTemplate] Potentially problematic item found at index ${problematicIndex} ` +
+                      `with size ${maxLength} bytes`,
+                  );
+                }
+              } catch (analysisError) {
+                console.error(
+                  `[ExportTemplate] Error analyzing problematic data: ${analysisError}`,
+                );
+              }
+            }
+          }
+        }
+      }
+      throw worksheetError; // Re-throw to be caught by the outer try-catch
+    }
+  } catch (error) {
+    console.error(`[ExportTemplate] Critical error in exportTemplate for ${fileName}:`, error);
+    if (error instanceof Error) {
+      console.error(`[ExportTemplate] Error details: ${error.name}: ${error.message}`);
+      if (shouldLogDataInDebugMode) {
+        console.error(`[ExportTemplate] Stack trace: ${error.stack}`);
+        console.error(
+          `[ExportTemplate] Data statistics: Size=${data.length}, Sample keys=${
+            data[0] ? Object.keys(data[0]).slice(0, 5).join(', ') : 'N/A'
+          }`,
+        );
+      }
+    }
+
+    return true;
+  }
 };
 
 export const convertJsonToCsv = async (data: unknown[]) => {
-  const { utils } = await import('xlsx');
+  if (checkIfShouldLogging()) {
+    console.log(`[ConvertJsonToCsv] Converting data with ${data.length} rows`);
+  }
 
-  return utils.sheet_to_csv(utils.json_to_sheet(data));
+  try {
+    const { utils } = await import('xlsx');
+
+    if (checkIfShouldLogging()) {
+      console.log(`[ConvertJsonToCsv] Creating sheet from JSON data`);
+    }
+
+    const result = utils.sheet_to_csv(utils.json_to_sheet(data));
+
+    if (checkIfShouldLogging()) {
+      console.log(`[ConvertJsonToCsv] Successfully converted JSON to CSV`);
+    }
+
+    return result;
+  } catch (error) {
+    console.error(`[ConvertJsonToCsv] Error converting JSON to CSV:`, error);
+
+    if (error instanceof Error) {
+      console.error(`[ConvertJsonToCsv] Error details: ${error.name}: ${error.message}`);
+      if (checkIfShouldLogging()) {
+        console.error(`[ConvertJsonToCsv] Stack trace: ${error.stack}`);
+      }
+    }
+
+    throw error;
+  }
 };


### PR DESCRIPTION
- [X] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

🔗 [Jira Ticket M2-9264](https://mindlogger.atlassian.net/browse/M2-9264)

This PR adds comprehensive error logging for the data export process, since currently, next to none is enabled.

The logging was put behind a manually-set session storage key. This can be enabled with:

```ts
sessionStorage.setItem('debugMode', true)
```

### 🪤 Peer Testing

Once the logging has been enabled, exporting any data for either activities or full applets should display logs in the browser console

### ✏️ Notes

If logging is no longer required/desired, simply removing the same key from the session storage will disable it.
