### PR TITLE
fix: applet save across network issue (M2-8966, M2-9851)

### DIFF
--- a/src/modules/Builder/features/SaveAndPublish/SaveAndPublish.hooks.ts
+++ b/src/modules/Builder/features/SaveAndPublish/SaveAndPublish.hooks.ts
@@ -321,6 +321,7 @@ export const useSaveAndPublishSetup = (): SaveAndPublishSetup => {
   const checkIfAppletBeingCreatedOrUpdatedRef = useRef(false);
   const { result: appletData } = applet.useAppletData() ?? {};
   const appletEncryption = appletData?.encryption;
+  const encryptionRef = useRef<Encryption | undefined>(appletEncryption);
   const setAppletPrivateKey = useAppletPrivateKeySetter();
   const removeAppletData = useRemoveAppletData();
   const handleLogout = useLogout();
@@ -491,7 +492,11 @@ export const useSaveAndPublishSetup = (): SaveAndPublishSetup => {
 
   const sendRequest = async (password?: string) => {
     const encryptionData: Encryption | undefined =
-      password && ownerId ? await getEncryptionToServer(password, ownerId) : appletEncryption;
+      password && ownerId
+        ? await getEncryptionToServer(password, ownerId)
+        : appletEncryption || encryptionRef.current;
+
+    encryptionRef.current = encryptionData;
 
     setPublishProcessPopupOpened(true);
     const appletData = getAppletData(encryptionData);


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to Curious [open source credit page](https://mindlogger.atlassian.net/wiki/spaces/MINDLOGGER1/pages/263127186/Admin+Panel+Applet+Builder+Library)
- [x] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-8966](https://mindlogger.atlassian.net/browse/M2-8966)
🔗 [Jira Ticket M2-9851](https://mindlogger.atlassian.net/browse/M2-9851)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

This PR fixes an issue where the `encryption` object was being lost during Save & Publish in case of a network error. The loss was due to relying solely on the `appletEncryption` value, which is not persisted after the first load.

Changes include:

- Introduced useRef to persist encryption across rerenders and retries:
  - `const encryptionRef = useRef<Encryption | undefined>();`
- Modified encryption selection logic to:
  - Prefer encryption from getEncryptionToServer() if password and ownerId are available
  - Fallback to previously cached appletEncryption or the value from encryptionRef
- Updated the ref after determining the final encryptionData
- Used getAppletData(encryptionData) consistently with the resolved encryption

### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| <!-- Paste before image/video here -->**Network error:**<img width="1498" height="695" alt="image" src="https://github.com/user-attachments/assets/c0a53ac9-5a8c-4cf5-8df0-b9e7aa2d6071" />**Save after Network error: (Status Code:422)**<img width="1500" height="617" alt="image" src="https://github.com/user-attachments/assets/a7f943dd-2077-41f6-a145-4818fde6e44f" /> | **Network error:**<img width="1501" height="578" alt="image" src="https://github.com/user-attachments/assets/f22b9273-dd50-493e-9564-13cc28a85900" />**Save after Network error: (Status Code:200)**<img width="1493" height="689" alt="image" src="https://github.com/user-attachments/assets/a6a5f30e-e38a-4c13-b32e-e274593299fa" /><!-- Paste after image/video here --> |

### 🪤 Peer Testing

<!-- If peer testing is not needed, then delete this section -->
<!-- Uncomment out any of the following as needed:           -->
<!-- **Requires `npm install`**     -->

<!--
Replace this with a series of test steps & expected outcomes.

Example test step:

- This is a test step.  Highlight actions **in bold**.

    **Expected outcome:** This is what to expect after the step
-->

- Login as a user with an applet .
- Go to Applet Builder, edit content and Save & Publish.
- While publishing, disconnect network temporarily to simulate an error.
- After error is handled, retry publishing .
  - **Expected outcome**: Applet publishes successfully without asking for password again, and encryption object is retained.

### ✏️ Notes

<!--
Replace this line with anything else you think may be relevant or related PRs

If there are no notes, then delete this section.
-->

- This approach ensures the encryption data remains available even when the UI re-renders or errors occur.
- This method is consistent with how encryption is handled in other flows like the duplication modal (DuplicatePopups.tsx).