### PR TITLE
fix: allow accented and other non-latin characters in our alphanumeric validation (m2-9655)

### DIFF
--- a/src/modules/Builder/pages/BuilderApplet/BuilderApplet.const.ts
+++ b/src/modules/Builder/pages/BuilderApplet/BuilderApplet.const.ts
@@ -64,7 +64,7 @@ export const ALLOWED_TYPES_IN_VARIABLES = [
 
 export const ordinalStrings = ['First', 'Second', 'Third', 'Fourth'];
 
-export const alphanumericAndHyphenRegexp = /^[a-zA-Z0-9_-]+$/g;
+export const alphanumericAndHyphenRegexp = /^[\p{L}0-9_-]+$/gu;
 
 export const enum ItemTestFunctions {
   UniqueItemName = 'unique-item-name',


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-9655](https://mindlogger.atlassian.net/browse/M2-9655)

Prior to this update, we only allowed characters a-z, A-Z, 0-9, _ and - in our alphanumeric validation that is used in in the admin. The only example I can find is the Item Name and "Section Name (within Scores & Reports) fields, though it's surprising it's not in other places.. This prohibited many words from many other languages from being entered into these fields.  
