### PR TITLE
fix: Recovery Codes formatting and Disable MFA styling (M2-10378,M2-10381)

### DIFF
--- a/src/modules/Auth/utils/mfa.utils.test.ts
+++ b/src/modules/Auth/utils/mfa.utils.test.ts
@@ -198,6 +198,15 @@ describe('MFA Utilities', () => {
     it('preserves existing hyphen position', () => {
       expect(formatRecoveryCode('ABCDE-12345')).toBe('ABCDE-12345');
     });
+
+    it('handles deletion from formatted code without double hyphens', () => {
+      // Simulate deleting from "ABCDE-12345" to "ABCD-12345"
+      expect(formatRecoveryCode('ABCD-12345')).toBe('ABCD1-2345');
+      // Simulate deleting all from second half: "ABCDE-" becomes "ABCDE"
+      expect(formatRecoveryCode('ABCDE-')).toBe('ABCDE');
+      // Simulate deleting from first half leaving hyphen: "ABC-12345"
+      expect(formatRecoveryCode('ABC-12345')).toBe('ABC12-345');
+    });
   });
 
   describe('isValidMFACode', () => {

--- a/src/modules/Dashboard/features/AccountSettings/RemoveMFA/RemoveMFAConfirmation.styles.ts
+++ b/src/modules/Dashboard/features/AccountSettings/RemoveMFA/RemoveMFAConfirmation.styles.ts
@@ -102,7 +102,7 @@ export const StyledButton = styled('button')`
   padding: 10px 24px;
   display: flex;
   align-items: center;
-  justify-center;
+  justify-content: center;
 
   &.primary {
     background: ${variables.palette.error};

--- a/src/modules/Dashboard/features/AccountSettings/shared/ConfirmIdentityRecoveryCode.tsx
+++ b/src/modules/Dashboard/features/AccountSettings/shared/ConfirmIdentityRecoveryCode.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { Box } from '@mui/material';
 
 import { Svg } from 'shared/components/Svg';
+import { formatRecoveryCode } from 'modules/Auth/utils/mfa.utils';
 
 import {
   StyledDialog,
@@ -57,19 +58,9 @@ export const ConfirmIdentityRecoveryCode = ({
   const shouldDisableInput = !!onRetry;
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value.toUpperCase();
-    // Allow only alphanumeric characters and dash
-    const sanitized = value.replace(/[^A-Z0-9-]/g, '');
-
-    // Auto-insert hyphen after 5 characters (format: XXXXX-XXXXX)
-    if (sanitized.length === 5 && !sanitized.includes('-')) {
-      setRecoveryCode(`${sanitized}-`);
-    } else if (sanitized.length === 6 && sanitized.charAt(5) !== '-') {
-      // If user pastes or types through, ensure hyphen is at position 5
-      setRecoveryCode(`${sanitized.slice(0, 5)}-${sanitized.slice(5)}`);
-    } else {
-      setRecoveryCode(sanitized);
-    }
+    // Use the same formatting utility as login flow to avoid double-hyphen issues
+    const formatted = formatRecoveryCode(e.target.value);
+    setRecoveryCode(formatted);
   };
 
   return (


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to Curious [open source credit page](https://mindlogger.atlassian.net/wiki/spaces/MINDLOGGER1/pages/263127186/Admin+Panel+Applet+Builder+Library)
- [ ] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-10378](https://mindlogger.atlassian.net/browse/M2-10378)

🔗 [Jira Ticket M2-10381](https://mindlogger.atlassian.net/browse/M2-10381)


**Root Cause:** The `ConfirmIdentityRecoveryCode` component used custom manual formatting logic that preserved existing hyphens while trying to add new ones, causing double hyphens during deletion/editing. 

**Solution:** Replaced custom formatting logic with the existing `formatRecoveryCode()` utility function that was already working correctly in the login flow. This utility strips ALL non-alphanumeric characters (including existing hyphens) before reformatting, ensuring clean state.

Changes include:

- Updated `ConfirmIdentityRecoveryCode.tsx` to use `formatRecoveryCode()` utility from `modules/Auth/utils/mfa.utils`
- Simplified input handling logic by removing manual hyphen insertion code
- Added test case in `mfa.utils.test.ts` to prevent regression of deletion scenarios
- Ensured consistent formatting behavior across all MFA recovery code inputs (login & account settings)
- Added Justify-content : center, to align the texts in disable MFA to center


### 🪤 Peer Testing

**Test Steps:**

1. **Log in to Admin Panel** with an account that has MFA enabled
   
2. **Navigate to Account Settings:**
   - Click on your avatar in the top-right corner
   - Click "Settings"

3. **Access Recovery Code Input:**
   - Click the "View" button next to "Authenticator app"
   - Click "I can't access my authenticator app"

4. **Test Recovery Code Formatting:**
   - Type: `QWERTYUIO`
   
   **Expected outcome:** Code is formatted to `QWERT-YUIO` with hyphen after 5 characters
   
5. **Test Deletion/Editing:**
   - Delete characters back to `QWERT`
   
   **Expected outcome:** Shows `QWERT` with no hyphen (not `QWERT-`)
   
6. **Test Re-typing:**
   - Type `Y` again
   
   **Expected outcome:** Formats to `QWERTY-` (single hyphen, not double)
   
7. **Complete the code:**
   - Continue typing to complete: `QWERTYUIOP`
   
   **Expected outcome:** Final format is `QWERT-YUIOP` (correct formatting, no double hyphens)
