### PR TITLE
fix: Rerender to trigger Google Translate when dropdown changes (M2-10076)

### DIFF
--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/GroupedSelectSearchController/GroupedSelectSearchController.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/GroupedSelectSearchController/GroupedSelectSearchController.tsx
@@ -167,7 +167,9 @@ export const GroupedSelectSearchController = <T extends FieldValues>({
                 labelId="input-type-label"
                 label={t('itemType')}
                 renderValue={() => (
+                  // HACK: Use key to rerender when value changes to avoid interference from Google Translate (M2-10076)
                   <SelectItemContent
+                    key={value}
                     icon={itemsTypeIcons[value]}
                     label={t(getItemLanguageKey(value))}
                     value={value}

--- a/src/modules/Dashboard/features/Applet/Schedule/CreateEventPopup/CreateEventPopup.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Schedule/CreateEventPopup/CreateEventPopup.test.tsx
@@ -1,6 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import axios from 'axios';
@@ -161,7 +161,12 @@ describe('CreateEventPopup', () => {
       expect(listbox).toBeInTheDocument();
       expect(listbox.querySelectorAll('li')).toHaveLength(2); // 2 mock activity
       await userEvent.click(listbox.querySelectorAll('li')[0]);
-      expect(activityInput).toHaveValue('96d889e2-2264-4e76-8c60-744600e770fe'); // selected the 1st activity
+      await waitFor(() => {
+        // wait for activity container to rerender
+        const selectedActivityContainer = screen.getByTestId(`${dataTestid}-form-activity`);
+        const selectedActivityInput = selectedActivityContainer.querySelector('input');
+        expect(selectedActivityInput).toHaveValue('96d889e2-2264-4e76-8c60-744600e770fe'); // selected the 1st activity
+      });
       await userEvent.click(saveButton);
 
       const removeEventsPopupDataTestid = `${dataTestid}-remove-all-scheduled-events-popup`;
@@ -243,7 +248,12 @@ describe('CreateEventPopup', () => {
       expect(listbox).toBeInTheDocument();
       expect(listbox.querySelectorAll('li')).toHaveLength(2); // 2 mock activity
       await userEvent.click(listbox.querySelectorAll('li')[1]); // selected the 2nd activity
-      expect(activityInput).toHaveValue('60f83cbf-8ffe-447b-af34-0e4cc5f8d3d0');
+      await waitFor(() => {
+        // wait for activity container to rerender
+        const selectedActivityContainer = screen.getByTestId(`${dataTestid}-form-activity`);
+        const selectedActivityInput = selectedActivityContainer.querySelector('input');
+        expect(selectedActivityInput).toHaveValue('60f83cbf-8ffe-447b-af34-0e4cc5f8d3d0');
+      });
       const saveButton = screen.getByTestId(`${dataTestid}-submit-button`);
       await userEvent.click(saveButton);
 

--- a/src/shared/components/FormComponents/SelectController/SelectController.tsx
+++ b/src/shared/components/FormComponents/SelectController/SelectController.tsx
@@ -187,11 +187,12 @@ export const SelectController = <T extends FieldValues>({
     selectedValue?: string,
     error?: FieldError,
   ) => {
-      // HACK: Rerender when selectedValue changes to avoid interference from Google Translate (M2-10076)
-      const [forceRerenderKey, setForceRerenderKey] = useState(1);
-      useEffect(() => setForceRerenderKey(-forceRerenderKey), [selectedValue]);
+    // HACK: Rerender when selectedValue changes to avoid interference from Google Translate (M2-10076)
+    const [forceRerenderKey, setForceRerenderKey] = useState(1);
+    useEffect(() => setForceRerenderKey(-forceRerenderKey), [selectedValue]);
 
-      return (<Box sx={{ position: 'relative', width: '100%', ...sx }} className={className || ''}>
+    return (
+      <Box sx={{ position: 'relative', width: '100%', ...sx }} className={className || ''}>
         {placeholder && !selectedValue && (
           <>
             <StyledPlaceholderMask>{placeholder}</StyledPlaceholderMask>
@@ -247,7 +248,7 @@ export const SelectController = <T extends FieldValues>({
         </Tooltip>
       </Box>
     );
-  }
+  };
 
   return (
     <>

--- a/src/shared/components/FormComponents/SelectController/SelectController.tsx
+++ b/src/shared/components/FormComponents/SelectController/SelectController.tsx
@@ -187,9 +187,11 @@ export const SelectController = <T extends FieldValues>({
     selectedValue?: string,
     error?: FieldError,
   ) => {
+    /* eslint-disable react-hooks/rules-of-hooks */
     // HACK: Rerender when selectedValue changes to avoid interference from Google Translate (M2-10076)
     const [forceRerenderKey, setForceRerenderKey] = useState(1);
     useEffect(() => setForceRerenderKey(-forceRerenderKey), [selectedValue]);
+    /* eslint-enable react-hooks/rules-of-hooks */
 
     return (
       <Box sx={{ position: 'relative', width: '100%', ...sx }} className={className || ''}>

--- a/src/shared/components/FormComponents/SelectController/SelectController.tsx
+++ b/src/shared/components/FormComponents/SelectController/SelectController.tsx
@@ -186,62 +186,68 @@ export const SelectController = <T extends FieldValues>({
     onChange: ((e: SelectEvent) => void) | undefined,
     selectedValue?: string,
     error?: FieldError,
-  ) => (
-    <Box sx={{ position: 'relative', width: '100%', ...sx }} className={className || ''}>
-      {placeholder && !selectedValue && (
-        <>
-          <StyledPlaceholderMask>{placeholder}</StyledPlaceholderMask>
-          <StyledPlaceholder className="controller-placeholder">{placeholder}</StyledPlaceholder>
-        </>
-      )}
+  ) => {
+      // HACK: Rerender when selectedValue changes to avoid interference from Google Translate (M2-10076)
+      const [forceRerenderKey, setForceRerenderKey] = useState(1);
+      useEffect(() => setForceRerenderKey(-forceRerenderKey), [selectedValue]);
 
-      <Tooltip
-        enterDelay={500}
-        {...TooltipProps}
-        onClose={handleCloseTooltip}
-        onOpen={handleOpenTooltip}
-        open={open}
-      >
-        <StyledTextField
-          {...props}
-          select
-          onChange={onChange}
-          value={selectedValue}
-          error={!!error || providedError}
-          helperText={isErrorVisible ? error?.message || helperText : ''}
-          disabled={disabled}
-          SelectProps={{
-            MenuProps: {
-              PaperProps: {
-                sx: { ...selectDropdownStyles, ...dropdownStyles },
-                'data-testid': `${dataTestid}-dropdown`,
-              },
-            },
-            IconComponent: shouldSkipIcon
-              ? undefined
-              : (props) => <Svg className={props.className} id="navigate-down" />,
-            ...SelectProps,
-            onClose: handleCloseSelect,
-            onOpen: handleOpenSelect,
-            ...(shouldSkipIcon && {
-              inputProps: {
-                sx: {
-                  pr: '1.2rem !important',
-                  minWidth: '94% !important',
+      return (<Box sx={{ position: 'relative', width: '100%', ...sx }} className={className || ''}>
+        {placeholder && !selectedValue && (
+          <>
+            <StyledPlaceholderMask>{placeholder}</StyledPlaceholderMask>
+            <StyledPlaceholder className="controller-placeholder">{placeholder}</StyledPlaceholder>
+          </>
+        )}
+
+        <Tooltip
+          enterDelay={500}
+          {...TooltipProps}
+          onClose={handleCloseTooltip}
+          onOpen={handleOpenTooltip}
+          open={open}
+        >
+          <StyledTextField
+            {...props}
+            key={forceRerenderKey}
+            select
+            onChange={onChange}
+            value={selectedValue}
+            error={!!error || providedError}
+            helperText={isErrorVisible ? error?.message || helperText : ''}
+            disabled={disabled}
+            SelectProps={{
+              MenuProps: {
+                PaperProps: {
+                  sx: { ...selectDropdownStyles, ...dropdownStyles },
+                  'data-testid': `${dataTestid}-dropdown`,
                 },
               },
-            }),
-          }}
-          data-testid={dataTestid}
-        >
-          {renderGroupedOptions(selectedValue)}
-          {targetSelector && (
-            <SelectObserverTarget setTrigger={setTrigger} targetSelector={targetSelector} />
-          )}
-        </StyledTextField>
-      </Tooltip>
-    </Box>
-  );
+              IconComponent: shouldSkipIcon
+                ? undefined
+                : (props) => <Svg className={props.className} id="navigate-down" />,
+              ...SelectProps,
+              onClose: handleCloseSelect,
+              onOpen: handleOpenSelect,
+              ...(shouldSkipIcon && {
+                inputProps: {
+                  sx: {
+                    pr: '1.2rem !important',
+                    minWidth: '94% !important',
+                  },
+                },
+              }),
+            }}
+            data-testid={dataTestid}
+          >
+            {renderGroupedOptions(selectedValue)}
+            {targetSelector && (
+              <SelectObserverTarget setTrigger={setTrigger} targetSelector={targetSelector} />
+            )}
+          </StyledTextField>
+        </Tooltip>
+      </Box>
+    );
+  }
 
   return (
     <>

--- a/src/shared/components/FormComponents/SelectController/SelectController.tsx
+++ b/src/shared/components/FormComponents/SelectController/SelectController.tsx
@@ -186,71 +186,64 @@ export const SelectController = <T extends FieldValues>({
     onChange: ((e: SelectEvent) => void) | undefined,
     selectedValue?: string,
     error?: FieldError,
-  ) => {
-    /* eslint-disable react-hooks/rules-of-hooks */
-    // HACK: Rerender when selectedValue changes to avoid interference from Google Translate (M2-10076)
-    const [forceRerenderKey, setForceRerenderKey] = useState(1);
-    useEffect(() => setForceRerenderKey(-forceRerenderKey), [selectedValue]);
-    /* eslint-enable react-hooks/rules-of-hooks */
+  ) => (
+    <Box sx={{ position: 'relative', width: '100%', ...sx }} className={className || ''}>
+      {placeholder && !selectedValue && (
+        <>
+          <StyledPlaceholderMask>{placeholder}</StyledPlaceholderMask>
+          <StyledPlaceholder className="controller-placeholder">{placeholder}</StyledPlaceholder>
+        </>
+      )}
 
-    return (
-      <Box sx={{ position: 'relative', width: '100%', ...sx }} className={className || ''}>
-        {placeholder && !selectedValue && (
-          <>
-            <StyledPlaceholderMask>{placeholder}</StyledPlaceholderMask>
-            <StyledPlaceholder className="controller-placeholder">{placeholder}</StyledPlaceholder>
-          </>
-        )}
-
-        <Tooltip
-          enterDelay={500}
-          {...TooltipProps}
-          onClose={handleCloseTooltip}
-          onOpen={handleOpenTooltip}
-          open={open}
-        >
-          <StyledTextField
-            {...props}
-            key={forceRerenderKey}
-            select
-            onChange={onChange}
-            value={selectedValue}
-            error={!!error || providedError}
-            helperText={isErrorVisible ? error?.message || helperText : ''}
-            disabled={disabled}
-            SelectProps={{
-              MenuProps: {
-                PaperProps: {
-                  sx: { ...selectDropdownStyles, ...dropdownStyles },
-                  'data-testid': `${dataTestid}-dropdown`,
+      <Tooltip
+        enterDelay={500}
+        {...TooltipProps}
+        onClose={handleCloseTooltip}
+        onOpen={handleOpenTooltip}
+        open={open}
+      >
+        {/* HACK: Use key to rerender when selectedValue changes to avoid interference from Google Translate (M2-10076) */}
+        <StyledTextField
+          {...props}
+          key={selectedValue}
+          select
+          onChange={onChange}
+          value={selectedValue}
+          error={!!error || providedError}
+          helperText={isErrorVisible ? error?.message || helperText : ''}
+          disabled={disabled}
+          SelectProps={{
+            MenuProps: {
+              PaperProps: {
+                sx: { ...selectDropdownStyles, ...dropdownStyles },
+                'data-testid': `${dataTestid}-dropdown`,
+              },
+            },
+            IconComponent: shouldSkipIcon
+              ? undefined
+              : (props) => <Svg className={props.className} id="navigate-down" />,
+            ...SelectProps,
+            onClose: handleCloseSelect,
+            onOpen: handleOpenSelect,
+            ...(shouldSkipIcon && {
+              inputProps: {
+                sx: {
+                  pr: '1.2rem !important',
+                  minWidth: '94% !important',
                 },
               },
-              IconComponent: shouldSkipIcon
-                ? undefined
-                : (props) => <Svg className={props.className} id="navigate-down" />,
-              ...SelectProps,
-              onClose: handleCloseSelect,
-              onOpen: handleOpenSelect,
-              ...(shouldSkipIcon && {
-                inputProps: {
-                  sx: {
-                    pr: '1.2rem !important',
-                    minWidth: '94% !important',
-                  },
-                },
-              }),
-            }}
-            data-testid={dataTestid}
-          >
-            {renderGroupedOptions(selectedValue)}
-            {targetSelector && (
-              <SelectObserverTarget setTrigger={setTrigger} targetSelector={targetSelector} />
-            )}
-          </StyledTextField>
-        </Tooltip>
-      </Box>
-    );
-  };
+            }),
+          }}
+          data-testid={dataTestid}
+        >
+          {renderGroupedOptions(selectedValue)}
+          {targetSelector && (
+            <SelectObserverTarget setTrigger={setTrigger} targetSelector={targetSelector} />
+          )}
+        </StyledTextField>
+      </Tooltip>
+    </Box>
+  );
 
   return (
     <>


### PR DESCRIPTION
- [x] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

🔗 [Jira Ticket M2-10076](https://mindlogger.atlassian.net/browse/M2-10076)

Google Translate mutates DOM and interferes with React. This resulted in the selected dropdown value not updating in the UI even though the underlying `selectedValue` variable was updating in JavaScript.

Changes include:
- Rerender dropdown value when `selectedValue` changes so Google Translate will re-translate.

### 🪤 Peer Testing

Test steps:
1. Use Google Chrome and enable Google Translate. (On macOS, this could require updating the macOS language to something other than English in macOS Settings.)
2. Edit an Item Flow in an applet.
3. Change the value of a dropdown.

Behavior before fix:
- The old dropdown value remains in the UI.

Behavior after fix:
- The new dropdown value in the UI briefly displays in English (e.g., “is equal to”) before Google Translate re-translates it (e.g., “é igual a”).