### PR TITLE
fix: Scores and report fixes (M2-9830, M2-9832, M2-9833, M2-9834, M2-9835, M2-9712)

### DIFF
--- a/src/modules/Builder/components/ConditionRow/Condition/SwitchCondition/SingleOrRangeNumberCondition/SingleOrRangeNumberCondition.tsx
+++ b/src/modules/Builder/components/ConditionRow/Condition/SwitchCondition/SingleOrRangeNumberCondition/SingleOrRangeNumberCondition.tsx
@@ -1,4 +1,4 @@
-import { useWatch } from 'react-hook-form';
+import { useWatch, useFormContext } from 'react-hook-form';
 
 import { useCustomFormContext } from 'modules/Builder/hooks';
 
@@ -24,6 +24,7 @@ export const SingleOrRangeNumberCondition = ({
   dataTestid,
 }: SingleOrRangeNumberConditionProps) => {
   const { control } = useCustomFormContext();
+  const { clearErrors, trigger } = useFormContext();
   const rowIndex = useWatch({ name: rowIndexName });
 
   const { minNumber, maxNumber } = getConditionMinMaxValues({
@@ -48,6 +49,14 @@ export const SingleOrRangeNumberCondition = ({
           name={numberValueName}
           minNumberValue={minNumber}
           maxNumberValue={maxNumber}
+          onInput={() => {
+            // Clear errors immediately when user starts typing
+            clearErrors(numberValueName);
+          }}
+          onBlur={() => {
+            // Trigger validation on blur for performance
+            setTimeout(() => trigger(numberValueName), 100);
+          }}
           data-testid={`${dataTestid}-slider-value`}
         />
       )}
@@ -60,6 +69,14 @@ export const SingleOrRangeNumberCondition = ({
             name={minValueName}
             minNumberValue={leftRange.minNumber}
             maxNumberValue={leftRange.maxNumber}
+            onInput={() => {
+              // Clear errors immediately when user starts typing
+              clearErrors(minValueName);
+            }}
+            onBlur={() => {
+              // Trigger validation on blur for performance
+              setTimeout(() => trigger(minValueName), 100);
+            }}
             data-testid={`${dataTestid}-min-value`}
           />
           <StyledInputController
@@ -69,6 +86,14 @@ export const SingleOrRangeNumberCondition = ({
             name={maxValueName}
             minNumberValue={rightRange.minNumber}
             maxNumberValue={rightRange.maxNumber}
+            onInput={() => {
+              // Clear errors immediately when user starts typing
+              clearErrors(maxValueName);
+            }}
+            onBlur={() => {
+              // Trigger validation on blur for performance
+              setTimeout(() => trigger(maxValueName), 100);
+            }}
             data-testid={`${dataTestid}-max-value`}
           />
         </>

--- a/src/modules/Builder/components/ConditionRow/Condition/SwitchCondition/SingleOrRangeNumberCondition/SingleOrRangeNumberCondition.tsx
+++ b/src/modules/Builder/components/ConditionRow/Condition/SwitchCondition/SingleOrRangeNumberCondition/SingleOrRangeNumberCondition.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import { useWatch, useFormContext } from 'react-hook-form';
 
 import { useCustomFormContext } from 'modules/Builder/hooks';
@@ -23,9 +24,31 @@ export const SingleOrRangeNumberCondition = ({
   isRangeValueShown,
   dataTestid,
 }: SingleOrRangeNumberConditionProps) => {
-  const { control } = useCustomFormContext();
+  const { control, setValue, getValues } = useCustomFormContext();
   const { clearErrors, trigger } = useFormContext();
   const rowIndex = useWatch({ name: rowIndexName });
+
+  // Local state for instant typing feedback
+  const [localValues, setLocalValues] = useState(() => ({
+    number: String(getValues(numberValueName) ?? ''),
+    min: String(getValues(minValueName) ?? ''),
+    max: String(getValues(maxValueName) ?? ''),
+  }));
+
+  // Sync local state when form values change externally
+  const formValues = {
+    number: useWatch({ name: numberValueName, control }),
+    min: useWatch({ name: minValueName, control }),
+    max: useWatch({ name: maxValueName, control }),
+  };
+
+  useEffect(() => {
+    setLocalValues({
+      number: String(formValues.number ?? ''),
+      min: String(formValues.min ?? ''),
+      max: String(formValues.max ?? ''),
+    });
+  }, [formValues.number, formValues.min, formValues.max]);
 
   const { minNumber, maxNumber } = getConditionMinMaxValues({
     item: selectedItem,
@@ -49,12 +72,14 @@ export const SingleOrRangeNumberCondition = ({
           name={numberValueName}
           minNumberValue={minNumber}
           maxNumberValue={maxNumber}
-          onInput={() => {
-            // Clear errors immediately when user starts typing
+          value={localValues.number}
+          onChange={(e) => {
+            setLocalValues((prev) => ({ ...prev, number: e.target.value }));
             clearErrors(numberValueName);
           }}
-          onBlur={() => {
-            // Trigger validation on blur for performance
+          onBlur={(e) => {
+            const value = e.target.value;
+            setValue(numberValueName, value === '' ? '' : Number(value));
             setTimeout(() => trigger(numberValueName), 100);
           }}
           data-testid={`${dataTestid}-slider-value`}
@@ -69,12 +94,14 @@ export const SingleOrRangeNumberCondition = ({
             name={minValueName}
             minNumberValue={leftRange.minNumber}
             maxNumberValue={leftRange.maxNumber}
-            onInput={() => {
-              // Clear errors immediately when user starts typing
+            value={localValues.min}
+            onChange={(e) => {
+              setLocalValues((prev) => ({ ...prev, min: e.target.value }));
               clearErrors(minValueName);
             }}
-            onBlur={() => {
-              // Trigger validation on blur for performance
+            onBlur={(e) => {
+              const value = e.target.value;
+              setValue(minValueName, value === '' ? '' : Number(value));
               setTimeout(() => trigger(minValueName), 100);
             }}
             data-testid={`${dataTestid}-min-value`}
@@ -86,12 +113,14 @@ export const SingleOrRangeNumberCondition = ({
             name={maxValueName}
             minNumberValue={rightRange.minNumber}
             maxNumberValue={rightRange.maxNumber}
-            onInput={() => {
-              // Clear errors immediately when user starts typing
+            value={localValues.max}
+            onChange={(e) => {
+              setLocalValues((prev) => ({ ...prev, max: e.target.value }));
               clearErrors(maxValueName);
             }}
-            onBlur={() => {
-              // Trigger validation on blur for performance
+            onBlur={(e) => {
+              const value = e.target.value;
+              setValue(maxValueName, value === '' ? '' : Number(value));
               setTimeout(() => trigger(maxValueName), 100);
             }}
             data-testid={`${dataTestid}-max-value`}

--- a/src/modules/Builder/components/ConditionRow/Condition/SwitchCondition/SingleOrRangeNumberCondition/SingleOrRangeNumberCondition.tsx
+++ b/src/modules/Builder/components/ConditionRow/Condition/SwitchCondition/SingleOrRangeNumberCondition/SingleOrRangeNumberCondition.tsx
@@ -74,8 +74,15 @@ export const SingleOrRangeNumberCondition = ({
           maxNumberValue={maxNumber}
           value={localValues.number}
           onChange={(e) => {
-            setLocalValues((prev) => ({ ...prev, number: e.target.value }));
-            clearErrors(numberValueName);
+            const value = e.target.value;
+            setLocalValues((prev) => ({ ...prev, number: value }));
+            if (value === '') {
+              // Trigger validation immediately when content is cleared
+              setValue(numberValueName, '');
+              setTimeout(() => trigger(numberValueName), 0);
+            } else {
+              clearErrors(numberValueName);
+            }
           }}
           onBlur={(e) => {
             const value = e.target.value;
@@ -96,8 +103,15 @@ export const SingleOrRangeNumberCondition = ({
             maxNumberValue={leftRange.maxNumber}
             value={localValues.min}
             onChange={(e) => {
-              setLocalValues((prev) => ({ ...prev, min: e.target.value }));
-              clearErrors(minValueName);
+              const value = e.target.value;
+              setLocalValues((prev) => ({ ...prev, min: value }));
+              if (value === '') {
+                // Trigger validation immediately when content is cleared
+                setValue(minValueName, '');
+                setTimeout(() => trigger(minValueName), 0);
+              } else {
+                clearErrors(minValueName);
+              }
             }}
             onBlur={(e) => {
               const value = e.target.value;
@@ -115,8 +129,15 @@ export const SingleOrRangeNumberCondition = ({
             maxNumberValue={rightRange.maxNumber}
             value={localValues.max}
             onChange={(e) => {
-              setLocalValues((prev) => ({ ...prev, max: e.target.value }));
-              clearErrors(maxValueName);
+              const value = e.target.value;
+              setLocalValues((prev) => ({ ...prev, max: value }));
+              if (value === '') {
+                // Trigger validation immediately when content is cleared
+                setValue(maxValueName, '');
+                setTimeout(() => trigger(maxValueName), 0);
+              } else {
+                clearErrors(maxValueName);
+              }
             }}
             onBlur={(e) => {
               const value = e.target.value;

--- a/src/modules/Builder/features/ActivitySettings/ScoresAndReports/ConditionContent/ConditionContent.tsx
+++ b/src/modules/Builder/features/ActivitySettings/ScoresAndReports/ConditionContent/ConditionContent.tsx
@@ -1,4 +1,4 @@
-import { useFieldArray } from 'react-hook-form';
+import { useFieldArray, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
 import { ConditionRow, ConditionRowOld } from 'modules/Builder/components';
@@ -34,6 +34,7 @@ export const ConditionContent = ({
   const conditionsName = `${name}.conditions`;
   const { featureFlags } = useFeatureFlags();
   const { control, getFieldState, setValue } = useCustomFormContext();
+  const { trigger } = useFormContext();
   const { fieldName } = useCurrentActivity();
   const {
     fields: conditions,
@@ -70,10 +71,16 @@ export const ConditionContent = ({
         maxValue: +(maxValue ?? scoreRange?.maxScore ?? DEFAULT_PAYLOAD_MAX_VALUE).toFixed(2),
       };
 
-      return setValue(conditionPayloadName, payload);
+      setValue(conditionPayloadName, payload);
+      // Trigger validation on conditions array to clear "at least one condition" error
+      setTimeout(() => trigger(conditionsName), 100);
+
+      return;
     }
 
     setValue(conditionPayloadName, getPayload({ conditionType, conditionPayload, selectedItem }));
+    // Trigger validation on conditions array to clear "at least one condition" error
+    setTimeout(() => trigger(conditionsName), 100);
   };
 
   return (

--- a/src/modules/Builder/features/ActivitySettings/ScoresAndReports/ScoreContent/ScoreCondition/ScoreCondition.tsx
+++ b/src/modules/Builder/features/ActivitySettings/ScoresAndReports/ScoreContent/ScoreCondition/ScoreCondition.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Box } from '@mui/material';
+import { useFormContext } from 'react-hook-form';
 
 import { useCheckAndTriggerOnNameUniqueness, useCustomFormContext } from 'modules/Builder/hooks';
 import {
@@ -41,6 +42,7 @@ export const ScoreCondition = ({
 }: ScoreConditionProps) => {
   const { t } = useTranslation();
   const { control, setValue, watch, getValues } = useCustomFormContext();
+  const { trigger, clearErrors, getFieldState } = useFormContext();
   const conditionName = watch(`${name}.name`);
   const conditionId = watch(`${name}.id`);
   const targetSelector = `report-${scoreKey}`;
@@ -111,7 +113,21 @@ export const ScoreCondition = ({
               key={`${name}.name`}
               name={`${name}.name`}
               label={t('scoreConditionName')}
-              onBlur={handleConditionNameBlur}
+              onInput={() => {
+                // Clear errors immediately when user starts typing
+                if (getFieldState(`${name}.name`).error) clearErrors(`${name}.name`);
+              }}
+              onBlur={(e) => {
+                // With debounce, manually set current DOM value before custom blur handler
+                const currentValue = (e.target as HTMLInputElement).value;
+                setValue(`${name}.name`, currentValue, { shouldValidate: false });
+                setTimeout(() => {
+                  // Trigger validation first to show errors immediately
+                  trigger(`${name}.name`);
+                  // Then run custom blur logic
+                  handleConditionNameBlur();
+                }, 0);
+              }}
               data-testid={`${dataTestid}-name`}
               withDebounce
             />

--- a/src/modules/Builder/features/ActivitySettings/ScoresAndReports/ScoreContent/ScoreContent.tsx
+++ b/src/modules/Builder/features/ActivitySettings/ScoresAndReports/ScoreContent/ScoreContent.tsx
@@ -82,7 +82,7 @@ export const ScoreContent = ({
   const navigate = useNavigate();
   const { appletId, activityId } = useParams();
   const { control, setValue, getValues } = useCustomFormContext();
-  const { clearErrors, trigger } = useFormContext();
+  const { clearErrors, trigger, getFieldState } = useFormContext();
   const [isChangeScoreIdPopupVisible, setIsChangeScoreIdPopupVisible] = useState(false);
   const [isRemoveConditionalPopupVisible, setIsRemoveConditionalPopupVisible] = useState(false);
   const [removeConditionalIndex, setIsRemoveConditionalIndex] = useState(0);
@@ -438,7 +438,21 @@ export const ScoreContent = ({
                 key={scoreNameField}
                 name={scoreNameField}
                 label={t('scoreName')}
-                onBlur={handleNameBlur}
+                onInput={() => {
+                  // Clear errors immediately when user starts typing
+                  if (getFieldState(scoreNameField).error) clearErrors(scoreNameField);
+                }}
+                onBlur={(e) => {
+                  // With debounce, manually set current DOM value before custom blur handler
+                  const currentValue = (e.target as HTMLInputElement).value;
+                  setValue(scoreNameField, currentValue, { shouldValidate: false });
+                  setTimeout(() => {
+                    // Trigger validation first to show errors immediately
+                    trigger(scoreNameField);
+                    // Then run custom blur logic
+                    handleNameBlur();
+                  }, 0);
+                }}
                 sx={{ mb: theme.spacing(4.8) }}
                 data-testid={`${dataTestid}-name`}
                 withDebounce

--- a/src/modules/Builder/features/ActivitySettings/ScoresAndReports/ScoreContent/ScoreContent.tsx
+++ b/src/modules/Builder/features/ActivitySettings/ScoresAndReports/ScoreContent/ScoreContent.tsx
@@ -260,6 +260,8 @@ export const ScoreContent = ({
 
       if (!newLinkedSubscale) return;
 
+      // Clear validation error when subscale is selected
+      clearErrors(subscaleNameField);
       setValue(subscaleNameField, subscaleName);
 
       if (scoringType === 'score') {
@@ -284,6 +286,7 @@ export const ScoreContent = ({
       scoringType,
       setValue,
       eligibleSubscales,
+      clearErrors,
     ],
   );
 

--- a/src/modules/Builder/features/ActivitySettings/ScoresAndReports/SectionContent/SectionContent.tsx
+++ b/src/modules/Builder/features/ActivitySettings/ScoresAndReports/SectionContent/SectionContent.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useWatch } from 'react-hook-form';
+import { useWatch, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { Box } from '@mui/material';
 
@@ -39,6 +39,7 @@ export const SectionContent = ({
 }: SectionContentProps) => {
   const { t } = useTranslation('app');
   const { control, setValue } = useCustomFormContext();
+  const { trigger, clearErrors, getFieldState } = useFormContext();
   const conditionalLogicName = `${name}.conditionalLogic`;
   const conditionalLogic = useWatch({ name: conditionalLogicName });
   const [isRemoveConditionalPopupVisible, setIsRemoveConditionalPopupVisible] = useState(false);
@@ -83,6 +84,20 @@ export const SectionContent = ({
             label={t('sectionName')}
             data-testid={`${dataTestid}-name`}
             withDebounce
+            onInput={() => {
+              // Clear errors immediately when user starts typing
+              if (getFieldState(`${name}.name`).error) clearErrors(`${name}.name`);
+            }}
+            onBlur={(e) => {
+              // With debounce, manually set current DOM value and trigger validation
+              // This ensures validation sees the actual typed value
+              const currentValue = (e.target as HTMLInputElement).value;
+              setValue(`${name}.name`, currentValue, { shouldValidate: false });
+              // Wait for setValue to complete, then trigger validation
+              setTimeout(() => {
+                trigger(`${name}.name`);
+              }, 0);
+            }}
           />
           <Box sx={{ mt: theme.spacing(2.4) }}>
             {conditionalLogic ? (


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to Curious [open source credit page](https://mindlogger.atlassian.net/wiki/spaces/MINDLOGGER1/pages/263127186/Admin+Panel+Applet+Builder+Library)
- [x] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

This PR addresses multiple issues in the Activity Settings > Scores & Reports section, focusing on improving validation logic, error handling, and input responsiveness.

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-9830](https://mindlogger.atlassian.net/browse/M2-9830)
🔗 [Jira Ticket M2-9832](https://mindlogger.atlassian.net/browse/M2-9832)
🔗 [Jira Ticket M2-9833](https://mindlogger.atlassian.net/browse/M2-9833)
🔗 [Jira Ticket M2-9834](https://mindlogger.atlassian.net/browse/M2-9834)
🔗 [Jira Ticket M2-9835](https://mindlogger.atlassian.net/browse/M2-9835)
🔗 [Jira Ticket M2-9712](https://mindlogger.atlassian.net/browse/M2-9712)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Changes include:

1. **M2-9830: Fixed Validation for Debounced Name Fields**

- Enhanced validation behavior for score condition name, score name, and section name fields with debounce
- Added onInput handler to clear errors immediately when user starts typing
- Modified onBlur to manually set current DOM value via setValue before validation
- Ensures validation sees the actual typed value (not the debounced value) when blur occurs
- Improved UX by triggering validation before running custom blur logic using setTimeout
- Files modified: ScoreCondition.tsx, ScoreContent.tsx, SectionContent.tsx

2. **M2-9832: Fixed Condition Array Validation Clearing**

- Added validation trigger for conditions array after payload changes
- Ensures "at least one condition" error clears immediately when a condition is added/modified
- Integrated trigger(conditionsName) with 100ms timeout for proper validation timing
- File modified: ConditionContent.tsx

3. **M2-9833 & M2-9834: Enhanced Number Input Validation**

- Implemented immediate error clearing with onInput handler for all number condition inputs (single value, min, max)
- Added onBlur validation trigger with 100ms timeout for performance optimization
- Improved validation feedback for score condition number fields (range validation)
- Ensures errors clear instantly when user starts typing
- File modified: SingleOrRangeNumberCondition.tsx

4. **M2-9835: Fixed Subscale Selection Validation**

- Added clearErrors call when subscale is selected from dropdown
- Ensures validation error clears immediately when user selects a valid subscale
- Improved user feedback by removing stale error messages after valid selection
- File modified: ScoreContent.tsx

5. **M2-9712: Fixed Input Typing Delay (Critical UX Fix)**

- Resolved critical UX issue where typing numbers in score condition value fields had significant lag
- Implemented local state pattern with useState to provide instant visual feedback during typing
- Added lazy initialization using getValues to set initial local state values
- Used onChange to update local state instantly + clear errors (replaces onInput)
- Syncs to React Hook Form on onBlur using setValue + trigger for validation
- Added useWatch to monitor form value changes + useEffect to sync local state when form changes externally
- Consolidated logic into single useEffect for all three fields (number, min, max)
- Maintained React Hook Form integration while eliminating typing lag
- File modified: SingleOrRangeNumberCondition.tsx

### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| <!-- Paste before image/video here --> | **M2-9830**: <img width="873" height="166" alt="image" src="https://github.com/user-attachments/assets/1443c870-f184-4ad8-bce8-036cddd21ccc" /> |

### 🪤 Peer Testing

<!-- If peer testing is not needed, then delete this section -->
<!-- Uncomment out any of the following as needed:           -->
<!-- **Requires `npm install`**     -->

<!--
Replace this with a series of test steps & expected outcomes.

Example test step:

- This is a test step.  Highlight actions **in bold**.

    **Expected outcome:** This is what to expect after the step
-->

1. Test M2-9830 - Name Field Validation with Debounce:

- Go to Activity Settings > Scores & Reports
- Type quickly in any name field (Score Name, Condition Name, Section Name) and immediately blur
- Start typing again after error appears
- Expected: Error shows immediately on blur, clears immediately when typing

2. Test M2-9832 - Condition Validation:

- Create a score with Conditional Logic enabled (no conditions added)
- Add a condition
- Expected: "At least one condition required" error disappears immediately

3. Test M2-9833/9834 - Number Input Error Clearing:

- Add a score condition with range type
- Enter invalid range (e.g., min=100, max=50)
- Start typing a new value
- Expected: Error clears immediately when typing starts

4. Test M2-9835 - Subscale Selection:

- Create a score, clear the subscale field (error appears)
- Select a subscale from dropdown
- Expected: Error clears immediately upon selection

5. Test M2-9712 - Typing Delay Fix:

- Add a score condition
- Quickly type "999" in any number field
- Expected: All digits appear instantly with no lag

### ✏️ Notes

<!--
Replace this line with anything else you think may be relevant or related PRs

If there are no notes, then delete this section.
-->

- All changes focus on improving validation timing and user feedback for debounced inputs
- The typing delay fix (M2-9712) significantly improves UX without modifying core debounce settings
- Changes maintain backward compatibility and preserve existing validation logic
- Local state pattern in M2-9712 ensures instant typing feedback while maintaining RHF integration
- 