### PR TITLE
fix: applet & activity name validation (M2-9831)

### DIFF
--- a/src/modules/Builder/features/AboutApplet/AboutApplet.tsx
+++ b/src/modules/Builder/features/AboutApplet/AboutApplet.tsx
@@ -21,11 +21,27 @@ import { getColorThemeOptions } from './AboutApplet.utils';
 import { commonUploaderProps } from './AboutApplet.const';
 import { ThemeSelectController } from './ThemeSelectController';
 
+// Utility to handle displayName validation and error clearing
+const handleDisplayNameValidation = (
+  value: string,
+  applyChange: () => void,
+  trigger: (fieldName: string) => void,
+  clearErrors: (fieldName: string) => void,
+  fieldName: string,
+) => {
+  applyChange();
+  if (!value || value.trim() === '') {
+    setTimeout(() => trigger(fieldName), 0);
+  } else {
+    clearErrors(fieldName);
+  }
+};
+
 export const AboutApplet = () => {
   const { t } = useTranslation();
   const { result: themesList = [] } = themes.useThemesData() || {};
   const themesOptions = getColorThemeOptions(themesList);
-  const { control, setValue, watch } = useCustomFormContext();
+  const { control, setValue, watch, trigger, clearErrors } = useCustomFormContext();
 
   const commonInputProps = {
     control,
@@ -73,6 +89,15 @@ export const AboutApplet = () => {
               label={t('appletName')}
               restrictExceededValueLength
               data-testid="about-applet-display-name"
+              onChange={(e, applyChange) =>
+                handleDisplayNameValidation(
+                  e.target.value,
+                  applyChange,
+                  trigger,
+                  clearErrors,
+                  'displayName',
+                )
+              }
             />
           </Box>
           <Box sx={{ mb: theme.spacing(4.4) }}>

--- a/src/modules/Builder/features/ActivityAbout/ActivityAbout.tsx
+++ b/src/modules/Builder/features/ActivityAbout/ActivityAbout.tsx
@@ -43,13 +43,29 @@ import {
   useCheckIfItemsHaveVariables,
 } from './ActivityAbout.hooks';
 
+// Utility to handle activity name validation and error clearing
+const handleDisplayNameValidation = (
+  value: string,
+  applyChange: () => void,
+  trigger: (fieldName: string) => void,
+  clearErrors: (fieldName: string) => void,
+  fieldName: string,
+) => {
+  applyChange();
+  if (!value || value.trim() === '') {
+    setTimeout(() => trigger(fieldName), 0);
+  } else {
+    clearErrors(fieldName);
+  }
+};
+
 export const ActivityAbout = () => {
   const { t } = useTranslation();
   const { featureFlags } = useFeatureFlags();
 
   useRedirectIfNoMatchedActivity();
 
-  const { control, setValue } = useCustomFormContext();
+  const { control, setValue, trigger, clearErrors } = useCustomFormContext();
   const { fieldName, activity } = useCurrentActivity();
   const hasVariableAmongItems = useCheckIfItemsHaveVariables();
   const hasRequiredItems = useCheckIfItemsHaveRequiredItems();
@@ -209,6 +225,15 @@ export const ActivityAbout = () => {
               restrictExceededValueLength
               label={t('activityName')}
               data-testid="builder-activity-about-name"
+              onChange={(e, applyChange) =>
+                handleDisplayNameValidation(
+                  e.target.value,
+                  applyChange,
+                  trigger,
+                  clearErrors,
+                  `${fieldName}.name`,
+                )
+              }
             />
           </Box>
           <InputController


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to Curious [open source credit page](https://mindlogger.atlassian.net/wiki/spaces/MINDLOGGER1/pages/263127186/Admin+Panel+Applet+Builder+Library)
- [x] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

This PR fixes validation behavior for applet and activity name fields to ensure proper error handling and immediate error clearing.

🔗 [Jira Ticket M2-9831](https://mindlogger.atlassian.net/browse/M2-9831)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Changes include:

1. **Applet Name Validation Fix (`AboutApplet.tsx`)**

  - Added utility function handleDisplayNameValidation to manage applet name validation and error clearing
  - Implemented onChange handler for applet display name field that:
  - Triggers validation immediately when name is empty or contains only whitespace
  - Clears errors automatically when valid text is entered
  - Integrated trigger and clearErrors from React Hook Form
  - Improved user feedback by clearing stale errors as user types valid content

2. **Activity Name Validation Fix (`ActivityAbout.tsx`)**

  - Added utility function handleDisplayNameValidation to manage activity name validation and error clearing
  - Implemented onChange handler for activity name field that:
  - Triggers validation immediately when name is empty or contains only whitespace
  - Clears errors automatically when valid text is entered
  - Integrated trigger and clearErrors from React Hook Form
  - Improved user feedback by clearing stale errors as user types valid content

### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| <!-- Paste before image/video here --> | <!-- Paste after image/video here --> |

### 🪤 Peer Testing

<!-- If peer testing is not needed, then delete this section -->
<!-- Uncomment out any of the following as needed:           -->
<!-- **Requires `npm install`**     -->

<!--
Replace this with a series of test steps & expected outcomes.

Example test step:

- This is a test step.  Highlight actions **in bold**.

    **Expected outcome:** This is what to expect after the step
-->

1. **Test Applet Name Validation:**

- Go to Builder > About Applet
- Clear the Applet Name field (leave empty or enter only whitespace)
- Start typing a valid applet name
- Expected:
  -   Error appears when field is empty/whitespace only
  -   Error clears immediately when valid text is entered

2. **Test Activity Name Validation:**

- Go to Builder > Activity > About
- Clear the Activity Name field (leave empty or enter only whitespace)
- Start typing a valid activity name
- Expected:
  - Error appears when field is empty/whitespace only
  - Error clears immediately when valid text is entered


### ✏️ Notes

<!--
Replace this line with anything else you think may be relevant or related PRs

If there are no notes, then delete this section.
-->

- This fix ensures applet and activity name validation behaves consistently with other form fields
- Empty or whitespace-only names properly trigger validation errors
- Valid text entry immediately clears any existing validation errors
- No changes to existing validation logic or rules
- Same validation pattern applied to both applet and activity name fields for consistency