### PR TITLE
Disable RUM tracking resources

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,7 +12,6 @@ import './i18n';
 import reportWebVitals from './reportWebVitals';
 import { isUat, isProduction } from './shared/utils/env';
 
-
 if (import.meta.env.REACT_APP_DD_CLIENT_TOKEN) {
   datadogLogs.init({
     clientToken: import.meta.env.REACT_APP_DD_CLIENT_TOKEN as string,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import { asyncWithLDProvider } from 'launchdarkly-react-client-sdk';
 import { datadogRum, RumEvent } from '@datadog/browser-rum';
 import { datadogLogs } from '@datadog/browser-logs';
-import type { RumEventDomainContext } from '@datadog/browser-rum-core/src/domainContext.types';
 
 import { Mixpanel } from 'shared/utils/mixpanel';
 
@@ -49,7 +48,7 @@ if (
       (url) => url.indexOf('api-uat.cmiml.net') > -1,
       (url) => url.indexOf('api-v2.gettingcurious.com') > -1,
     ],
-    beforeSend: (event: RumEvent, context: RumEventDomainContext) => {
+    beforeSend: (event: RumEvent) => {
       // Do not instrument S3 calls, especially for exports.
       if (event.type === 'resource' && event.resource.url.indexOf('s3.amazonaws.com') > -1) {
         return false;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -41,7 +41,7 @@ if (
     sessionSampleRate: 100,
     sessionReplaySampleRate: 0,
     defaultPrivacyLevel: 'mask-user-input',
-    trackResources: true,
+    trackResources: false,
     trackLongTasks: true,
     trackUserInteractions: false,
     allowedTracingUrls: [

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { asyncWithLDProvider } from 'launchdarkly-react-client-sdk';
-import { datadogRum } from '@datadog/browser-rum';
+import {datadogRum, RumEvent} from '@datadog/browser-rum';
 import { datadogLogs } from '@datadog/browser-logs';
 
 import { Mixpanel } from 'shared/utils/mixpanel';
@@ -10,6 +10,7 @@ import App from './App';
 import './i18n';
 import reportWebVitals from './reportWebVitals';
 import { isUat, isProduction } from './shared/utils/env';
+import type {RumEventDomainContext} from "@datadog/browser-rum-core/src/domainContext.types";
 
 if (import.meta.env.REACT_APP_DD_CLIENT_TOKEN) {
   datadogLogs.init({
@@ -41,13 +42,21 @@ if (
     sessionSampleRate: 100,
     sessionReplaySampleRate: 0,
     defaultPrivacyLevel: 'mask-user-input',
-    trackResources: false,
+    trackResources: true,
     trackLongTasks: true,
     trackUserInteractions: false,
     allowedTracingUrls: [
       (url) => url.indexOf('api-uat.cmiml.net') > -1,
       (url) => url.indexOf('api-v2.gettingcurious.com') > -1,
     ],
+    beforeSend: (event: RumEvent, context: RumEventDomainContext) => {
+      // Do not instrument S3 calls, especially for exports.
+      if (event.type === 'resource' && event.resource.url.indexOf('s3.amazonaws.com') > -1) {
+        return false;
+      }
+
+      return true;
+    },
   });
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { asyncWithLDProvider } from 'launchdarkly-react-client-sdk';
-import {datadogRum, RumEvent} from '@datadog/browser-rum';
+import { datadogRum, RumEvent } from '@datadog/browser-rum';
 import { datadogLogs } from '@datadog/browser-logs';
+import type { RumEventDomainContext } from '@datadog/browser-rum-core/src/domainContext.types';
 
 import { Mixpanel } from 'shared/utils/mixpanel';
 
@@ -10,7 +11,7 @@ import App from './App';
 import './i18n';
 import reportWebVitals from './reportWebVitals';
 import { isUat, isProduction } from './shared/utils/env';
-import type {RumEventDomainContext} from "@datadog/browser-rum-core/src/domainContext.types";
+
 
 if (import.meta.env.REACT_APP_DD_CLIENT_TOKEN) {
   datadogLogs.init({


### PR DESCRIPTION


### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-9993](https://mindlogger.atlassian.net/browse/M2-9993)

A RUM tracking request was made for every file during an export.  This is excessive and impaired the export progress.

Changes include:

- Disabling tracking resources on S3