### PR TITLE
fix: Translate MFA error messages and placeholders

### DIFF
--- a/src/modules/Dashboard/features/AccountSettings/MFASetup/MFASetup.const.ts
+++ b/src/modules/Dashboard/features/AccountSettings/MFASetup/MFASetup.const.ts
@@ -8,12 +8,12 @@ export const MFA_CONSTANTS = {
 } as const;
 
 export const MFA_ERROR_MESSAGES = {
-  INVALID_CODE: 'Invalid Code',
-  EXPIRED_SETUP: 'Setup expired. Please reinitiate MFA',
-  SETUP_NOT_FOUND: 'No setup found. Please reinitiate MFA',
-  NETWORK_ERROR: 'Network Error',
-  UNKNOWN_ERROR: 'Something went wrong. Please try again.',
-  ALREADY_ENABLED: 'Two-factor authentication is already enabled for your account.',
+  INVALID_CODE: 'invalidMFACode',
+  EXPIRED_SETUP: 'mfaSessionExpired',
+  SETUP_NOT_FOUND: 'mfaSessionExpired',
+  NETWORK_ERROR: 'networkError',
+  UNKNOWN_ERROR: 'somethingWentWrong',
+  ALREADY_ENABLED: 'mfaAlreadyEnabled',
 } as const;
 
 // Backend error message patterns for matching

