### PR TITLE
feat: Conditional user journey export (M2-9648)

### DIFF
--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -468,9 +468,11 @@
       "responsesOnly": "Responses Only",
       "responsesAndEhrData": "Responses & EHR Data"
     },
+    "responses": "responses",
     "supplementaryFiles": {
       "description": "Supplementary files:",
       "includes": {
+        "userJourney": "User Journey Data",
         "scheduleHistory": "Include schedule history",
         "flowHistory": "Include activity flow history"
       }

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -468,9 +468,11 @@
       "responsesOnly": "Réponses uniquement",
       "responsesAndEhrData": "Réponses & données DSE"
     },
+    "responses": "réponses",
     "supplementaryFiles": {
-      "description": "Fichiers supplémentaires :",
+      "description": "Fichiers supplémentaires:",
       "includes": {
+        "userJourney": "Données du parcours utilisateur",
         "scheduleHistory": "Inclure l'historique du programme",
         "flowHistory": "Inclure l'historique du flux d'activité"
       }

--- a/src/shared/features/AppletSettings/ExportDataSetting/ExportDataSetting.tsx
+++ b/src/shared/features/AppletSettings/ExportDataSetting/ExportDataSetting.tsx
@@ -1,7 +1,7 @@
+import { yupResolver } from '@hookform/resolvers/yup';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { ObjectSchema } from 'yup';
-import { yupResolver } from '@hookform/resolvers/yup';
 
 import { DataExportPopup } from 'shared/features/AppletSettings/ExportDataSetting/Popups/DataExportPopup';
 import { useFeatureFlags } from 'shared/hooks';
@@ -96,11 +96,30 @@ export const ExportDataSetting = ({
     .filter((file) => (defaultSupportedSupplementaryFiles as string[]).includes(file));
 
   let appletName = '';
+  let contextItemName = '';
+
   if (appletData) {
     if ('appletDisplayName' in appletData) {
       appletName = appletData.appletDisplayName ?? '';
     } else if ('displayName' in appletData) {
       appletName = appletData.displayName;
+    }
+
+    contextItemName = appletName;
+
+    // Check if we have activity or flow filters and update the context item name accordingly
+    if (filters?.activityId && 'activities' in appletData) {
+      const activity = appletData.activities?.find(
+        (activity) => activity.id === filters.activityId,
+      );
+      if (activity?.name) {
+        contextItemName = activity.name;
+      }
+    } else if (filters?.flowId && 'activityFlows' in appletData) {
+      const flow = appletData.activityFlows?.find((flow) => flow.id === filters.flowId);
+      if (flow?.name) {
+        contextItemName = flow.name;
+      }
     }
   }
 
@@ -123,7 +142,7 @@ export const ExportDataSetting = ({
           }}
           minDate={minDate}
           getMaxDate={getMaxDate}
-          appletName={appletName}
+          contextItemName={contextItemName}
           supportedSupplementaryFiles={filteredSupportedSupplementaryFiles}
           canExportEhrHealthData={canExportEhrHealthData}
           data-testid={`${dataTestId}-settings`}

--- a/src/shared/features/AppletSettings/ExportDataSetting/ExportDataSetting.tsx
+++ b/src/shared/features/AppletSettings/ExportDataSetting/ExportDataSetting.tsx
@@ -4,12 +4,13 @@ import { ObjectSchema } from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup';
 
 import { DataExportPopup } from 'shared/features/AppletSettings/ExportDataSetting/Popups/DataExportPopup';
-import { applet } from 'shared/state/Applet';
-import { getNormalizedTimezoneDate } from 'shared/utils/dateTimezone';
-import { UniqueTuple } from 'shared/types';
 import { useFeatureFlags } from 'shared/hooks';
 import { FeatureFlagDefaults } from 'shared/hooks/useFeatureFlags.const';
+import { applet } from 'shared/state/Applet';
+import { UniqueTuple } from 'shared/types';
+import { getNormalizedTimezoneDate } from 'shared/utils/dateTimezone';
 
+import { exportDataSettingSchema } from './ExportDataSetting.schema';
 import {
   ExportDataExported,
   ExportDataFormValues,
@@ -18,7 +19,6 @@ import {
   SupplementaryFiles,
   SupplementaryFilesWithFeatureFlag,
 } from './ExportDataSetting.types';
-import { exportDataSettingSchema } from './ExportDataSetting.schema';
 import { ExportSettingsPopup } from './Popups/ExportSettingsPopup/ExportSettingsPopup';
 
 export const ExportDataSetting = ({
@@ -49,7 +49,10 @@ export const ExportDataSetting = ({
       fromDate: minDate,
       toDate: getMaxDate(),
       supplementaryFiles: SupplementaryFiles.reduce(
-        (acc, fileType) => ({ ...acc, [fileType]: false }),
+        (acc, fileType) => ({
+          ...acc,
+          [fileType]: fileType === 'userJourney',
+        }),
         {} as Record<SupplementaryFiles, boolean>,
       ),
     }),
@@ -65,8 +68,10 @@ export const ExportDataSetting = ({
     methods.reset(defaultValues);
   }, [defaultValues, methods]);
 
-  const defaultSupportedSupplementaryFiles =
-    supportedSupplementaryFiles ?? (SupplementaryFiles as UniqueTuple<SupplementaryFiles>);
+  // User journey is always supported
+  const defaultSupportedSupplementaryFiles = supportedSupplementaryFiles
+    ? [...new Set([...supportedSupplementaryFiles, 'userJourney'])]
+    : (SupplementaryFiles as UniqueTuple<SupplementaryFiles>);
 
   const filteredSupportedSupplementaryFiles = (
     Object.entries(SupplementaryFilesWithFeatureFlag) as unknown as [

--- a/src/shared/features/AppletSettings/ExportDataSetting/ExportDataSetting.types.ts
+++ b/src/shared/features/AppletSettings/ExportDataSetting/ExportDataSetting.types.ts
@@ -1,7 +1,7 @@
 import { ChosenAppletData } from 'modules/Dashboard/features';
 import { SingleApplet } from 'shared/state';
-import { ExportDataFilters } from 'shared/utils';
 import { UniqueTuple } from 'shared/types';
+import { ExportDataFilters } from 'shared/utils';
 
 export const enum ExportDateType {
   AllTime = 'allTime',
@@ -21,12 +21,12 @@ export const enum ExportDataExported {
 // to that flag's corresponding array, otherwise add it to the `none` array
 export const SupplementaryFilesWithFeatureFlag = {
   enableEmaExtraFiles: ['flowHistory', 'scheduleHistory'],
-  // none: [],
+  none: ['userJourney'],
 } as const;
 
 export const SupplementaryFiles = [
   ...SupplementaryFilesWithFeatureFlag.enableEmaExtraFiles,
-  //...SupplementaryFilesWithFeatureFlag.none,
+  ...SupplementaryFilesWithFeatureFlag.none,
 ] as const;
 
 export type SupplementaryFiles = (typeof SupplementaryFiles)[number];

--- a/src/shared/features/AppletSettings/ExportDataSetting/Popups/DataExportPopup/DataExportPopup_old.tsx
+++ b/src/shared/features/AppletSettings/ExportDataSetting/Popups/DataExportPopup/DataExportPopup_old.tsx
@@ -58,7 +58,7 @@ export const DataExportPopup = ({
 }: DataExportPopupProps) => {
   const dataExportingRef = useRef(false);
   const { featureFlags } = useFeatureFlags();
-  const { getValues } = useFormContext<ExportDataFormValues>() ?? {};
+  const { getValues, watch } = useFormContext<ExportDataFormValues>() ?? {};
   const { t } = useTranslation('app');
   const { ownerId } = workspaces.useData() ?? {};
   const [dataIsExporting, setDataIsExporting] = useState(false);
@@ -70,6 +70,7 @@ export const DataExportPopup = ({
   });
 
   const appletId = get(chosenAppletData, isAppletSetting ? 'id' : 'appletId');
+  const shouldGenerateUserJourney = watch('supplementaryFiles.userJourney');
   const subjectId = isAppletSetting ? undefined : (chosenAppletData as ChosenAppletData)?.subjectId;
   const { encryption } = chosenAppletData ?? {};
 
@@ -142,6 +143,7 @@ export const DataExportPopup = ({
           suffix: exportDataPages > 1 ? getExportDataSuffix(1) : '',
           filters,
           flags: featureFlags,
+          shouldGenerateUserJourney,
         })(firstPageData);
 
         if (exportDataPages > 1) {
@@ -160,6 +162,7 @@ export const DataExportPopup = ({
               suffix: getExportDataSuffix(page),
               filters,
               flags: featureFlags,
+              shouldGenerateUserJourney,
             })(nextPageData);
           }
         }

--- a/src/shared/features/AppletSettings/ExportDataSetting/Popups/DataExportPopup/DataExportWorkersManager/DataExportWorkersManager.ts
+++ b/src/shared/features/AppletSettings/ExportDataSetting/Popups/DataExportPopup/DataExportWorkersManager/DataExportWorkersManager.ts
@@ -1,17 +1,17 @@
 import { Dispatch, MutableRefObject, SetStateAction } from 'react';
 
-import { ExportDataResult } from 'shared/types/answer';
-import { EncryptionParsed } from 'shared/utils/encryption';
-import { ExportDataFilters, exportDecryptedDataSucceed } from 'shared/utils/exportData';
 import { ItemResponseType } from 'shared/consts';
-import { Mixpanel } from 'shared/utils/mixpanel/mixpanel';
-import { MixpanelEventType, MixpanelProps } from 'shared/utils/mixpanel/mixpanel.types';
-import { FeatureFlags } from 'shared/types/featureFlags';
-import DecryptionWorker from 'shared/features/AppletSettings/ExportDataSetting/Popups/DataExportPopup/DataExportWorker/DataExportWorker.worker';
 import { IdleWorker } from 'shared/features/AppletSettings/ExportDataSetting/Popups/DataExportPopup/DataExportPopup.types';
+import { getExportDataSuffix } from 'shared/features/AppletSettings/ExportDataSetting/Popups/DataExportPopup/DataExportPopup.utils';
 import { NUM_WORKERS } from 'shared/features/AppletSettings/ExportDataSetting/Popups/DataExportPopup/DataExportWorker/DataExportWorker.const';
 import { WorkerOnMessageEvent } from 'shared/features/AppletSettings/ExportDataSetting/Popups/DataExportPopup/DataExportWorker/DataExportWorker.types';
-import { getExportDataSuffix } from 'shared/features/AppletSettings/ExportDataSetting/Popups/DataExportPopup/DataExportPopup.utils';
+import DecryptionWorker from 'shared/features/AppletSettings/ExportDataSetting/Popups/DataExportPopup/DataExportWorker/DataExportWorker.worker';
+import { ExportDataResult } from 'shared/types/answer';
+import { FeatureFlags } from 'shared/types/featureFlags';
+import { EncryptionParsed } from 'shared/utils/encryption';
+import { ExportDataFilters, exportDecryptedDataSucceed } from 'shared/utils/exportData';
+import { Mixpanel } from 'shared/utils/mixpanel/mixpanel';
+import { MixpanelEventType, MixpanelProps } from 'shared/utils/mixpanel/mixpanel.types';
 
 export class DataExportWorkersManager {
   private workers: IdleWorker[] = [];
@@ -70,6 +70,8 @@ export class DataExportWorkersManager {
         suffix: hasSuffix ? getExportDataSuffix(page) : '',
         filters,
         flags: this.flags,
+        // TODO: This should be properly passed from the form once this exporter is enabled
+        shouldGenerateUserJourney: true,
       })(decryptedData).then(() => {
         this.finishedPagesRef.current.add(page);
         this.handleAllTasksCompleted();

--- a/src/shared/features/AppletSettings/ExportDataSetting/Popups/ExportSettingsPopup/ExportSettingsPopup.test.tsx
+++ b/src/shared/features/AppletSettings/ExportDataSetting/Popups/ExportSettingsPopup/ExportSettingsPopup.test.tsx
@@ -6,17 +6,17 @@ import { FieldValues, FormProvider, useForm, UseFormReturn } from 'react-hook-fo
 import { initialStateData } from 'redux/modules';
 import { page } from 'resources';
 import { DateFormats } from 'shared/consts';
-import { mockedAppletId, mockedApplet } from 'shared/mock';
-import { SettingParam, getNormalizedTimezoneDate } from 'shared/utils';
+import { mockedApplet, mockedAppletId } from 'shared/mock';
+import { getNormalizedTimezoneDate, SettingParam } from 'shared/utils';
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
 
-import { ExportSettingsPopup } from './ExportSettingsPopup';
 import { DATA_TESTID_EXPORT_DATA_SETTINGS_POPUP } from '../../ExportDataSetting.const';
 import {
   ExportDataFormValues,
   ExportDateType,
   SupplementaryFiles,
 } from '../../ExportDataSetting.types';
+import { ExportSettingsPopup } from './ExportSettingsPopup';
 
 const dateString = '2023-11-14T14:43:33.369902';
 const date = new Date(dateString);
@@ -62,7 +62,7 @@ const commonProps = {
   onExport: mockOnExport,
   minDate: date,
   getMaxDate: () => getNormalizedTimezoneDate(new Date().toString()),
-  appletName: mockedApplet.displayName,
+  contextItemName: mockedApplet.displayName,
   'data-testid': DATA_TESTID_EXPORT_DATA_SETTINGS_POPUP,
 };
 

--- a/src/shared/features/AppletSettings/ExportDataSetting/Popups/ExportSettingsPopup/ExportSettingsPopup.tsx
+++ b/src/shared/features/AppletSettings/ExportDataSetting/Popups/ExportSettingsPopup/ExportSettingsPopup.tsx
@@ -1,31 +1,32 @@
-import { useTranslation } from 'react-i18next';
-import { addDays, endOfDay, startOfDay } from 'date-fns';
-import { useFormContext } from 'react-hook-form';
-import { useMemo } from 'react';
 import { Button } from '@mui/material';
+import { addDays, endOfDay, startOfDay } from 'date-fns';
+import { useMemo } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 
-import { Svg } from 'shared/components/Svg';
-import { CheckboxController, SelectController } from 'shared/components/FormComponents';
 import { DatePicker } from 'shared/components/DatePicker';
+import { DateType } from 'shared/components/DatePicker/DatePicker.types';
+import { CheckboxController, SelectController } from 'shared/components/FormComponents';
 import { Modal } from 'shared/components/Modal';
+import { Svg } from 'shared/components/Svg';
 import {
   StyledBodyLarge,
   StyledFlexAllCenter,
   StyledFlexColumn,
   StyledFlexTopCenter,
   StyledModalWrapper,
+  StyledTitleBoldMedium,
   theme,
 } from 'shared/styles';
 import { SelectEvent } from 'shared/types';
-import { DateType } from 'shared/components/DatePicker/DatePicker.types';
 
-import { ExportSettingsPopupProps } from './ExportSettingsPopup.types';
-import { getDataExportedOptions, getDateTypeOptions } from './ExportSettingsPopup.utils';
 import {
   ExportDataFormValues,
   ExportDateType,
   SupplementaryFilesFormValues,
 } from '../../ExportDataSetting.types';
+import { ExportSettingsPopupProps } from './ExportSettingsPopup.types';
+import { getDataExportedOptions, getDateTypeOptions } from './ExportSettingsPopup.utils';
 
 export const ExportSettingsPopup = ({
   isOpen,
@@ -33,7 +34,7 @@ export const ExportSettingsPopup = ({
   onExport,
   minDate,
   getMaxDate,
-  appletName,
+  contextItemName,
   supportedSupplementaryFiles,
   canExportEhrHealthData,
   'data-testid': dataTestId,
@@ -108,9 +109,7 @@ export const ExportSettingsPopup = ({
   return (
     <Modal
       open={isOpen}
-      title={t('exportDataForApplet', {
-        name: appletName,
-      })}
+      title={t('exportData')}
       onClose={onClose}
       width="57.5"
       data-testid={dataTestId}
@@ -118,6 +117,12 @@ export const ExportSettingsPopup = ({
       <StyledModalWrapper sx={{ pb: 0 }}>
         <form noValidate autoComplete="off">
           <StyledFlexColumn sx={{ gap: 3.2 }}>
+            <StyledFlexTopCenter sx={{ gap: 0.8 }}>
+              <StyledBodyLarge>{t('export')}:</StyledBodyLarge>
+              <StyledTitleBoldMedium>
+                {contextItemName} {t('dataExport.responses')}
+              </StyledTitleBoldMedium>
+            </StyledFlexTopCenter>
             <StyledFlexColumn sx={{ gap: 1.6 }}>
               {canExportEhrHealthData && (
                 <SelectController

--- a/src/shared/features/AppletSettings/ExportDataSetting/Popups/ExportSettingsPopup/ExportSettingsPopup.types.ts
+++ b/src/shared/features/AppletSettings/ExportDataSetting/Popups/ExportSettingsPopup/ExportSettingsPopup.types.ts
@@ -6,7 +6,7 @@ export type ExportSettingsPopupProps = {
   onExport: () => void;
   minDate: Date;
   getMaxDate: () => Date;
-  appletName: string;
+  contextItemName: string; // Activity name or Activity Flow name or Applet name
   supportedSupplementaryFiles?: SupplementaryFiles[];
   canExportEhrHealthData?: boolean;
   'data-testid'?: string;

--- a/src/shared/utils/exportData/exportDataSucceed.test.ts
+++ b/src/shared/utils/exportData/exportDataSucceed.test.ts
@@ -1,17 +1,17 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
 import {
+  activityJourneyHeader,
   legacyActivityJourneyHeader,
   legacyReportHeader,
-  activityJourneyHeader,
   reportHeader,
 } from 'shared/consts';
 
-import { exportEncryptedDataSucceed, exportDecryptedDataSucceed } from './exportDataSucceed';
-import * as prepareDataUtils from './prepareData';
 import * as exportTemplateUtils from '../exportTemplate';
 import * as exportCsvZipUtils from './exportCsvZip';
+import { exportDecryptedDataSucceed, exportEncryptedDataSucceed } from './exportDataSucceed';
 import * as exportMediaZipUtils from './exportMediaZip';
+import * as prepareDataUtils from './prepareData';
 
 const mockFlags = {
   enableDataExportRenaming: false,
@@ -125,6 +125,7 @@ describe('exportDataSucceed', () => {
     await exportDecryptedDataSucceed({
       suffix: '',
       flags: mockFlags,
+      shouldGenerateUserJourney: true,
     })(undefined);
 
     expect(prepareDataUtils.prepareDecryptedData).not.toHaveBeenCalled();
@@ -135,14 +136,16 @@ describe('exportDataSucceed', () => {
       getDecryptedAnswers: mockedGetDecryptedAnswers,
       suffix: '-test',
       flags: mockFlags,
+      shouldGenerateUserJourney: true,
     })(mockedExportData);
 
-    expect(prepareDataUtils.prepareEncryptedData).toHaveBeenCalledWith(
-      mockedExportData,
-      mockedGetDecryptedAnswers,
-      mockFlags,
-      undefined,
-    );
+    expect(prepareDataUtils.prepareEncryptedData).toHaveBeenCalledWith({
+      data: mockedExportData,
+      getDecryptedAnswers: mockedGetDecryptedAnswers,
+      flags: mockFlags,
+      filters: undefined,
+      shouldGenerateUserJourney: true,
+    });
 
     checkCommonActions();
   });
@@ -151,13 +154,15 @@ describe('exportDataSucceed', () => {
     await exportDecryptedDataSucceed({
       suffix: '-test',
       flags: mockFlags,
+      shouldGenerateUserJourney: true,
     })(mockedDecryptedExportData);
 
-    expect(prepareDataUtils.prepareDecryptedData).toHaveBeenCalledWith(
-      mockedDecryptedExportData,
-      mockFlags,
-      undefined,
-    );
+    expect(prepareDataUtils.prepareDecryptedData).toHaveBeenCalledWith({
+      parsedAnswers: mockedDecryptedExportData,
+      flags: mockFlags,
+      shouldGenerateUserJourney: true,
+      filters: undefined,
+    });
 
     checkCommonActions();
   });
@@ -167,14 +172,16 @@ describe('exportDataSucceed', () => {
       getDecryptedAnswers: mockedGetDecryptedAnswers,
       suffix: '-test',
       flags: { ...mockFlags, enableDataExportRenaming: true },
+      shouldGenerateUserJourney: true,
     })(mockedExportData);
 
-    expect(prepareDataUtils.prepareEncryptedData).toHaveBeenCalledWith(
-      mockedExportData,
-      mockedGetDecryptedAnswers,
-      { ...mockFlags, enableDataExportRenaming: true },
-      undefined,
-    );
+    expect(prepareDataUtils.prepareEncryptedData).toHaveBeenCalledWith({
+      data: mockedExportData,
+      getDecryptedAnswers: mockedGetDecryptedAnswers,
+      flags: { ...mockFlags, enableDataExportRenaming: true },
+      filters: undefined,
+      shouldGenerateUserJourney: true,
+    });
 
     checkCommonActions(true);
   });
@@ -183,13 +190,15 @@ describe('exportDataSucceed', () => {
     await exportDecryptedDataSucceed({
       suffix: '-test',
       flags: { ...mockFlags, enableDataExportRenaming: true },
+      shouldGenerateUserJourney: true,
     })(mockedDecryptedExportData);
 
-    expect(prepareDataUtils.prepareDecryptedData).toHaveBeenCalledWith(
-      mockedDecryptedExportData,
-      { ...mockFlags, enableDataExportRenaming: true },
-      undefined,
-    );
+    expect(prepareDataUtils.prepareDecryptedData).toHaveBeenCalledWith({
+      parsedAnswers: mockedDecryptedExportData,
+      flags: { ...mockFlags, enableDataExportRenaming: true },
+      filters: undefined,
+      shouldGenerateUserJourney: true,
+    });
 
     checkCommonActions(true);
   });
@@ -206,6 +215,7 @@ describe('exportDataSucceed', () => {
       getDecryptedAnswers: mockedGetDecryptedAnswers,
       suffix: '',
       flags: mockFlags,
+      shouldGenerateUserJourney: true,
     })(mockedExportData);
 
     checkExportTemplateDefaultData();
@@ -224,6 +234,7 @@ describe('exportDataSucceed', () => {
     await exportDecryptedDataSucceed({
       suffix: '',
       flags: mockFlags,
+      shouldGenerateUserJourney: true,
     })(mockedDecryptedExportData);
 
     checkExportTemplateDefaultData();

--- a/src/shared/utils/exportData/prepareData.test.ts
+++ b/src/shared/utils/exportData/prepareData.test.ts
@@ -172,7 +172,11 @@ describe('prepareData', () => {
   });
 
   test('prepareDecryptedData should return an object with the correct keys', async () => {
-    const result = await prepareDecryptedData([]);
+    const result = await prepareDecryptedData({
+      parsedAnswers: [],
+      flags: mockFlags,
+      shouldGenerateUserJourney: true,
+    });
 
     testCorrectKeys(result);
   });

--- a/src/shared/utils/exportData/prepareData.test.ts
+++ b/src/shared/utils/exportData/prepareData.test.ts
@@ -162,7 +162,11 @@ describe('prepareData', () => {
   test('prepareEncryptedData should return an object with the correct keys', async () => {
     const data = { activities: [], answers: [] };
     const getDecryptedAnswers = jest.fn();
-    const result = await prepareEncryptedData(data, getDecryptedAnswers);
+    const result = await prepareEncryptedData({
+      data,
+      getDecryptedAnswers,
+      shouldGenerateUserJourney: true,
+    });
 
     testCorrectKeys(result);
   });
@@ -408,12 +412,21 @@ describe('prepareData', () => {
       .spyOn(getParsedAnswersFunctions, 'getParsedAnswers')
       .mockImplementationOnce(() => mockedParsedAnswers);
 
-    const result = await prepareEncryptedData(data, getDecryptedAnswers, mockFlags);
+    const result = await prepareEncryptedData({
+      data,
+      getDecryptedAnswers,
+      shouldGenerateUserJourney: true,
+      flags: mockFlags,
+    });
     expect(result).toEqual(mockedExportDataResult);
   });
 
   test('prepareDecryptedData should return filled in reportData', async () => {
-    const result = await prepareDecryptedData(mockedParsedAnswers, mockFlags);
+    const result = await prepareDecryptedData({
+      parsedAnswers: mockedParsedAnswers,
+      flags: mockFlags,
+      shouldGenerateUserJourney: true,
+    });
     expect(result).toEqual(mockedExportDataResult);
   });
 });


### PR DESCRIPTION
- [X] Tests for the changes have been added
- [X] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

🔗 [Jira Ticket M2-9648](https://mindlogger.atlassian.net/browse/M2-9648)

This PR focuses on enabling users to conditionally export the user journey reports. This is done via a simple checkbox within the export modal.

Also, improved context was added for export modal (activity, flow or applet name)

### 📸 Screenshots

https://github.com/user-attachments/assets/ab2b1efc-ac9f-4d59-ba31-08692a8e70c4


### 🪤 Peer Testing

To test the main feature this PR targets, go to any activity, activity flow or applet and toggle the "User Journey Data". Those reports should be skipped from generation/download.
