### PR TITLE
fix: item type validation error clearing issue (M2-9809)

### DIFF
--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/GroupedSelectSearchController/GroupedSelectSearchController.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/GroupedSelectSearchController/GroupedSelectSearchController.tsx
@@ -11,6 +11,7 @@ import { ChangeEvent, MouseEvent, ReactNode, useState } from 'react';
 import { Controller, FieldValues } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
+import { useCustomFormContext } from 'modules/Builder/hooks';
 import { ItemResponseTypeNoPerfTasks } from 'modules/Builder/types';
 import { Chip, ChipShape, OptionalTooltipWrapper } from 'shared/components';
 import { Svg } from 'shared/components/Svg';
@@ -72,11 +73,13 @@ export const GroupedSelectSearchController = <T extends FieldValues>({
   options,
   setValue,
   fieldName,
-  onBeforeChange,
+  onBeforeChange: _onBeforeChange,
   checkIfSelectChangePopupIsVisible,
 }: GroupedSelectControllerProps<T>) => {
   const { t } = useTranslation('app');
   const { featureFlags } = useFeatureFlags();
+  const { clearErrors } = useCustomFormContext();
+
   const {
     getItemLanguageKey,
     getIsNotHaveSearchValue,
@@ -129,10 +132,11 @@ export const GroupedSelectSearchController = <T extends FieldValues>({
         control={control}
         render={({ field: { onChange, value }, fieldState: { error } }) => {
           const handleOnSelectChange = (event: SelectChangeEvent<unknown>, child: ReactNode) => {
-            const newValue = event.target.value as ItemResponseType;
-
-            if (onBeforeChange && !onBeforeChange(newValue)) {
-              return;
+            // Clear errors immediately if field has error and user is making a selection
+            if (error && clearErrors) {
+              setTimeout(() => {
+                clearErrors(name);
+              }, 200);
             }
 
             if (checkIfSelectChangePopupIsVisible) {


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-9809](https://mindlogger.atlassian.net/browse/M2-9809)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

This pull request addresses the issue where the Item Type validation error was not clearing when a valid selection was made. 

Changes include:

- Added `clearErrors` calls with a **150ms** delay in the `GroupedSelectSearchController` component to ensure proper error clearing for both popup and non-popup flows.

### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| <!-- Paste before image/video here --><img width="1371" height="604" alt="image" src="https://github.com/user-attachments/assets/a96105cf-0bd1-4f0f-ac06-7b9bf0827174" /> | <!-- Paste after image/video here --><img width="1386" height="620" alt="image" src="https://github.com/user-attachments/assets/944928e5-81e9-4b1a-bb9d-a3a220118159" />
 |

### 🪤 Peer Testing

<!-- If peer testing is not needed, then delete this section -->
<!-- Uncomment out any of the following as needed:           -->
<!-- **Requires `npm install`**     -->

<!--
Replace this with a series of test steps & expected outcomes.

Example test step:

- This is a test step.  Highlight actions **in bold**.

    **Expected outcome:** This is what to expect after the step
-->

- Navigate to the Item Configuration page.
- Select '`Save and Publish`'.
    - **Expected outcome**: The validation error appears.
- Select a valid Item Type.
    - **Expected outcome**: The validation error clears.

### ✏️ Notes

<!--
Replace this line with anything else you think may be relevant or related PRs

If there are no notes, then delete this section.
-->
- No new dependencies were added.
