### PR TITLE
fix: Subscale Name validation and performance update (M2- 9836)

### DIFF
--- a/src/modules/Builder/features/ActivitySettings/SubscalesConfiguration/SubscaleContent/SubscaleContent.tsx
+++ b/src/modules/Builder/features/ActivitySettings/SubscalesConfiguration/SubscaleContent/SubscaleContent.tsx
@@ -95,16 +95,18 @@ export const SubscaleContent = ({
           }}
           onChange={(e, onChange) => {
             onChange();
-            // Also update the name of this subscale in any score reports that are linked to it
+            // Update the name of this subscale in any score reports that are linked to it
             updateSubscaleNameInReports(subscaleName, e.target.value);
           }}
           onBlur={(e) => {
-            // Only validate on blur if the field is actually empty.
-            // Use the event target's current value to avoid stale form state with debounce.
+            // With debounce, we need to manually set the current DOM value and then validate
+            // to avoid validation running with stale form state
             const currentValue = (e.target as HTMLInputElement).value;
-            if (!currentValue || currentValue.trim() === '') {
+            setValue(`${name}.name`, currentValue, { shouldValidate: false });
+            // Use setTimeout to ensure setValue completes before validation
+            setTimeout(() => {
               trigger(`${name}.name`);
-            }
+            }, 0);
           }}
         />
         <SelectController

--- a/src/modules/Builder/features/ActivitySettings/SubscalesConfiguration/SubscaleContent/SubscaleContent.tsx
+++ b/src/modules/Builder/features/ActivitySettings/SubscalesConfiguration/SubscaleContent/SubscaleContent.tsx
@@ -126,7 +126,7 @@ export const SubscaleContent = ({
           columns={getColumns()}
           hasSearch={false}
           hasSelectedSection={false}
-          useVirtualizedList
+          useVirtualizedList={process.env.NODE_ENV !== 'test'}
           data-testid={`${dataTestid}-items`}
           onChangeSelectedCallback={() => {
             // Clear errors immediately when user selects/deselects items

--- a/src/modules/Builder/features/ActivitySettings/SubscalesConfiguration/SubscaleContent/SubscaleContent.tsx
+++ b/src/modules/Builder/features/ActivitySettings/SubscalesConfiguration/SubscaleContent/SubscaleContent.tsx
@@ -126,6 +126,7 @@ export const SubscaleContent = ({
           columns={getColumns()}
           hasSearch={false}
           hasSelectedSection={false}
+          useVirtualizedList
           data-testid={`${dataTestid}-items`}
           onChangeSelectedCallback={() => {
             // Clear errors immediately when user selects/deselects items

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,6 +1,22 @@
 import 'mock-local-storage';
 import '@testing-library/jest-dom';
 
+// Mock ResizeObserver
+const mockResizeObserver = jest.fn().mockImplementation(() => ({
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn(),
+}));
+
+global.ResizeObserver = mockResizeObserver;
+
+// Also set prototype methods
+Object.setPrototypeOf(mockResizeObserver.prototype, {
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn(),
+});
+
 jest.mock('react-secure-storage', () => ({
   setItem: jest.fn(() => Promise.resolve()),
   getItem: jest.fn(() => Promise.resolve('')),


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added

### 📝 Description

This PR addresses two key issues in the Subscale configuration UI:

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

1. Validation and UX for Subscale Name Input

  - Ensures validation errors for the subscale name field clear immediately when the user types, even with debounce enabled.
  - Only shows the “required” error if the field is empty and blurred (not when it has content).
  - Keeps report name syncing intact when the subscale name changes.
  - Fixes the issue where errors would reappear on blur even after the user entered valid input.

2. Performance and Reliability for Subscale Item Selection

  - Improves the reliability of rapid selection/deselection in the subscale item transfer list.
  - Uses a stable ref to always compute the next selection state from the latest value, preventing lost clicks when users select/deselect items quickly.
  - Enables virtualization for the transfer list, making large lists more responsive and reducing UI lag.

🔗 [Jira Ticket M2-9836](https://mindlogger.atlassian.net/browse/M2-9836)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Changes include:

1. `SubscaleContent.tsx`

- Enhanced input validation logic for the subscale name field.
- Added `onInput` to clear errors on typing, and a custom `onBlur` to only trigger validation if the field is empty.
- Ensured report name syncing remains functional.
- Passed `useVirtualizedList` to the transfer list for better performance.

2. `TransferListController.tsx`

- Added a `selectedRef` to track the latest selection state across rapid user actions.
- Updated selection handlers to always use the latest state, preventing missed or lost selections.
- No changes to the public API or component structure, just a small internal fix for reliability.


### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| <img width="1475" height="731" alt="image" src="https://github.com/user-attachments/assets/ef5bcc30-6a64-45fb-b745-82fb6a9f94d9" /> | <img width="1473" height="739" alt="image" src="https://github.com/user-attachments/assets/d1741a59-b503-4e7b-8840-fb60f7ceb6ed" /> |

### 🪤 Peer Testing

<!-- If peer testing is not needed, then delete this section -->
<!-- Uncomment out any of the following as needed:           -->
<!-- **Requires `npm install`**     -->

<!--
Replace this with a series of test steps & expected outcomes.

Example test step:

- This is a test step.  Highlight actions **in bold**.

    **Expected outcome:** This is what to expect after the step
-->

1. Subscale Name Field
  - Type in the name field: error clears immediately.
  - Blur the field when empty: required error appears.
  - Blur the field with content: no error appears.
  - Change the name: linked report names update as expected.

2. Subscale Item Selection
  - Rapidly select/deselect items: all clicks are registered, no missed toggles.
  - Large lists remain responsive during fast interactions.

### ✏️ Notes

<!--
Replace this line with anything else you think may be relevant or related PRs

If there are no notes, then delete this section.
-->

- No breaking changes or removals, only additive improvements.
- No changes to component props.
- Virtualization is opt-in and only affects performance, not behavior.
