### PR TITLE
Fix : alert validation not clearing when option is selected (M2-9814)

### DIFF
--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/Alerts/Alert/Alert.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/Alerts/Alert/Alert.tsx
@@ -13,6 +13,7 @@ import {
   theme,
   variables,
 } from 'shared/styles';
+import { SelectEvent } from 'shared/types';
 
 import { ItemConfigurationSettings } from '../../ItemConfiguration.types';
 import { StyledAlert, StyledDescription, StyledRow, StyledSelectController } from './Alert.styles';
@@ -26,6 +27,7 @@ export const Alert = ({ name, index, removeAlert }: AlertProps) => {
     getValues,
     watch,
     formState: { errors },
+    clearErrors,
   } = useCustomFormContext();
 
   const alertName = `${name}.alerts.${index}`;
@@ -68,6 +70,13 @@ export const Alert = ({ name, index, removeAlert }: AlertProps) => {
   };
   const sliderErrorText = getSliderErrorText();
 
+  // Generic handler to clear validation errors on selection
+  const handleClearFieldError = (fieldName: string) => (_event: SelectEvent) => {
+    if (clearErrors) {
+      clearErrors(fieldName);
+    }
+  };
+
   const renderAlertContent = () => {
     switch (responseType) {
       case ItemResponseType.SingleSelection:
@@ -82,6 +91,7 @@ export const Alert = ({ name, index, removeAlert }: AlertProps) => {
                 placeholder={t('option')}
                 options={getOptionsList(getValues(name) as ItemFormValues, alert)}
                 isErrorVisible={false}
+                customChange={handleClearFieldError(alertValueName)}
                 data-testid={`${dataTestid}-selection-option`}
               />,
             ]}
@@ -99,6 +109,7 @@ export const Alert = ({ name, index, removeAlert }: AlertProps) => {
                 placeholder={t('option')}
                 options={getOptionsList(getValues(name) as ItemFormValues, alert)}
                 isErrorVisible={false}
+                customChange={handleClearFieldError(optionName)}
                 data-testid={`${dataTestid}-selection-per-row-option`}
               />,
               <StyledSelectController
@@ -107,6 +118,7 @@ export const Alert = ({ name, index, removeAlert }: AlertProps) => {
                 placeholder={t('row')}
                 options={getItemsList(getValues(name) as ItemFormValues, alert)}
                 isErrorVisible={false}
+                customChange={handleClearFieldError(rowName)}
                 data-testid={`${dataTestid}-selection-per-row-row`}
               />,
             ]}
@@ -123,6 +135,7 @@ export const Alert = ({ name, index, removeAlert }: AlertProps) => {
                 placeholder={t('slider')}
                 options={getOptionsList(getValues(name) as ItemFormValues, alert)}
                 isErrorVisible={false}
+                customChange={handleClearFieldError(alertSliderIdName)}
                 data-testid={`${dataTestid}-slider-rows-row`}
               />,
               <StyledSelectController
@@ -131,6 +144,7 @@ export const Alert = ({ name, index, removeAlert }: AlertProps) => {
                 placeholder={t('option')}
                 options={getSliderRowsItemList(getValues(name), alert)}
                 isErrorVisible={false}
+                customChange={handleClearFieldError(alertValueName)}
                 data-testid={`${dataTestid}-slider-rows-value`}
               />,
             ]}


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-9814](https://mindlogger.atlassian.net/browse/M2-9814)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

**Fix: Alert validation errors not clearing when option is selected**

This PR resolves an issue where validation errors on alert form fields were not being automatically cleared when users selected valid options from dropdown menus.

Changes include:

- Added `clearErrors` functionality to Alert component
- Implemented generic error clearing handler for all SelectController components  
- Added `customChange` handlers to 5 dropdown fields (single/multiple selection options, selection per row options/rows, slider rows options/values)
- Imported required `SelectEvent` type for proper typing

### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| <!-- Paste before image/video here --><img width="1496" height="730" alt="Screenshot 2025-09-25 at 3 14 58 PM" src="https://github.com/user-attachments/assets/e61825bf-06e4-46dd-a563-9c66db03b602" /> | <!-- Paste after image/video here --> <img width="1462" height="714" alt="Screenshot 2025-09-25 at 3 18 01 PM" src="https://github.com/user-attachments/assets/7dca56f6-dafd-4629-bfce-c6d0bac72d2e" />|

### 🪤 Peer Testing

<!-- If peer testing is not needed, then delete this section -->
<!-- Uncomment out any of the following as needed:           -->
<!-- **Requires `npm install`**     -->

- Navigate to Activity Builder > Add/Edit Item > ScoresandAlerts > Add alerts
- Add an **Alert** to any item type that supports alerts 
- Leave the alert dropdown fields **empty** and try to save/validate the form
- **Expected outcome:** Validation errors should appear on empty required fields
- On selection
- **Expected outcome:** Validation errors should immediately disappear when valid selections are made

<!--
Replace this with a series of test steps & expected outcomes.

Example test step:

- This is a test step.  Highlight actions **in bold**.

    **Expected outcome:** This is what to expect after the step
-->

### ✏️ Notes

<!--
Replace this line with anything else you think may be relevant or related PRs

If there are no notes, then delete this section.
-->
- No breaking changes - only adds error clearing functionality