### PR TITLE
perf: Replace JSZip with fflate for export speedup (M2-9993)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "dompurify": "^3.3.0",
         "dotenv": "^16.5.0",
         "downloadjs": "^1.4.7",
+        "fflate": "^0.8.2",
         "file-saver": "^2.0.5",
         "history": "^5.3.0",
         "i18next": "^23.5.1",
@@ -8881,6 +8882,12 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -13851,6 +13858,7 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
       "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
       "dependencies": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
@@ -13862,6 +13870,7 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -13875,12 +13884,14 @@
     "node_modules/jszip/node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
     },
     "node_modules/jszip/node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -13977,6 +13988,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
       "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
       "dependencies": {
         "immediate": "~3.0.5"
       }
@@ -24366,6 +24378,11 @@
       "requires": {
         "bser": "2.1.1"
       }
+    },
+    "fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="
     },
     "file-entry-cache": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "dompurify": "^3.3.0",
     "dotenv": "^16.5.0",
     "downloadjs": "^1.4.7",
+    "fflate": "^0.8.2",
     "file-saver": "^2.0.5",
     "history": "^5.3.0",
     "i18next": "^23.5.1",

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/__tests__/ItemConfigurationSingleMultiSelect.test.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/__tests__/ItemConfigurationSingleMultiSelect.test.tsx
@@ -388,7 +388,7 @@ describe('ItemConfiguration: Single Selection & Multiple Selection', () => {
         screen.getByTestId('builder-activity-items-item-configuration-set-color-palette'),
       ).toBeVisible();
       expect(ref.current.getValues(`${mockedItemName}.responseValues.paletteName`)).toBeUndefined();
-    });
+    }, 10000);
 
     test('Is initialized correctly for item with paletteName', () => {
       renderWithAppletFormData({

--- a/src/shared/utils/exportData/exportCsvZip.ts
+++ b/src/shared/utils/exportData/exportCsvZip.ts
@@ -1,4 +1,5 @@
 import FileSaver from 'file-saver';
+import { zipSync, strToU8 } from 'fflate';
 
 import { ExportCsvData } from 'shared/types';
 
@@ -6,19 +7,18 @@ export const exportCsvZip = async (csvDataList: ExportCsvData[], reportName: str
   if (!csvDataList.length) return;
 
   try {
-    const JSZip = await import('jszip');
-    const zip = new JSZip.default();
-
+    // Convert CSV strings to Uint8Array for fflate
+    const zipData: Record<string, Uint8Array> = {};
     for (const csvData of csvDataList) {
-      zip.file(csvData.name, csvData.data);
+      zipData[csvData.name] = strToU8(csvData.data);
     }
 
-    const generatedZip = await zip.generateAsync({
-      type: 'blob',
-      compression: 'DEFLATE',
-    });
+    // Use fflate's zipSync for fast, synchronous zip generation
+    // level: 0 means no compression (STORE mode) for maximum speed
+    const zipped = zipSync(zipData, { level: 0 });
+    const blob = new Blob([new Uint8Array(zipped)], { type: 'application/zip' });
 
-    FileSaver.saveAs(generatedZip, reportName);
+    FileSaver.saveAs(blob, reportName);
   } catch (err) {
     console.warn(err);
   }

--- a/src/shared/utils/exportData/exportZip.ts
+++ b/src/shared/utils/exportData/exportZip.ts
@@ -1,21 +1,20 @@
-import { JSZipGeneratorOptions } from 'jszip';
 import FileSaver from 'file-saver';
-
-export const BLOB_ZIP_OPTIONS: JSZipGeneratorOptions<'blob'> = {
-  type: 'blob',
-  compression: 'DEFLATE',
-  compressionOptions: { level: 3 },
-};
+import { zipSync } from 'fflate';
 
 export const exportZip = async (data: { fileName: string; file: Blob }[], fileName: string) => {
   const dataArray = Array.isArray(data) ? data : [data];
 
-  const JSZip = await import('jszip');
-  const zip = new JSZip.default();
-  dataArray.forEach((data) => {
-    zip.file(data.fileName, data.file);
-  });
+  // Convert blobs to Uint8Array for fflate
+  const zipData: Record<string, Uint8Array> = {};
+  for (const item of dataArray) {
+    const arrayBuffer = await item.file.arrayBuffer();
+    zipData[item.fileName] = new Uint8Array(arrayBuffer);
+  }
 
-  const content = await zip.generateAsync(BLOB_ZIP_OPTIONS);
+  // Use fflate's zipSync for fast, synchronous zip generation
+  // level: 0 means no compression (STORE mode) for maximum speed
+  const zipped = zipSync(zipData, { level: 0 });
+  const content = new Blob([new Uint8Array(zipped)], { type: 'application/zip' });
+
   FileSaver.saveAs(content, fileName);
 };

--- a/src/shared/utils/logger.ts
+++ b/src/shared/utils/logger.ts
@@ -1,7 +1,8 @@
+import { zipSync, strToU8 } from 'fflate';
+
 import { getUploadFormData } from 'shared/utils/getUploadFormData';
 
 import { postLogFile } from '../api/api';
-import { BLOB_ZIP_OPTIONS } from './exportData/exportZip';
 import { SessionStorageKeys } from './storage';
 
 const DEVICE_ID = 'browser';
@@ -54,15 +55,14 @@ export const sendLogFile = async ({
     errorStack: error?.stack ?? '',
   };
   const logString = JSON.stringify(logObject, undefined, 4);
-  const file = new File([logString], `log_${time}.txt`, {
-    type: 'text/plain',
-    lastModified: time,
-  });
   const fileId = `${pathname.replace(/\//g, '_')}_${time}`;
-  const JSZip = await import('jszip');
-  const zip = new JSZip.default();
-  zip.file(`${fileId}.txt`, file);
-  const content = await zip.generateAsync(BLOB_ZIP_OPTIONS);
+
+  // Use fflate for fast zip generation
+  const zipData = {
+    [`${fileId}.txt`]: strToU8(logString),
+  };
+  const zipped = zipSync(zipData, { level: 0 });
+  const content = new Blob([new Uint8Array(zipped)], { type: 'application/zip' });
   const fileFormData = getUploadFormData(content);
 
   try {


### PR DESCRIPTION
### 📝 Description

Export operations (CSV, media files, logs) were taking 60+ seconds after Vite migration due to JSZip's poor polyfill performance. Replaced JSZip with fflate for speedup.

🔗 [Jira Ticket M2-9993](https://mindlogger.atlassian.net/browse/M2-9993)

**Root Cause:** JSZip's `generateAsync()` relies on Node.js streams that are slower when transformed by Vite's esbuild polyfills (stream-browserify).

**Solution:** fflate uses synchronous operations with zero Node.js dependencies, designed for modern bundlers.

Changes include:

- Added fflate ^0.8.2 (jszip kept for safe rollback)
- Replaced JSZip with fflate in `exportCsvZip.ts`, `exportZip.ts`, `logger.ts`
- Export times: 68s → 0.15s (trails), 68s → 2.8s (drawing with 828 files)

### 🪤 Peer Testing

**Test export functionality:**

1. Navigate to Dashboard and select any applet with response data
2. Click **Export** button for responses (drawing, trails, stability tracker, flanker)

   **Expected outcome:** Exports complete in under a minute (previously hung for 60+ seconds)

3. Export activity with media files (images/SVGs)

   **Expected outcome:** Media zip downloads quickly without hanging


### ✏️ Notes

- JSZip dependency kept in package.json for safe rollback after production verification
- Can be removed in future PR once confirmed stable
- No compression used (level: 0) for maximum speed - file sizes acceptable for browser downloads