### PR TITLE
fix: Search Item Type in Google translated language (M2-10095)

### DIFF
--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/GroupedSelectSearchController/GroupedSelectSearchController.hooks.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/GroupedSelectSearchController/GroupedSelectSearchController.hooks.tsx
@@ -21,7 +21,7 @@ export const useItemTypeSelectSetup = () => {
   };
 
   const getIsNotHaveSearchValue = (value: string, searchTermLowercase: string) =>
-    t(getItemLanguageKey(value)).toLowerCase().indexOf(searchTermLowercase) === -1;
+    t(getItemLanguageKey(value)).toLocaleLowerCase().indexOf(searchTermLowercase) === -1;
 
   const getItemTypesNames = (): string[] =>
     Object.keys(ItemResponseType).map((key) =>
@@ -29,11 +29,12 @@ export const useItemTypeSelectSetup = () => {
         enableParagraphTextItem && key === 'Text'
           ? textLanguageKey
           : ItemResponseType[key as keyof typeof ItemResponseType],
-      ).toLowerCase(),
+      ).toLocaleLowerCase(),
     );
 
   const getEmptyComponent = (searchTerm: string) => {
-    if (getItemTypesNames().some((name) => name.includes(searchTerm.toLowerCase()))) return null;
+    if (getItemTypesNames().some((name) => name.includes(searchTerm.toLocaleLowerCase())))
+      return null;
     const MAX_SEARCH_VALUE_LENGTH = 80;
 
     const searchValue =
@@ -52,7 +53,7 @@ export const useItemTypeSelectSetup = () => {
   const getGroupName = (groupName: string, options: ItemsOption[], searchTermLowercase: string) => {
     if (
       options.some(({ value }) =>
-        t(getItemLanguageKey(value)).toLowerCase().includes(searchTermLowercase),
+        t(getItemLanguageKey(value)).toLocaleLowerCase().includes(searchTermLowercase),
       )
     ) {
       return (

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/GroupedSelectSearchController/GroupedSelectSearchController.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/GroupedSelectSearchController/GroupedSelectSearchController.tsx
@@ -7,7 +7,7 @@ import {
   SelectChangeEvent,
   TextField,
 } from '@mui/material';
-import { ChangeEvent, MouseEvent, ReactNode, useState } from 'react';
+import { ChangeEvent, MouseEvent, ReactNode, useRef, useState } from 'react';
 import { Controller, FieldValues } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
@@ -91,7 +91,7 @@ export const GroupedSelectSearchController = <T extends FieldValues>({
   const [selectOpen, setSelectOpen] = useState(false);
   const [anchorEl, setAnchorEl] = useState<HTMLLIElement | null>(null);
   const [currentItemType, setCurrentItemType] = useState<ItemResponseTypeNoPerfTasks | null>(null);
-  const searchTermLowercase = searchTerm.toLowerCase();
+  const searchTermLowercase = searchTerm.toLocaleLowerCase();
 
   const handleTooltipOpen = (
     event: MouseEvent<HTMLLIElement>,
@@ -219,11 +219,24 @@ export const GroupedSelectSearchController = <T extends FieldValues>({
                 {options?.map(({ groupName, groupOptions }) => [
                   getGroupName(groupName, groupOptions, searchTermLowercase),
                   ...groupOptions.map(({ value, icon, disabled, tooltip }) => {
-                    const isHidden = getIsNotHaveSearchValue(value, searchTermLowercase);
+                    // HACK: Read translated value from DOM if Google Translate is enabled (M2-10091)
+
+                    // eslint-disable-next-line react-hooks/rules-of-hooks
+                    const menuItemRef = useRef<HTMLLIElement>(null);
+                    const maybeGoogleTranslatedValue = menuItemRef.current?.textContent;
+                    const hasGoogleTranslatedValue =
+                      maybeGoogleTranslatedValue && maybeGoogleTranslatedValue !== value;
+
+                    // hide if value does not have search term and if value from Google Translate does not have search term
+                    const isHidden =
+                      getIsNotHaveSearchValue(value, searchTermLowercase) &&
+                      (!hasGoogleTranslatedValue ||
+                        getIsNotHaveSearchValue(maybeGoogleTranslatedValue, searchTermLowercase));
 
                     // HACK: Use key to rerender when search term changes to avoid interference from Google Translate (M2-10091)
                     return (
                       <StyledMenuItem
+                        ref={menuItemRef}
                         onMouseEnter={
                           selectOpen ? (event) => handleTooltipOpen(event, value) : falseReturnFunc
                         }

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/GroupedSelectSearchController/GroupedSelectSearchController.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/GroupedSelectSearchController/GroupedSelectSearchController.tsx
@@ -219,7 +219,7 @@ export const GroupedSelectSearchController = <T extends FieldValues>({
                 {options?.map(({ groupName, groupOptions }) => [
                   getGroupName(groupName, groupOptions, searchTermLowercase),
                   ...groupOptions.map(({ value, icon, disabled, tooltip }) => {
-                    // HACK: Read translated value from DOM if Google Translate is enabled (M2-10091)
+                    // HACK: Read translated value from DOM if Google Translate is enabled (M2-10095)
 
                     // eslint-disable-next-line react-hooks/rules-of-hooks
                     const menuItemRef = useRef<HTMLLIElement>(null);

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/GroupedSelectSearchController/GroupedSelectSearchController.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/GroupedSelectSearchController/GroupedSelectSearchController.tsx
@@ -7,7 +7,7 @@ import {
   SelectChangeEvent,
   TextField,
 } from '@mui/material';
-import { ChangeEvent, MouseEvent, ReactNode, useRef, useState } from 'react';
+import { ChangeEvent, MouseEvent, ReactNode, useEffect, useRef, useState } from 'react';
 import { Controller, FieldValues } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
@@ -219,19 +219,30 @@ export const GroupedSelectSearchController = <T extends FieldValues>({
                 {options?.map(({ groupName, groupOptions }) => [
                   getGroupName(groupName, groupOptions, searchTermLowercase),
                   ...groupOptions.map(({ value, icon, disabled, tooltip }) => {
-                    // HACK: Read translated value from DOM if Google Translate is enabled (M2-10095)
-
                     // eslint-disable-next-line react-hooks/rules-of-hooks
                     const menuItemRef = useRef<HTMLLIElement>(null);
+                    // eslint-disable-next-line react-hooks/rules-of-hooks
+                    const [googleTranslatedValue, setGoogleTranslatedValue] = useState<string>('');
+
+                    // HACK: Read translated value from DOM if Google Translate is enabled (M2-10095)
                     const maybeGoogleTranslatedValue = menuItemRef.current?.textContent;
-                    const hasGoogleTranslatedValue =
-                      maybeGoogleTranslatedValue && maybeGoogleTranslatedValue !== value;
+                    // eslint-disable-next-line react-hooks/rules-of-hooks
+                    useEffect(() => {
+                      // cache value from DOM if it has been changed by Google Translate
+                      if (
+                        maybeGoogleTranslatedValue &&
+                        maybeGoogleTranslatedValue !== googleTranslatedValue &&
+                        !maybeGoogleTranslatedValue.startsWith(t(value))
+                      ) {
+                        setGoogleTranslatedValue(maybeGoogleTranslatedValue);
+                      }
+                    }, [maybeGoogleTranslatedValue]);
 
                     // hide if value does not have search term and if value from Google Translate does not have search term
                     const isHidden =
                       getIsNotHaveSearchValue(value, searchTermLowercase) &&
-                      (!hasGoogleTranslatedValue ||
-                        getIsNotHaveSearchValue(maybeGoogleTranslatedValue, searchTermLowercase));
+                      (!googleTranslatedValue ||
+                        getIsNotHaveSearchValue(googleTranslatedValue, searchTermLowercase));
 
                     // HACK: Use key to rerender when search term changes to avoid interference from Google Translate (M2-10091)
                     return (


### PR DESCRIPTION
- [x] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

🔗 [Jira Ticket M2-10095](https://mindlogger.atlassian.net/browse/M2-10095)

We filter **Item Type** options according to the original English values, not the values translated by Google Translate.

Changes include:
- Try fetching translated value from the DOM
- Filter **Item Type** options by translated value if available
- Switch from `.toLowerCase()` to `.toLocaleLowerCase()` to handle non-English lowercase (e.g., normalizing `İ` to `i`)

### 🪤 Peer Testing

Test steps:
1. Use Google Chrome and enable Google Translate. (On macOS, this could require updating the macOS language to something other than English in macOS Settings.)
2. Create a new **Item**.
3. Click the **Item Type** dropdown.
4. Type something to search for item types in the dropdown.

Behavior before fix:
- The item types filter for English search terms, but not for search terms in the translated language.

Behavior after fix:
- The item types filter for both English search terms and search terms in the translated language.