### PR TITLE
Fix: Activity Flow name and description disappearing after Save & Publish (M2-10002)

### DIFF
--- a/src/modules/Builder/features/SaveAndPublish/SaveAndPublish.hooks.ts
+++ b/src/modules/Builder/features/SaveAndPublish/SaveAndPublish.hooks.ts
@@ -43,6 +43,7 @@ import { ErrorResponseType, LocationState, LocationStateKeys } from 'shared/type
 import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 import { AppletPasswordRefType } from 'modules/Dashboard/features/Applet/Popups';
 import { apiSlice } from 'shared/api/apiSlice';
+import { getDefaultValues } from 'modules/Builder/pages/BuilderApplet/BuilderApplet.utils';
 
 import {
   getActivityItems,
@@ -275,8 +276,14 @@ export const useUpdatedAppletNavigate = () => {
         itemId,
       });
       const url = getUpdatedAppletUrl(appletId, newActivityOrFlowId, newItemId, location.pathname);
+
+      // Convert the new applet data to form values
+      const formValues = getDefaultValues(newApplet);
+
       await navigate(url);
-      reset(undefined, { keepDirty: false });
+
+      // Reset with the actual new data instead of undefined
+      reset(formValues, { keepDirty: false });
     }
   };
 };


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to Curious [open source credit page](https://mindlogger.atlassian.net/wiki/spaces/MINDLOGGER1/pages/263127186/Admin+Panel+Applet+Builder+Library)
- [x] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-10002](https://mindlogger.atlassian.net/browse/M2-10002)

Fixed a bug where Activity Flow name and description fields would clear after clicking "Save & Publish" on newly created Activity Flows. The data was successfully saved to the backend, but the form UI displayed empty fields.

**Root Cause:** The `useUpdatedAppletNavigate` hook was resetting the form with `undefined` instead of the actual applet data after navigation.

**Solution:** Convert the fetched applet data using `getDefaultValues()` utility before resetting the form, ensuring the form is properly populated with the backend data.

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Changes include:

- Modified `useUpdatedAppletNavigate` hook in `SaveAndPublish.hooks.ts`
- Added conversion of fetched applet data to form values before form reset
- Existing tests continue to pass (all 3730 tests)


### 🪤 Peer Testing

1. **Create a new Applet** and add an Activity with at least one item
2. **Navigate to Activity Flows** and click "Add Flow"
3. **Enter a name and description** for the Activity Flow (e.g., "Test Flow" and "Test Description")
4. **Add the activity** to the flow
5. **Click "Save & Publish"** button

   **Expected outcome:** After publishing, the Activity Flow name "Test Flow" and description "Test Description" should remain visible in the form fields (not disappear)


### ✏️ Notes

<!--
Replace this line with anything else you think may be relevant or related PRs

If there are no notes, then delete this section.
-->
- The issue only affected newly created Activity Flows on their first save (when ID changes from UUID to database ID)