### PR TITLE
fix: add waitFor to flaky RespondentDataReview test assertions

### DIFF
--- a/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.test.tsx
+++ b/src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.test.tsx
@@ -473,10 +473,12 @@ describe('RespondentDataReview', () => {
       ).toBeInTheDocument();
 
       // the activity list in the review menu child component is rendered correctly
-      const activityLength = screen.queryAllByTestId(
-        /respondents-review-menu-activity-\d+-select$/,
-      );
-      expect(activityLength).toHaveLength(1);
+      await waitFor(() => {
+        const activityLength = screen.queryAllByTestId(
+          /respondents-review-menu-activity-\d+-select$/,
+        );
+        expect(activityLength).toHaveLength(1);
+      });
 
       const activity = screen.getByTestId(`${dataTestid}-menu-activity-0-select`);
       await userEvent.click(activity);
@@ -694,7 +696,11 @@ describe('RespondentDataReview', () => {
       );
 
       // check that the Feedback Reviews tab is open
-      expect(screen.getByTestId('respondents-data-summary-feedback-reviewed')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('respondents-data-summary-feedback-reviewed'),
+        ).toBeInTheDocument();
+      });
     },
     JEST_TEST_TIMEOUT,
   );


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to Curious [open source credit page](https://mindlogger.atlassian.net/wiki/spaces/MINDLOGGER1/pages/263127186/Admin+Panel+Applet+Builder+Library)
- [ ] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-#](https://mindlogger.atlassian.net/browse/M2-#)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Changes include:

Fixing the race condition that's occurring in `src/modules/Dashboard/features/RespondentData/RespondentDataReview/RespondentDataReview.test.tsx`

