### PR TITLE
fix: Rerender to trigger Google Translate when item type search term changes (M2-10091)

### DIFF
--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/GroupedSelectSearchController/GroupedSelectSearchController.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/GroupedSelectSearchController/GroupedSelectSearchController.tsx
@@ -219,6 +219,7 @@ export const GroupedSelectSearchController = <T extends FieldValues>({
                   ...groupOptions.map(({ value, icon, disabled, tooltip }) => {
                     const isHidden = getIsNotHaveSearchValue(value, searchTermLowercase);
 
+                    // HACK: Use key to rerender when search term changes to avoid interference from Google Translate (M2-10091)
                     return (
                       <StyledMenuItem
                         onMouseEnter={
@@ -226,7 +227,7 @@ export const GroupedSelectSearchController = <T extends FieldValues>({
                         }
                         onMouseLeave={handleTooltipClose}
                         isHidden={isHidden}
-                        key={value}
+                        key={`${searchTerm} - ${value}`}
                         value={disabled ? undefined : value}
                         disabled={disabled}
                         data-testid={`${dataTestid}-option-${value}`}


### PR DESCRIPTION
- [x] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

🔗 [Jira Ticket M2-10091](https://mindlogger.atlassian.net/browse/M2-10091)

Google Translate mutates DOM and interferes with React. This resulted in the options in the **Item Type** dropdown not updating in the UI when the search term changes.

Changes include:
- Rerender **Item Type** menu items when `searchTerm` changes so Google Translate will re-translate.

### 🪤 Peer Testing

Test steps:
1. Use Google Chrome and enable Google Translate. (On macOS, this could require updating the macOS language to something other than English in macOS Settings.)
2. Create a new **Item**.
3. Click the **Item Type** dropdown.
4. Type something to search for item types in the dropdown.

Behavior before fix:
- The text for the item types in the dropdown would be repeated each time the search term changes (e.g. “Tempo Tempo Tempo Tempo…”)

Behavior after fix:
- The text for the item types in the dropdown remain stable (e.g. “Tempo”)