### PR TITLE
fix: correcting off by one error on image dimension upload validation (M2-9676)

### DIFF
--- a/src/shared/components/Uploader/Uploader.tsx
+++ b/src/shared/components/Uploader/Uploader.tsx
@@ -80,10 +80,10 @@ export const Uploader = ({
         img.onload = () => {
           const { width, height } = img;
           resolve(
-            width > MIN_IMAGE_WIDTH &&
-              width < MAX_IMAGE_WIDTH &&
-              height > MIN_IMAGE_HEIGHT &&
-              height < MAX_IMAGE_HEIGHT,
+            width >= MIN_IMAGE_WIDTH &&
+              width <= MAX_IMAGE_WIDTH &&
+              height >= MIN_IMAGE_HEIGHT &&
+              height <= MAX_IMAGE_HEIGHT,
           );
         };
         img.onerror = reject;


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-9676](https://mindlogger.atlassian.net/browse/M2-9676)

Drawing item example and background images were supposed to be limited to 100 to 1920 pixels, however they were actually limited to 101 to 1919 pixels because of the incorrect use of < > instead of <= >=. The error messages were correct.  


### 🪤 Peer Testing

Create a drawing item in an activity
Upload an example image that is 100x100 or 1920x1920.
This should succeed
99x99 or 1919x1919 should fail. 