--- a/src/modules/Dashboard/features/AccountSettings/RemoveMFA/RemoveMFA.constants.ts
+++ b/src/modules/Dashboard/features/AccountSettings/RemoveMFA/RemoveMFA.constants.ts
@@ -2,7 +2,7 @@
  * Error messages for MFA disable operations
  */
 export const MFA_DISABLE_ERROR_MESSAGES = {
-  NOT_ENABLED: 'Two-factor authentication is not enabled on this account.',
+  NOT_ENABLED: 'mfaNotEnabled',
   INVALID_CODE: 'invalidCode', // Fallback, same as INVALID_VERIFICATION_CODE
   INVALID_VERIFICATION_CODE: 'invalidMFACode',
   INVALID_RECOVERY_CODE: 'invalidRecoveryCode',

--- a/src/modules/Dashboard/features/AccountSettings/RemoveMFA/RemoveMFA.constants.ts
+++ b/src/modules/Dashboard/features/AccountSettings/RemoveMFA/RemoveMFA.constants.ts
@@ -3,19 +3,17 @@
  */
 export const MFA_DISABLE_ERROR_MESSAGES = {
   NOT_ENABLED: 'Two-factor authentication is not enabled on this account.',
-  INVALID_CODE: 'Invalid code. Please check your authenticator app and try again.', // Fallback, same as INVALID_VERIFICATION_CODE
-  INVALID_VERIFICATION_CODE:
-    'Invalid TOTP code. Please check your authenticator app and try again.',
-  INVALID_RECOVERY_CODE: 'Invalid recovery code. Please check the code and try again.',
-  RECOVERY_CODE_USED: 'This recovery code has already been used. Each code can only be used once.',
-  SESSION_EXPIRED: 'Your verification session has expired. Please start over.',
-  EXPIRED_SESSION: 'Your verification session has expired. Please start over.', // Alias for SESSION_EXPIRED, used in useRemoveMFA
-  MAX_ATTEMPTS: 'Too many invalid attempts. Please try again later.',
-  GLOBAL_LOCKOUT:
-    'Account temporarily locked due to multiple failed attempts. Please try again later.',
-  SESSION_MISMATCH: 'Invalid verification session. Please start over.',
-  NETWORK_ERROR: 'Network error. Please check your connection and try again.',
-  UNKNOWN_ERROR: 'An unexpected error occurred. Please try again.',
+  INVALID_CODE: 'invalidCode', // Fallback, same as INVALID_VERIFICATION_CODE
+  INVALID_VERIFICATION_CODE: 'invalidMFACode',
+  INVALID_RECOVERY_CODE: 'invalidRecoveryCode',
+  RECOVERY_CODE_USED: 'recoveryCodeAlreadyUsed',
+  SESSION_EXPIRED: 'mfaSessionExpired',
+  EXPIRED_SESSION: 'mfaSessionExpired', // Alias for SESSION_EXPIRED, used in useRemoveMFA
+  MAX_ATTEMPTS: 'tooManyAttempts',
+  GLOBAL_LOCKOUT: 'tooManyAttempts',
+  SESSION_MISMATCH: 'mfaSessionExpired',
+  NETWORK_ERROR: 'networkError',
+  UNKNOWN_ERROR: 'somethingWentWrong',
 } as const;
 
 /**

--- a/src/modules/Dashboard/features/AccountSettings/ViewRecoveryCodes/ViewRecoveryCodes.utils.ts
+++ b/src/modules/Dashboard/features/AccountSettings/ViewRecoveryCodes/ViewRecoveryCodes.utils.ts
@@ -23,8 +23,8 @@ const ERROR_MESSAGES = {
   MAX_ATTEMPTS: 'tooManyAttempts',
   SESSION_EXPIRED: 'mfaSessionExpired',
   GLOBAL_LOCKOUT: 'tooManyAttempts',
-  MFA_NOT_ENABLED: 'Two-factor authentication is not enabled on this account.',
-  NO_RECOVERY_CODES: 'Two-factor authentication is not enabled on this account.',
+  MFA_NOT_ENABLED: 'mfaNotEnabled',
+  NO_RECOVERY_CODES: 'mfaNotEnabled',
   NETWORK_ERROR: 'networkError',
   UNKNOWN_ERROR: 'somethingWentWrong',
 };

--- a/src/modules/Dashboard/features/AccountSettings/ViewRecoveryCodes/ViewRecoveryCodes.utils.ts
+++ b/src/modules/Dashboard/features/AccountSettings/ViewRecoveryCodes/ViewRecoveryCodes.utils.ts
@@ -17,17 +17,16 @@ const STATUS_CODES = {
 };
 
 const ERROR_MESSAGES = {
-  INVALID_CODE: 'Invalid TOTP code. Please check your authenticator app and try again.', // Fallback, same as INVALID_VERIFICATION_CODE
-  INVALID_VERIFICATION_CODE:
-    'Invalid TOTP code. Please check your authenticator app and try again.',
-  INVALID_RECOVERY_CODE: 'Invalid recovery code. Please check the code and try again.',
-  MAX_ATTEMPTS: 'Too many invalid attempts. Please try again.',
-  SESSION_EXPIRED: 'Your session has expired. Please try again.',
-  GLOBAL_LOCKOUT: 'Too many failed attempts. Please try again later.',
-  MFA_NOT_ENABLED: 'MFA is not enabled for your account.',
-  NO_RECOVERY_CODES: 'No recovery codes found. Please set up MFA first.',
-  NETWORK_ERROR: 'Network error. Please check your connection and try again.',
-  UNKNOWN_ERROR: 'An error occurred. Please try again.',
+  INVALID_CODE: 'invalidCode', // Fallback, same as INVALID_VERIFICATION_CODE
+  INVALID_VERIFICATION_CODE: 'invalidMFACode',
+  INVALID_RECOVERY_CODE: 'invalidRecoveryCode',
+  MAX_ATTEMPTS: 'tooManyAttempts',
+  SESSION_EXPIRED: 'mfaSessionExpired',
+  GLOBAL_LOCKOUT: 'tooManyAttempts',
+  MFA_NOT_ENABLED: 'Two-factor authentication is not enabled on this account.',
+  NO_RECOVERY_CODES: 'Two-factor authentication is not enabled on this account.',
+  NETWORK_ERROR: 'networkError',
+  UNKNOWN_ERROR: 'somethingWentWrong',
 };
 
 export const parseError = createErrorParser(ERROR_MESSAGES, BACKEND_ERROR_PATTERNS, STATUS_CODES);

--- a/src/modules/Dashboard/features/AccountSettings/ViewRecoveryCodes/useViewRecoveryCodes.test.ts
+++ b/src/modules/Dashboard/features/AccountSettings/ViewRecoveryCodes/useViewRecoveryCodes.test.ts
@@ -119,9 +119,7 @@ describe('useViewRecoveryCodes', () => {
         expect(verifyResult?.success).toBe(false);
       });
 
-      expect(result.current.error).toBe(
-        'Invalid TOTP code. Please check your authenticator app and try again.',
-      );
+      expect(result.current.error).toBe('invalidMFACode');
     });
 
     it('should handle MFA not enabled error (403)', async () => {
@@ -147,7 +145,9 @@ describe('useViewRecoveryCodes', () => {
         expect(initiateResult?.success).toBe(false);
       });
 
-      expect(result.current.error).toBe('MFA is not enabled for your account.');
+      expect(result.current.error).toBe(
+        'Two-factor authentication is not enabled on this account.',
+      );
     });
 
     it('should handle no recovery codes found (404)', async () => {
@@ -173,7 +173,9 @@ describe('useViewRecoveryCodes', () => {
         expect(initiateResult?.success).toBe(false);
       });
 
-      expect(result.current.error).toBe('No recovery codes found. Please set up MFA first.');
+      expect(result.current.error).toBe(
+        'Two-factor authentication is not enabled on this account.',
+      );
     });
   });
 
@@ -238,9 +240,7 @@ describe('useViewRecoveryCodes', () => {
         expect(verifyResult?.success).toBe(false);
       });
 
-      expect(result.current.error).toBe(
-        'Invalid recovery code. Please check the code and try again.',
-      );
+      expect(result.current.error).toBe('invalidRecoveryCode');
     });
 
     it('should handle rate limiting (429)', async () => {
@@ -274,7 +274,7 @@ describe('useViewRecoveryCodes', () => {
         expect(verifyResult?.success).toBe(false);
       });
 
-      expect(result.current.error).toBe('Too many invalid attempts. Please try again.');
+      expect(result.current.error).toBe('tooManyAttempts');
     });
   });
 
@@ -299,9 +299,7 @@ describe('useViewRecoveryCodes', () => {
         expect(initiateResult?.success).toBe(false);
       });
 
-      expect(result.current.error).toBe(
-        'Network error. Please check your connection and try again.',
-      );
+      expect(result.current.error).toBe('networkError');
     });
 
     it('should handle missing codes from verify response', async () => {
@@ -332,9 +330,7 @@ describe('useViewRecoveryCodes', () => {
         expect(verifyResult?.success).toBe(false);
       });
 
-      expect(result.current.error).toBe(
-        'Network error. Please check your connection and try again.',
-      );
+      expect(result.current.error).toBe('networkError');
     });
 
     it('should handle network errors', async () => {
@@ -356,9 +352,7 @@ describe('useViewRecoveryCodes', () => {
         expect(initiateResult?.success).toBe(false);
       });
 
-      expect(result.current.error).toBe(
-        'Network error. Please check your connection and try again.',
-      );
+      expect(result.current.error).toBe('networkError');
     });
   });
 
@@ -475,9 +469,7 @@ describe('useViewRecoveryCodes', () => {
       });
 
       await waitFor(() => {
-        expect(result.current.error).toBe(
-          'Invalid TOTP code. Please check your authenticator app and try again.',
-        );
+        expect(result.current.error).toBe('invalidMFACode');
       });
 
       // Clear error before next test
@@ -500,9 +492,7 @@ describe('useViewRecoveryCodes', () => {
       });
 
       await waitFor(() => {
-        expect(result.current.error).toBe(
-          'Invalid recovery code. Please check the code and try again.',
-        );
+        expect(result.current.error).toBe('invalidRecoveryCode');
       });
     });
   });

--- a/src/modules/Dashboard/features/AccountSettings/ViewRecoveryCodes/useViewRecoveryCodes.test.ts
+++ b/src/modules/Dashboard/features/AccountSettings/ViewRecoveryCodes/useViewRecoveryCodes.test.ts
@@ -145,9 +145,7 @@ describe('useViewRecoveryCodes', () => {
         expect(initiateResult?.success).toBe(false);
       });
 
-      expect(result.current.error).toBe(
-        'Two-factor authentication is not enabled on this account.',
-      );
+      expect(result.current.error).toBe('mfaNotEnabled');
     });
 
     it('should handle no recovery codes found (404)', async () => {
@@ -173,9 +171,7 @@ describe('useViewRecoveryCodes', () => {
         expect(initiateResult?.success).toBe(false);
       });
 
-      expect(result.current.error).toBe(
-        'Two-factor authentication is not enabled on this account.',
-      );
+      expect(result.current.error).toBe('mfaNotEnabled');
     });
   });
 

--- a/src/modules/Dashboard/features/AccountSettings/ViewRecoveryCodes/useViewRecoveryCodes.ts
+++ b/src/modules/Dashboard/features/AccountSettings/ViewRecoveryCodes/useViewRecoveryCodes.ts
@@ -72,7 +72,7 @@ export const useViewRecoveryCodes = () => {
 
   const handleVerifyCode = async (_code: string): Promise<VerificationResult> => {
     if (!mfaToken) {
-      setError('Session expired. Please try again.');
+      setError('mfaSessionExpired');
 
       return { success: false };
     }
@@ -123,7 +123,7 @@ export const useViewRecoveryCodes = () => {
 
   const handleVerifyRecoveryCode = async (_code: string): Promise<VerificationResult> => {
     if (!mfaToken) {
-      setError('Session expired. Please try again.');
+      setError('mfaSessionExpired');
 
       return { success: false };
     }

--- a/src/modules/Dashboard/features/AccountSettings/shared/ConfirmIdentityRecoveryCode.tsx
+++ b/src/modules/Dashboard/features/AccountSettings/shared/ConfirmIdentityRecoveryCode.tsx
@@ -31,6 +31,7 @@ export const ConfirmIdentityRecoveryCode = ({
   error,
 }: ConfirmIdentityRecoveryCodeProps) => {
   const { t } = useTranslation('app');
+  const translatedError = error ? t(error, { defaultValue: error }) : null;
 
   const handleClose = () => {
     // Remove focus from any focused element before closing to prevent aria-hidden focus warning
@@ -86,7 +87,7 @@ export const ConfirmIdentityRecoveryCode = ({
               disabled={isLoading || shouldDisableInput}
             />
           </StyledInputContainer>
-          {error && <StyledErrorMessage>{error}</StyledErrorMessage>}
+          {translatedError && <StyledErrorMessage>{translatedError}</StyledErrorMessage>}
         </Box>
 
         <StyledButtonContainer>

--- a/src/modules/Dashboard/features/AccountSettings/shared/ConfirmIdentityVerificationCode.tsx
+++ b/src/modules/Dashboard/features/AccountSettings/shared/ConfirmIdentityVerificationCode.tsx
@@ -32,6 +32,7 @@ export const ConfirmIdentityVerificationCode = ({
 }: ConfirmIdentityVerificationCodeProps) => {
   const { t } = useTranslation('app');
   const { handleInputChange } = useMFAInputHandler(setVerificationCode, clearError, error);
+  const translatedError = error ? t(error, { defaultValue: error }) : null;
 
   const handleClose = () => {
     if (document.activeElement instanceof HTMLElement) {
@@ -78,7 +79,7 @@ export const ConfirmIdentityVerificationCode = ({
               disabled={isLoading || shouldDisableInput}
             />
           </StyledInputContainer>
-          {error && <StyledErrorMessage>{error}</StyledErrorMessage>}
+          {translatedError && <StyledErrorMessage>{translatedError}</StyledErrorMessage>}
         </Box>
 
         <StyledButtonContainer>

--- a/src/modules/Dashboard/features/AccountSettings/shared/MFAVerificationForm.tsx
+++ b/src/modules/Dashboard/features/AccountSettings/shared/MFAVerificationForm.tsx
@@ -1,4 +1,5 @@
 import { Box } from '@mui/material';
+import { useTranslation } from 'react-i18next';
 
 import { MFAVerificationFormProps } from './MFAVerificationForm.types';
 
@@ -18,6 +19,7 @@ export const MFAVerificationForm = ({
   StyledButton,
   StyledErrorMessage,
 }: MFAVerificationFormProps) => {
+  const { t } = useTranslation('app');
   // Cast to any to avoid TypeScript prop forwarding issues with transient props
   const InputContainer = StyledInputContainer as any;
 
@@ -28,19 +30,19 @@ export const MFAVerificationForm = ({
           <StyledInput
             type="text"
             inputMode="numeric"
-            placeholder="Enter verification code"
+            placeholder={t('mfa.verificationCode.placeholder')}
             value={verificationCode}
             onChange={onInputChange}
             maxLength={6}
             disabled={isLoading}
           />
         </InputContainer>
-        {error && <StyledErrorMessage>{error}</StyledErrorMessage>}
+        {error && <StyledErrorMessage>{t(error, { defaultValue: error })}</StyledErrorMessage>}
       </Box>
 
       <StyledButtonContainer>
         <StyledButton type="button" className="primary" onClick={onPrimaryAction}>
-          {isLoading ? 'Verifying...' : primaryButtonText}
+          {isLoading ? t('mfa.buttons.verifying') : primaryButtonText}
         </StyledButton>
         <StyledButton
           type="button"

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -1860,6 +1860,7 @@
   "invalidRecoveryCode": "Invalid recovery code",
   "recoveryCodeAlreadyUsed": "This recovery code has already been used",
   "mfaAlreadyEnabled": "Two-factor authentication is already enabled for your account",
+  "mfaNotEnabled": "Two-factor authentication is not enabled on this account",
   "attemptsRemaining": "{{count}} attempts remaining",
   "mfa": {
     "title": "Two-factor authentication",

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -1859,6 +1859,7 @@
   "mfaSessionExpired": "Your session has expired. Please log in again.",
   "invalidRecoveryCode": "Invalid recovery code",
   "recoveryCodeAlreadyUsed": "This recovery code has already been used",
+  "mfaAlreadyEnabled": "Two-factor authentication is already enabled for your account",
   "attemptsRemaining": "{{count}} attempts remaining",
   "mfa": {
     "title": "Two-factor authentication",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -1858,6 +1858,7 @@
   "invalidRecoveryCode": "Code de récupération invalide",
   "recoveryCodeAlreadyUsed": "Ce code de récupération a déjà été utilisé",
   "mfaAlreadyEnabled": "L'authentification à deux facteurs est déjà activée pour votre compte",
+  "mfaNotEnabled": "L'authentification à deux facteurs n'est pas activée sur ce compte",
   "attemptsRemaining": "{{count}} tentatives restantes",
   "mfa": {
     "title": "Authentification à deux facteurs",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -1857,6 +1857,7 @@
   "mfaSessionExpired": "Votre session a expiré. Veuillez vous reconnecter.",
   "invalidRecoveryCode": "Code de récupération invalide",
   "recoveryCodeAlreadyUsed": "Ce code de récupération a déjà été utilisé",
+  "mfaAlreadyEnabled": "L'authentification à deux facteurs est déjà activée pour votre compte",
   "attemptsRemaining": "{{count}} tentatives restantes",
   "mfa": {
     "title": "Authentification à deux facteurs",


### PR DESCRIPTION
- [x] Tests for the changes have been added (existing tests pass)
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to Curious [open source credit page](https://mindlogger.atlassian.net/wiki/spaces/MINDLOGGER1/pages/263127186/Admin+Panel+Applet+Builder+Library)
- [ ] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

🔗 [Jira Ticket M2-10397](https://mindlogger.atlassian.net/browse/M2-10397)  
🔗 [Jira Ticket M2-10399](https://mindlogger.atlassian.net/browse/M2-10399)  
🔗 [Jira Ticket M2-10400](https://mindlogger.atlassian.net/browse/M2-10400)

Fixed MFA flows (setup, disable, and view recovery codes) to properly display French translations for placeholder text and error messages when the application language is changed to French.

Changes include:

- **MFAVerificationForm**: Added translation wrapper to error display using `t(error, { defaultValue: error })`
- **Error Constants**: Converted all hardcoded English error messages to translation keys:
  - `MFASetup.const.ts`: Updated error messages to use keys like `invalidMFACode`, `mfaSessionExpired`, `networkError`
  - `RemoveMFA.constants.ts`: Updated error messages to use keys like `invalidRecoveryCode`, `recoveryCodeAlreadyUsed`, `tooManyAttempts`
  - `ViewRecoveryCodes.utils.ts`: Updated error messages to use translation keys
- **Translation Files**: Added new `mfaAlreadyEnabled` translation key in both `app-en.json` and `app-fr.json`
- **ViewRecoveryCodes Hook**: Fixed two hardcoded "Session expired. Please try again." messages to use `mfaSessionExpired` translation key
- **Identity Confirmation Components**: Ensured `ConfirmIdentityVerificationCode` and `ConfirmIdentityRecoveryCode` properly translate errors


### 🪤 Peer Testing

1. **Log in** to the application
2. **Navigate** to Account Settings → MFA section
3. **Change language** to French using the language selector
4. **Enable MFA** and enter an incorrect verification code

    **Expected outcome:** Error message should appear in French: "Code de vérification invalide"

5. **Try to view recovery codes** with an incorrect code

    **Expected outcome:** Error message should appear in French: "Code invalide"

6. **Try to disable MFA** with an incorrect recovery code

    **Expected outcome:** Error message should appear in French: "Code de récupération invalide"

7. **Wait for session to expire** during any MFA flow

    **Expected outcome:** Error message should appear in French: "Votre session a expiré. Veuillez vous reconnecter."
