### PR TITLE
  feat(M2-9858): Add Unity media export support    

### DIFF
--- a/src/shared/consts.tsx
+++ b/src/shared/consts.tsx
@@ -169,6 +169,7 @@ export const ItemsWithFileResponses = [
   ItemResponseType.Photo,
   ItemResponseType.Video,
   ItemResponseType.Audio,
+  ItemResponseType.Unity,
 ];
 
 export enum CalculationType {

--- a/src/shared/mock/index.ts
+++ b/src/shared/mock/index.ts
@@ -3341,6 +3341,99 @@ export const mockedDecryptedObjectForAudio = {
   subscaleSetting: null,
 };
 
+export const mockedUnitySettings = {
+  question: '',
+  responseType: 'unity',
+  responseValues: null,
+  config: {
+    removeBackButton: false,
+    skippableItem: false,
+    additionalResponseOption: {
+      textInputOption: false,
+      textInputRequired: false,
+    },
+    timer: 0,
+  },
+  name: 'unity_mobile',
+  isHidden: false,
+  conditionalLogic: null,
+  allowEdit: true,
+  id: 'a1b2c3d4-5678-9012-3456-789012345678',
+};
+export const mockedDecryptedAnswerForUnityString = {
+  value: 'https://media-dev.cmiml.net/mindlogger/2048412251058983019/unity/unity_config.txt',
+};
+export const mockedDecryptedObjectForUnityString = {
+  activityItem: mockedUnitySettings,
+  answer: mockedDecryptedAnswerForUnityString,
+  id: 'unity-answer-id-1',
+  submitId: 'becbb3e7-3e29-4b27-a224-85ee4db54c86',
+  version: '2.0.0',
+  respondentId: '835e5277-5949-4dff-817a-d85c17a3604f',
+  respondentSecretId: 'respondentSecretId',
+  sourceSubjectId: 'bba7bcd3-f245-4354-9461-b494f186dcca',
+  sourceSecretId: 'source-secret-id',
+  targetSubjectId: '116d59c1-2bb5-405b-8503-cb6c1e6b7620',
+  targetSecretId: 'target-secret-id',
+  legacyProfileId: null,
+  scheduledDatetime: null,
+  startDatetime: 1689755822,
+  endDatetime: 1689756087,
+  migratedDate: null,
+  appletHistoryId: '7aa07032-93f5-41aa-a4e1-b24d92405bc0_2.0.0',
+  activityHistoryId: '62e7e2c2-9fdb-4f2f-8460-78375a657f57_2.0.0',
+  flowHistoryId: null,
+  flowName: null,
+  reviewedAnswerId: null,
+  createdAt: '2023-07-19T08:41:37.130943',
+  appletId: '7aa07032-93f5-41aa-a4e1-b24d92405bc0',
+  activityId: '62e7e2c2-9fdb-4f2f-8460-78375a657f57',
+  flowId: null,
+  items: [mockedUnitySettings],
+  activityName: 'New Activity#1',
+  subscaleSetting: null,
+};
+
+export const mockedDecryptedAnswerForUnityTaskData = {
+  value: {
+    taskData: [
+      'https://media-dev.cmiml.net/mindlogger/2048412251058983019/unity/data1.txt',
+      'https://media-dev.cmiml.net/mindlogger/2048412251058983019/unity/data2.txt',
+      'https://media-dev.cmiml.net/mindlogger/2048412251058983019/unity/data3.txt',
+    ],
+  },
+};
+export const mockedDecryptedObjectForUnityTaskData = {
+  activityItem: mockedUnitySettings,
+  answer: mockedDecryptedAnswerForUnityTaskData,
+  id: 'unity-answer-id-2',
+  submitId: 'becbb3e7-3e29-4b27-a224-85ee4db54c86',
+  version: '2.0.0',
+  respondentId: '835e5277-5949-4dff-817a-d85c17a3604f',
+  respondentSecretId: 'respondentSecretId',
+  sourceSubjectId: 'bba7bcd3-f245-4354-9461-b494f186dcca',
+  sourceSecretId: 'source-secret-id',
+  targetSubjectId: '116d59c1-2bb5-405b-8503-cb6c1e6b7620',
+  targetSecretId: 'target-secret-id',
+  legacyProfileId: null,
+  scheduledDatetime: null,
+  startDatetime: 1689755822,
+  endDatetime: 1689756087,
+  migratedDate: null,
+  appletHistoryId: '7aa07032-93f5-41aa-a4e1-b24d92405bc0_2.0.0',
+  activityHistoryId: '62e7e2c2-9fdb-4f2f-8460-78375a657f57_2.0.0',
+  flowHistoryId: null,
+  flowName: null,
+  reviewedAnswerId: null,
+  createdAt: '2023-07-19T08:41:37.130943',
+  appletId: '7aa07032-93f5-41aa-a4e1-b24d92405bc0',
+  activityId: '62e7e2c2-9fdb-4f2f-8460-78375a657f57',
+  flowId: null,
+  items: [mockedUnitySettings],
+  activityName: 'New Activity#1',
+  subscaleSetting: null,
+};
+
 export const mockedAlert = {
   id: 'dcc07d2a-617c-43af-8e5a-0dcb1564d5e0',
   isWatched: true,

--- a/src/shared/types/answer.ts
+++ b/src/shared/types/answer.ts
@@ -29,6 +29,7 @@ import {
   TimeRangeItem,
   TouchPracticeItem,
   TouchTestItem,
+  UnityItem,
   VideoItem,
 } from 'shared/state';
 import { getJourneyCSVObject } from 'shared/utils/exportData/getJourneyCSVObject';
@@ -181,6 +182,12 @@ type CachedMediaValue = {
 
 export type DecryptedMediaAnswer = AdditionalTextType & {
   value: string | CachedMediaValue;
+};
+
+export type DecryptedUnityAnswer = {
+  value: {
+    taskData: string[];
+  };
 };
 
 export type DecryptedDateRangeAnswer = AdditionalTextType & {
@@ -360,7 +367,8 @@ export type AnswerDTO =
   | DecryptedABTrailsAnswer
   | DecryptedStabilityTrackerAnswer
   | DecryptedFlankerAnswer
-  | DecryptedRequestHealthRecordDataAnswer;
+  | DecryptedRequestHealthRecordDataAnswer
+  | DecryptedUnityAnswer;
 
 export type AnswerValue =
   | null
@@ -435,7 +443,8 @@ export type ActivityItemAnswer =
   | MessageItemAnswer
   | TouchPracticeItemAnswer
   | TouchTestItemAnswer
-  | RequestHealthRecordDataAnswer;
+  | RequestHealthRecordDataAnswer
+  | UnityItemAnswer;
 
 type ActivityItemAnswerCommonType = {
   id?: string;
@@ -489,6 +498,10 @@ export type AudioItemAnswer = ActivityItemAnswerCommonType & {
 export type PhotoItemAnswer = ActivityItemAnswerCommonType & {
   activityItem: PhotoItem;
   answer: DecryptedMediaAnswer;
+};
+export type UnityItemAnswer = ActivityItemAnswerCommonType & {
+  activityItem: UnityItem;
+  answer: DecryptedUnityAnswer;
 };
 export type VideoItemAnswer = ActivityItemAnswerCommonType & {
   activityItem: VideoItem;
@@ -600,6 +613,7 @@ export type AppletExportData = {
   stabilityTrackerItemsData: ExportCsvData[];
   abTrailsItemsData: ExportCsvData[];
   flankerItemsData: ExportCsvData[];
+  unityData: ExportMediaData[];
 };
 
 export type ExportMediaData = {

--- a/src/shared/types/answer.ts
+++ b/src/shared/types/answer.ts
@@ -185,9 +185,12 @@ export type DecryptedMediaAnswer = AdditionalTextType & {
 };
 
 export type DecryptedUnityAnswer = {
-  value: {
-    taskData: string[];
-  };
+  value:
+    | {
+        taskData: string[];
+      }
+    | string
+    | CachedMediaValue;
 };
 
 export type DecryptedDateRangeAnswer = AdditionalTextType & {

--- a/src/shared/types/answer.ts
+++ b/src/shared/types/answer.ts
@@ -189,6 +189,7 @@ export type DecryptedUnityAnswer = {
     | {
         taskData: string[];
       }
+    | string[]
     | string
     | CachedMediaValue;
 };

--- a/src/shared/types/guards.ts
+++ b/src/shared/types/guards.ts
@@ -8,6 +8,7 @@ import {
   ExtendedExportAnswerWithoutEncryption,
   PhotoItemAnswer,
   RequestHealthRecordDataAnswer,
+  UnityItemAnswer,
   VideoItemAnswer,
 } from 'shared/types/answer';
 
@@ -34,6 +35,18 @@ export const isMediaAnswerData = (
   ExtendedExportAnswerWithoutEncryption,
   AudioItemAnswer | PhotoItemAnswer | VideoItemAnswer
 > => ItemsWithFileResponses.includes(item.activityItem?.responseType);
+
+export const isNotUnityAnswerData = (
+  item: DecryptedAnswerData,
+): item is DecryptedAnswerData<
+  ExtendedExportAnswerWithoutEncryption,
+  Exclude<ActivityItemAnswer, UnityItemAnswer>
+> => item.activityItem?.responseType !== ItemResponseType.Unity || !item.answer;
+
+export const isUnityAnswerData = (
+  item: DecryptedAnswerData,
+): item is DecryptedAnswerData<ExtendedExportAnswerWithoutEncryption, UnityItemAnswer> =>
+  item.activityItem?.responseType === ItemResponseType.Unity;
 
 export const isRequestHealthRecordDataAnswerData = (
   item: DecryptedAnswerData,

--- a/src/shared/types/guards.ts
+++ b/src/shared/types/guards.ts
@@ -34,7 +34,9 @@ export const isMediaAnswerData = (
 ): item is DecryptedAnswerData<
   ExtendedExportAnswerWithoutEncryption,
   AudioItemAnswer | PhotoItemAnswer | VideoItemAnswer
-> => ItemsWithFileResponses.includes(item.activityItem?.responseType);
+> =>
+  ItemsWithFileResponses.includes(item.activityItem?.responseType) &&
+  item.activityItem?.responseType !== ItemResponseType.Unity;
 
 export const isNotUnityAnswerData = (
   item: DecryptedAnswerData,

--- a/src/shared/utils/exportData/exportDataSucceed.test.ts
+++ b/src/shared/utils/exportData/exportDataSucceed.test.ts
@@ -89,11 +89,16 @@ describe('exportDataSucceed', () => {
       [],
       'flanker-responses-Sat Jan 01 2000-test.zip',
     );
-    expect(exportMediaZipUtils.exportMediaZip).toHaveBeenCalledTimes(1);
+    expect(exportMediaZipUtils.exportMediaZip).toHaveBeenCalledTimes(2);
     expect(exportMediaZipUtils.exportMediaZip).toHaveBeenNthCalledWith(
       1,
       [],
       'media-responses-Sat Jan 01 2000-test.zip',
+    );
+    expect(exportMediaZipUtils.exportMediaZip).toHaveBeenNthCalledWith(
+      2,
+      [],
+      'unity-responses-Sat Jan 01 2000-test.zip',
     );
   };
 

--- a/src/shared/utils/exportData/exportDataSucceed.ts
+++ b/src/shared/utils/exportData/exportDataSucceed.ts
@@ -30,6 +30,7 @@ const exportProcessedData = async ({
   stabilityTrackerItemsData,
   abTrailsItemsData,
   flankerItemsData,
+  unityData,
   suffix,
   flags,
 }: AppletExportData & { suffix: string; flags: FeatureFlags }) => {
@@ -55,6 +56,7 @@ const exportProcessedData = async ({
     exportCsvZip(abTrailsItemsData, getReportZipName(ZipFile.ABTrails, suffix)),
     exportCsvZip(flankerItemsData, getReportZipName(ZipFile.Flanker, suffix)),
     exportMediaZip(mediaData, getReportZipName(ZipFile.Media, suffix)),
+    exportMediaZip(unityData, getReportZipName(ZipFile.Unity, suffix)),
   ]);
 };
 

--- a/src/shared/utils/exportData/getDecryptedAnswers.ts
+++ b/src/shared/utils/exportData/getDecryptedAnswers.ts
@@ -78,6 +78,9 @@ export const getDecryptedAnswers = async <T extends EncryptedAnswerSharedProps>(
         console.warn('Error while answer parsing:', error);
       }
     }
+
+    console.log('🔐 [DECRYPTION COMPLETE] Decrypted Answers:', answersDecrypted);
+    console.log('🔐 [DECRYPTION COMPLETE] Decrypted Events:', eventsDecrypted);
   }
 
   /*
@@ -163,6 +166,7 @@ export const getDecryptedAnswers = async <T extends EncryptedAnswerSharedProps>(
     },
     [],
   );
+  console.log('🔐 [DECRYPTION COMPLETE] Decrypted Events:', eventsDecrypted, answerDataDecrypted);
 
   return {
     decryptedAnswers: answerDataDecrypted,

--- a/src/shared/utils/exportData/getDecryptedAnswers.ts
+++ b/src/shared/utils/exportData/getDecryptedAnswers.ts
@@ -78,9 +78,6 @@ export const getDecryptedAnswers = async <T extends EncryptedAnswerSharedProps>(
         console.warn('Error while answer parsing:', error);
       }
     }
-
-    console.log('🔐 [DECRYPTION COMPLETE] Decrypted Answers:', answersDecrypted);
-    console.log('🔐 [DECRYPTION COMPLETE] Decrypted Events:', eventsDecrypted);
   }
 
   /*
@@ -166,7 +163,6 @@ export const getDecryptedAnswers = async <T extends EncryptedAnswerSharedProps>(
     },
     [],
   );
-  console.log('🔐 [DECRYPTION COMPLETE] Decrypted Events:', eventsDecrypted, answerDataDecrypted);
 
   return {
     decryptedAnswers: answerDataDecrypted,

--- a/src/shared/utils/exportData/getReportAndMediaData.test.ts
+++ b/src/shared/utils/exportData/getReportAndMediaData.test.ts
@@ -1032,15 +1032,15 @@ describe('getReportAndMediaData', () => {
       const result = getUnityData([], [mockedDecryptedObjectForUnityTaskData]);
       expect(result).toEqual([
         {
-          fileName: 'target-secret-id-unity-answer-id-2-unity_mobile/0.txt',
+          fileName: 'target-secret-id-unity-answer-id-2-unity_mobile/data1.txt',
           url: 'https://media-dev.cmiml.net/mindlogger/2048412251058983019/unity/data1.txt',
         },
         {
-          fileName: 'target-secret-id-unity-answer-id-2-unity_mobile/1.txt',
+          fileName: 'target-secret-id-unity-answer-id-2-unity_mobile/data2.txt',
           url: 'https://media-dev.cmiml.net/mindlogger/2048412251058983019/unity/data2.txt',
         },
         {
-          fileName: 'target-secret-id-unity-answer-id-2-unity_mobile/2.txt',
+          fileName: 'target-secret-id-unity-answer-id-2-unity_mobile/data3.txt',
           url: 'https://media-dev.cmiml.net/mindlogger/2048412251058983019/unity/data3.txt',
         },
       ]);

--- a/src/shared/utils/exportData/getReportAndMediaData.test.ts
+++ b/src/shared/utils/exportData/getReportAndMediaData.test.ts
@@ -5,6 +5,7 @@ import {
   mockedDecryptedObjectForDrawing,
   mockedDecryptedObjectForPhoto,
   mockedDecryptedObjectForVideo,
+  mockedDecryptedObjectForUnityTaskData,
   mockedParsedAnswers,
 } from 'shared/mock';
 import { DecryptedAnswerData, UserActionType } from 'shared/types';
@@ -17,6 +18,7 @@ import {
   getDecryptedAnswersObject,
   getMediaData,
   getReportData,
+  getUnityData,
 } from './getReportAndMediaData';
 
 describe('getReportAndMediaData', () => {
@@ -1012,6 +1014,44 @@ describe('getReportAndMediaData', () => {
           legacy_user_id: null,
         },
       ]);
+    });
+  });
+  describe('getUnityData', () => {
+    const answersForRegularItems = mockedParsedAnswers[0].decryptedAnswers;
+
+    test('should return empty array for non-unity items', () => {
+      //eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      //@ts-ignore
+      const result = getUnityData([], answersForRegularItems);
+      expect(result).toEqual([]);
+    });
+
+    test('should return unity data for taskData format', () => {
+      //eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      //@ts-ignore
+      const result = getUnityData([], [mockedDecryptedObjectForUnityTaskData]);
+      expect(result).toEqual([
+        {
+          fileName: 'target-secret-id-unity-answer-id-2-unity_mobile.txt',
+          url: 'https://media-dev.cmiml.net/mindlogger/2048412251058983019/unity/data1.txt',
+        },
+        {
+          fileName: 'target-secret-id-unity-answer-id-2-unity_mobile.txt',
+          url: 'https://media-dev.cmiml.net/mindlogger/2048412251058983019/unity/data2.txt',
+        },
+        {
+          fileName: 'target-secret-id-unity-answer-id-2-unity_mobile.txt',
+          url: 'https://media-dev.cmiml.net/mindlogger/2048412251058983019/unity/data3.txt',
+        },
+      ]);
+    });
+
+    test('should accumulate with existing unity data', () => {
+      const existing = [{ fileName: 'existing.txt', url: 'existing-url' }];
+      //eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      //@ts-ignore
+      const result = getUnityData(existing, [mockedDecryptedObjectForUnityTaskData]);
+      expect(result.length).toBe(4);
     });
   });
   describe('checkIfHasGithubImportedEventScreen', () => {

--- a/src/shared/utils/exportData/getReportAndMediaData.test.ts
+++ b/src/shared/utils/exportData/getReportAndMediaData.test.ts
@@ -1032,15 +1032,15 @@ describe('getReportAndMediaData', () => {
       const result = getUnityData([], [mockedDecryptedObjectForUnityTaskData]);
       expect(result).toEqual([
         {
-          fileName: 'target-secret-id-unity-answer-id-2-unity_mobile.txt',
+          fileName: 'target-secret-id-unity-answer-id-2-unity_mobile/0.txt',
           url: 'https://media-dev.cmiml.net/mindlogger/2048412251058983019/unity/data1.txt',
         },
         {
-          fileName: 'target-secret-id-unity-answer-id-2-unity_mobile.txt',
+          fileName: 'target-secret-id-unity-answer-id-2-unity_mobile/1.txt',
           url: 'https://media-dev.cmiml.net/mindlogger/2048412251058983019/unity/data2.txt',
         },
         {
-          fileName: 'target-secret-id-unity-answer-id-2-unity_mobile.txt',
+          fileName: 'target-secret-id-unity-answer-id-2-unity_mobile/2.txt',
           url: 'https://media-dev.cmiml.net/mindlogger/2048412251058983019/unity/data3.txt',
         },
       ]);

--- a/src/shared/utils/exportData/getReportAndMediaData.ts
+++ b/src/shared/utils/exportData/getReportAndMediaData.ts
@@ -14,9 +14,9 @@ import {
 import { getReportCSVObject } from 'shared/utils/exportData/getReportCSVObject';
 import { getSubscales } from 'shared/utils/exportData/getSubscales';
 import { getFileExtension, getMediaFileName } from 'shared/utils/exportData/getReportName';
-import { ItemsWithFileResponses } from 'shared/consts';
+import { ItemResponseType, ItemsWithFileResponses } from 'shared/consts';
 import { getJourneyCSVObject, getSplashScreen } from 'shared/utils/exportData/getJourneyCSVObject';
-import { getDrawingUrl, getMediaUrl } from 'shared/utils/exportData/getUrls';
+import { getDrawingUrl, getMediaUrl, getUnityMediaUrls } from 'shared/utils/exportData/getUrls';
 import { FeatureFlags } from 'shared/types/featureFlags';
 
 import { getObjectFromList } from '../getObjectFromList';
@@ -96,6 +96,28 @@ export const getMediaData = (
   }, [] as ExportMediaData[]);
 
   return mediaData.concat(...mediaAnswers);
+};
+
+export const getUnityData = (
+  unityData: AppletExportData['unityData'],
+  decryptedAnswers: DecryptedAnswerData[],
+): ExportMediaData[] => {
+  const unityAnswers = decryptedAnswers.reduce((filteredAcc, item) => {
+    const responseType = item.activityItem?.responseType;
+
+    if (responseType !== ItemResponseType.Unity) {
+      return filteredAcc;
+    }
+
+    const mediaData = getUnityMediaUrls(item).map((url) => ({
+      fileName: getMediaFileName(item, getFileExtension(url)),
+      url,
+    }));
+
+    return filteredAcc.concat(mediaData);
+  }, [] as ExportMediaData[]);
+
+  return unityData.concat(...unityAnswers);
 };
 
 export const searchItemNameInUrlScreen = (screen: string) => screen.split('/').pop() ?? '';

--- a/src/shared/utils/exportData/getReportAndMediaData.ts
+++ b/src/shared/utils/exportData/getReportAndMediaData.ts
@@ -121,7 +121,6 @@ export const getUnityData = (
   }, [] as ExportMediaData[]);
 
   const result = unityData.concat(...unityAnswers);
-  console.log('🎮 [UNITY MULTI-FILE] Total Unity files to zip:', result.length, result);
 
   return result;
 };

--- a/src/shared/utils/exportData/getReportAndMediaData.ts
+++ b/src/shared/utils/exportData/getReportAndMediaData.ts
@@ -120,7 +120,10 @@ export const getUnityData = (
     return filteredAcc.concat(mediaData);
   }, [] as ExportMediaData[]);
 
-  return unityData.concat(...unityAnswers);
+  const result = unityData.concat(...unityAnswers);
+  console.log('🎮 [UNITY MULTI-FILE] Total Unity files to zip:', result.length, result);
+
+  return result;
 };
 
 export const searchItemNameInUrlScreen = (screen: string) => screen.split('/').pop() ?? '';

--- a/src/shared/utils/exportData/getReportAndMediaData.ts
+++ b/src/shared/utils/exportData/getReportAndMediaData.ts
@@ -111,8 +111,9 @@ export const getUnityData = (
       return filteredAcc;
     }
 
-    const mediaData = getUnityMediaUrls(item).map((url) => ({
-      fileName: getMediaFileName(item, getFileExtension(url)),
+    const folderName = `${item.targetSecretId}-${item.id}-${item.activityItem.name}`;
+    const mediaData = getUnityMediaUrls(item).map((url: string, index: number) => ({
+      fileName: `${folderName}/${index}.${getFileExtension(url)}`,
       url,
     }));
 

--- a/src/shared/utils/exportData/getReportAndMediaData.ts
+++ b/src/shared/utils/exportData/getReportAndMediaData.ts
@@ -112,10 +112,14 @@ export const getUnityData = (
     }
 
     const folderName = `${item.targetSecretId}-${item.id}-${item.activityItem.name}`;
-    const mediaData = getUnityMediaUrls(item).map((url: string, index: number) => ({
-      fileName: `${folderName}/${index}.${getFileExtension(url)}`,
-      url,
-    }));
+    const mediaData = getUnityMediaUrls(item).map((url: string, index: number) => {
+      const urlFileName = url.split('?')[0].split('/').pop() ?? '';
+
+      return {
+        fileName: `${folderName}/${urlFileName || `${index}.${getFileExtension(url)}`}`,
+        url,
+      };
+    });
 
     return filteredAcc.concat(mediaData);
   }, [] as ExportMediaData[]);

--- a/src/shared/utils/exportData/getReportName.ts
+++ b/src/shared/utils/exportData/getReportName.ts
@@ -6,6 +6,7 @@ export const enum ZipFile {
   StabilityTracker = 'stability-tracker',
   ABTrails = 'trails',
   Flanker = 'flanker',
+  Unity = 'unity',
 }
 
 export const getReportZipName = (name: ZipFile, suffix: string) =>

--- a/src/shared/utils/exportData/getUrls.ts
+++ b/src/shared/utils/exportData/getUrls.ts
@@ -1,6 +1,7 @@
 import {
   DecryptedAnswerData,
   DecryptedMediaAnswer,
+  DecryptedUnityAnswer,
   DrawingItemAnswer,
   ExtendedExportAnswerWithoutEncryption,
 } from 'shared/types';
@@ -20,5 +21,18 @@ export const getMediaUrl = (item: DecryptedAnswerData) => {
   const answer = item.answer as DecryptedMediaAnswer;
   if (!answer) return '';
 
-  return typeof answer.value === 'string' ? answer.value : '';
+  if (typeof answer.value === 'string') {
+    return answer.value;
+  } else if (Array.isArray(answer.value)) {
+    return answer.value[0];
+  }
+
+  return '';
+};
+
+export const getUnityMediaUrls = (item: DecryptedAnswerData) => {
+  const answer = item.answer as DecryptedUnityAnswer;
+  if (!answer || !answer.value?.taskData?.length) return [];
+
+  return answer.value.taskData;
 };

--- a/src/shared/utils/exportData/getUrls.ts
+++ b/src/shared/utils/exportData/getUrls.ts
@@ -34,14 +34,19 @@ export const getMediaUrl = (item: DecryptedAnswerData) => {
 
 export const getUnityMediaUrls = (item: DecryptedAnswerData) => {
   const answer = item.answer as DecryptedUnityAnswer;
-  if (
-    !answer ||
-    !answer.value ||
-    typeof answer.value === 'string' ||
-    !('taskData' in answer.value) ||
-    !answer.value.taskData?.length
-  )
-    return [];
+  if (!answer || !answer.value) return [];
 
-  return answer.value.taskData;
+  // Handle direct array of S3 URLs (actual format from mobile app decryption)
+  if (Array.isArray(answer.value)) {
+    return answer.value.filter((url): url is string => typeof url === 'string');
+  }
+
+  if (typeof answer.value === 'string') return [];
+
+  // Handle { taskData: string[] } format (after URL presigning replaces the value)
+  if ('taskData' in answer.value && answer.value.taskData?.length) {
+    return answer.value.taskData;
+  }
+
+  return [];
 };

--- a/src/shared/utils/exportData/getUrls.ts
+++ b/src/shared/utils/exportData/getUrls.ts
@@ -25,6 +25,8 @@ export const getMediaUrl = (item: DecryptedAnswerData) => {
     return answer.value;
   } else if (Array.isArray(answer.value)) {
     return answer.value[0];
+  } else if (answer.value && typeof answer.value === 'object' && 'uri' in answer.value) {
+    return answer.value.uri || '';
   }
 
   return '';

--- a/src/shared/utils/exportData/getUrls.ts
+++ b/src/shared/utils/exportData/getUrls.ts
@@ -34,7 +34,14 @@ export const getMediaUrl = (item: DecryptedAnswerData) => {
 
 export const getUnityMediaUrls = (item: DecryptedAnswerData) => {
   const answer = item.answer as DecryptedUnityAnswer;
-  if (!answer || !answer.value?.taskData?.length) return [];
+  if (
+    !answer ||
+    !answer.value ||
+    typeof answer.value === 'string' ||
+    !('taskData' in answer.value) ||
+    !answer.value.taskData?.length
+  )
+    return [];
 
   return answer.value.taskData;
 };

--- a/src/shared/utils/exportData/parseResponseValue.test.ts
+++ b/src/shared/utils/exportData/parseResponseValue.test.ts
@@ -1667,6 +1667,116 @@ describe('parseResponseValue', () => {
       ).toBe(expected);
     });
   });
+  describe('unity activity', () => {
+    const index = 0;
+    const isEvent = false;
+    const mockedSharedDecryptedAnswerData = {
+      id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+      submitId: 'submit-id-unity',
+      version: '1.0.0',
+      respondentId: '835e5277-5949-4dff-817a-d85c17a3604f',
+      respondentSecretId: 'respondentSecretId',
+      sourceSubjectId: 'bba7bcd3-f245-4354-9461-b494f186dcca',
+      sourceSecretId: 'source-secret-id',
+      targetSubjectId: '116d59c1-2bb5-405b-8503-cb6c1e6b7620',
+      targetSecretId: 'target-secret-id',
+      legacyProfileId: null,
+      scheduledDatetime: null,
+      startDatetime: 1686925181,
+      endDatetime: 1686925280,
+      migratedDate: null,
+      appletHistoryId: '35f5085a-9972-449c-98e2-5a7637a1a7d7_1.0.0',
+      activityHistoryId: 'f21a80cb-c5a2-442b-a6b1-37af779908c7_1.0.0',
+      flowHistoryId: null,
+      flowName: null,
+      reviewedAnswerId: null,
+      createdAt: '2026-02-12T15:01:30.000000',
+      appletId: '35f5085a-9972-449c-98e2-5a7637a1a7d7',
+      activityId: 'f21a80cb-c5a2-442b-a6b1-37af779908c7',
+      flowId: null,
+      items: [],
+      activityName: 'Unity Activity',
+      subscaleSetting: null,
+    };
+    const unityItem = {
+      question: '',
+      responseType: ItemResponseType.Unity,
+      responseValues: null,
+      config: {},
+      name: 'unity_mobile',
+      isHidden: false,
+      conditionalLogic: null,
+      allowEdit: false,
+      id: 'unity-item-id',
+    };
+
+    test('unity with string[] value (direct S3 URLs)', () => {
+      const item = {
+        ...mockedSharedDecryptedAnswerData,
+        activityItem: unityItem,
+        answer: {
+          value: [
+            'https://media.cmiml.net/mindlogger/bucket/StartNodeData_2_12_2026_3_01_30_PM.txt?AWSAccessKeyId=xxx',
+            'https://media.cmiml.net/mindlogger/bucket/EndNodeData_2_12_2026_3_01_30_PM.txt?AWSAccessKeyId=xxx',
+            'https://media.cmiml.net/mindlogger/bucket/taskData_2_12_2026_3_01_30_PM.txt?AWSAccessKeyId=xxx',
+          ],
+        },
+      };
+      expect(
+        parseResponseValue(
+          // @ts-ignore
+          item as DecryptedAnswerData<ExtendedExportAnswerWithoutEncryption>,
+          index,
+          isEvent,
+        ),
+      ).toBe(
+        'target-secret-id-a1b2c3d4-e5f6-7890-abcd-ef1234567890-unity_mobile/StartNodeData_2_12_2026_3_01_30_PM.txt, EndNodeData_2_12_2026_3_01_30_PM.txt, taskData_2_12_2026_3_01_30_PM.txt',
+      );
+    });
+
+    test('unity with { taskData: string[] } value (after URL presigning)', () => {
+      const item = {
+        ...mockedSharedDecryptedAnswerData,
+        activityItem: unityItem,
+        answer: {
+          value: {
+            taskData: [
+              'https://media.cmiml.net/mindlogger/bucket/StartNodeData_2_12_2026_3_01_30_PM.txt',
+              'https://media.cmiml.net/mindlogger/bucket/EndNodeData_2_12_2026_3_01_30_PM.txt',
+            ],
+          },
+        },
+      };
+      expect(
+        parseResponseValue(
+          // @ts-ignore
+          item as DecryptedAnswerData<ExtendedExportAnswerWithoutEncryption>,
+          index,
+          isEvent,
+        ),
+      ).toBe(
+        'target-secret-id-a1b2c3d4-e5f6-7890-abcd-ef1234567890-unity_mobile/StartNodeData_2_12_2026_3_01_30_PM.txt, EndNodeData_2_12_2026_3_01_30_PM.txt',
+      );
+    });
+
+    test('unity with empty value returns folder name only', () => {
+      const item = {
+        ...mockedSharedDecryptedAnswerData,
+        activityItem: unityItem,
+        answer: {
+          value: null,
+        },
+      };
+      expect(
+        parseResponseValue(
+          // @ts-ignore
+          item as DecryptedAnswerData<ExtendedExportAnswerWithoutEncryption>,
+          index,
+          isEvent,
+        ),
+      ).toBe('target-secret-id-a1b2c3d4-e5f6-7890-abcd-ef1234567890-unity_mobile');
+    });
+  });
   describe('isNullAnswer', () => {
     test.each`
       obj             | result   | description

--- a/src/shared/utils/exportData/parseResponseValue.test.ts
+++ b/src/shared/utils/exportData/parseResponseValue.test.ts
@@ -1730,7 +1730,7 @@ describe('parseResponseValue', () => {
           isEvent,
         ),
       ).toBe(
-        'target-secret-id-a1b2c3d4-e5f6-7890-abcd-ef1234567890-unity_mobile/StartNodeData_2_12_2026_3_01_30_PM.txt, EndNodeData_2_12_2026_3_01_30_PM.txt, taskData_2_12_2026_3_01_30_PM.txt',
+        'target-secret-id-a1b2c3d4-e5f6-7890-abcd-ef1234567890-unity_mobile/StartNodeData_2_12_2026_3_01_30_PM.txt, target-secret-id-a1b2c3d4-e5f6-7890-abcd-ef1234567890-unity_mobile/EndNodeData_2_12_2026_3_01_30_PM.txt, target-secret-id-a1b2c3d4-e5f6-7890-abcd-ef1234567890-unity_mobile/taskData_2_12_2026_3_01_30_PM.txt',
       );
     });
 
@@ -1755,7 +1755,7 @@ describe('parseResponseValue', () => {
           isEvent,
         ),
       ).toBe(
-        'target-secret-id-a1b2c3d4-e5f6-7890-abcd-ef1234567890-unity_mobile/StartNodeData_2_12_2026_3_01_30_PM.txt, EndNodeData_2_12_2026_3_01_30_PM.txt',
+        'target-secret-id-a1b2c3d4-e5f6-7890-abcd-ef1234567890-unity_mobile/StartNodeData_2_12_2026_3_01_30_PM.txt, target-secret-id-a1b2c3d4-e5f6-7890-abcd-ef1234567890-unity_mobile/EndNodeData_2_12_2026_3_01_30_PM.txt',
       );
     });
 

--- a/src/shared/utils/exportData/parseResponseValue.ts
+++ b/src/shared/utils/exportData/parseResponseValue.ts
@@ -185,9 +185,12 @@ export const parseResponseValueRaw = <T extends DecryptedAnswerData>(
     case ItemResponseType.Unity: {
       const folderName = `${item.targetSecretId}-${item.id}-${item.activityItem.name}`;
       const urls = getUnityMediaUrls(item);
-      const fileNames = urls.map((url) => url.split('?')[0].split('/').pop()).filter(Boolean);
+      const filePaths = urls
+        .map((url) => url.split('?')[0].split('/').pop())
+        .filter(Boolean)
+        .map((fileName) => `${folderName}/${fileName}`);
 
-      return fileNames.length ? `${folderName}/${fileNames.join(', ')}` : folderName;
+      return filePaths.length ? filePaths.join(', ') : folderName;
     }
     /*
       Item list as default case:

--- a/src/shared/utils/exportData/parseResponseValue.ts
+++ b/src/shared/utils/exportData/parseResponseValue.ts
@@ -28,6 +28,7 @@ import {
   getMediaFileName,
   getStabilityTrackerCsvName,
 } from './getReportName';
+import { getUnityMediaUrls } from './getUrls';
 import { joinWihComma } from '../joinWihComma';
 import { getAnswerValue } from '../getAnswerValue';
 
@@ -181,6 +182,13 @@ export const parseResponseValueRaw = <T extends DecryptedAnswerData>(
       );
     case ItemResponseType.Flanker:
       return getFlankerCsvName(item);
+    case ItemResponseType.Unity: {
+      const folderName = `${item.targetSecretId}-${item.id}-${item.activityItem.name}`;
+      const urls = getUnityMediaUrls(item);
+      const fileNames = urls.map((url) => url.split('?')[0].split('/').pop()).filter(Boolean);
+
+      return fileNames.length ? `${folderName}/${fileNames.join(', ')}` : folderName;
+    }
     /*
       Item list as default case:
       - 'singleSelect',

--- a/src/shared/utils/exportData/prepareData.test.ts
+++ b/src/shared/utils/exportData/prepareData.test.ts
@@ -135,6 +135,7 @@ const mockedExportDataResult = {
   stabilityTrackerItemsData: [],
   abTrailsItemsData: [],
   flankerItemsData: [],
+  unityData: [],
 };
 
 describe('prepareData', () => {
@@ -150,6 +151,7 @@ describe('prepareData', () => {
     expect(result).toHaveProperty('stabilityTrackerItemsData');
     expect(result).toHaveProperty('abTrailsItemsData');
     expect(result).toHaveProperty('flankerItemsData');
+    expect(result).toHaveProperty('unityData');
     expect(result.reportData).toEqual([]);
     expect(result.activityJourneyData).toEqual([]);
     expect(result.mediaData).toEqual([]);
@@ -157,6 +159,7 @@ describe('prepareData', () => {
     expect(result.stabilityTrackerItemsData).toEqual([]);
     expect(result.abTrailsItemsData).toEqual([]);
     expect(result.flankerItemsData).toEqual([]);
+    expect(result.unityData).toEqual([]);
   };
 
   test('prepareEncryptedData should return an object with the correct keys', async () => {

--- a/src/shared/utils/exportData/prepareData.ts
+++ b/src/shared/utils/exportData/prepareData.ts
@@ -19,7 +19,12 @@ import {
   getFlankerItemsData,
   getStabilityTrackerItemsData,
 } from './getItemsData';
-import { getActivityJourneyData, getMediaData, getReportData } from './getReportAndMediaData';
+import {
+  getActivityJourneyData,
+  getMediaData,
+  getReportData,
+  getUnityData,
+} from './getReportAndMediaData';
 import { logDataInDebugMode } from '../logger';
 
 export interface ExportDataFilters {
@@ -37,6 +42,7 @@ export const getDefaultExportData = (): AppletExportData => ({
   stabilityTrackerItemsData: [],
   abTrailsItemsData: [],
   flankerItemsData: [],
+  unityData: [],
 });
 
 export const getParsedAnswersFilterFn = (filters?: ExportDataFilters) => {
@@ -98,6 +104,8 @@ export const prepareDecryptedData = async (
     );
     const flankerItemsData = await getFlankerItemsData(acc.flankerItemsData, data.decryptedAnswers);
 
+    const unityData = getUnityData(acc.unityData, data.decryptedAnswers);
+
     acc = {
       reportData,
       activityJourneyData,
@@ -106,6 +114,7 @@ export const prepareDecryptedData = async (
       stabilityTrackerItemsData,
       abTrailsItemsData,
       flankerItemsData,
+      unityData,
     };
   }
 

--- a/src/shared/utils/getParsedAnswers.test.ts
+++ b/src/shared/utils/getParsedAnswers.test.ts
@@ -7,6 +7,11 @@ import { mockSuccessfulHttpResponse } from './axios-mocks';
 // Mock the api module
 vi.mock('api');
 
+const getAnswerValue = (answer: unknown) =>
+  typeof answer === 'object' && answer !== null && 'value' in answer
+    ? (answer as { value: unknown }).value
+    : undefined;
+
 describe('getParsedAnswers', () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -220,6 +225,36 @@ describe('getParsedAnswers', () => {
       ]);
     });
 
+    test('should handle unity items with string URL', async () => {
+      vi.mocked(axios.post).mockResolvedValue(
+        mockSuccessfulHttpResponse({
+          result: ['publicUnityUrl'],
+        }),
+      );
+
+      const parsedAnswers = [
+        {
+          decryptedAnswers: [
+            {
+              appletId: 'appletId',
+              activityItem: {
+                name: 'unity',
+                responseType: 'unity',
+              },
+              answer: {
+                value: 'private_unity_url',
+              },
+            },
+          ],
+          decryptedEvents: [],
+        },
+      ];
+      // @ts-ignore
+      const result = await getAnswersWithPublicUrls(parsedAnswers);
+
+      expect(getAnswerValue(result[0].decryptedAnswers[0].answer)).toBe('publicUnityUrl');
+    });
+
     test('should handle unity items with taskData URLs', async () => {
       vi.mocked(axios.post).mockResolvedValue(
         mockSuccessfulHttpResponse({
@@ -259,8 +294,8 @@ describe('getParsedAnswers', () => {
       // @ts-ignore
       const result = await getAnswersWithPublicUrls(parsedAnswers);
 
-      expect(result[0].decryptedAnswers[0].answer.value).toBe('publicAudioUrl');
-      expect(result[0].decryptedAnswers[1].answer.value).toEqual({
+      expect(getAnswerValue(result[0].decryptedAnswers[0].answer)).toBe('publicAudioUrl');
+      expect(getAnswerValue(result[0].decryptedAnswers[1].answer)).toEqual({
         taskData: ['publicUnity1', 'publicUnity2', 'publicUnity3'],
       });
     });
@@ -315,13 +350,13 @@ describe('getParsedAnswers', () => {
       const result = await getAnswersWithPublicUrls(parsedAnswers);
 
       // Unity consumes indices 0,1
-      expect(result[0].decryptedAnswers[0].answer.value).toEqual({
+      expect(getAnswerValue(result[0].decryptedAnswers[0].answer)).toEqual({
         taskData: ['publicUnity1', 'publicUnity2'],
       });
       // Audio gets index 2
-      expect(result[0].decryptedAnswers[1].answer.value).toBe('publicAudio');
+      expect(getAnswerValue(result[0].decryptedAnswers[1].answer)).toBe('publicAudio');
       // Photo gets index 3
-      expect(result[0].decryptedAnswers[2].answer.value).toBe('publicPhoto');
+      expect(getAnswerValue(result[0].decryptedAnswers[2].answer)).toBe('publicPhoto');
     });
   });
 });

--- a/src/shared/utils/getParsedAnswers.test.ts
+++ b/src/shared/utils/getParsedAnswers.test.ts
@@ -219,5 +219,109 @@ describe('getParsedAnswers', () => {
         },
       ]);
     });
+
+    test('should handle unity items with taskData URLs', async () => {
+      vi.mocked(axios.post).mockResolvedValue(
+        mockSuccessfulHttpResponse({
+          result: ['publicAudioUrl', 'publicUnity1', 'publicUnity2', 'publicUnity3'],
+        }),
+      );
+
+      const parsedAnswers = [
+        {
+          decryptedAnswers: [
+            {
+              appletId: 'appletId',
+              activityItem: {
+                name: 'audio',
+                responseType: 'audio',
+              },
+              answer: {
+                value: 'private_audio_url',
+              },
+            },
+            {
+              appletId: 'appletId',
+              activityItem: {
+                name: 'unity',
+                responseType: 'unity',
+              },
+              answer: {
+                value: {
+                  taskData: ['private_unity1', 'private_unity2', 'private_unity3'],
+                },
+              },
+            },
+          ],
+          decryptedEvents: [],
+        },
+      ];
+      // @ts-ignore
+      const result = await getAnswersWithPublicUrls(parsedAnswers);
+
+      expect(result[0].decryptedAnswers[0].answer.value).toBe('publicAudioUrl');
+      expect(result[0].decryptedAnswers[1].answer.value).toEqual({
+        taskData: ['publicUnity1', 'publicUnity2', 'publicUnity3'],
+      });
+    });
+
+    test('should maintain URL index sync with mixed unity and media items', async () => {
+      vi.mocked(axios.post).mockResolvedValue(
+        mockSuccessfulHttpResponse({
+          result: ['publicUnity1', 'publicUnity2', 'publicAudio', 'publicPhoto'],
+        }),
+      );
+
+      const parsedAnswers = [
+        {
+          decryptedAnswers: [
+            {
+              appletId: 'appletId',
+              activityItem: {
+                name: 'unity',
+                responseType: 'unity',
+              },
+              answer: {
+                value: {
+                  taskData: ['priv1', 'priv2'],
+                },
+              },
+            },
+            {
+              appletId: 'appletId',
+              activityItem: {
+                name: 'audio',
+                responseType: 'audio',
+              },
+              answer: {
+                value: 'priv_audio',
+              },
+            },
+            {
+              appletId: 'appletId',
+              activityItem: {
+                name: 'photo',
+                responseType: 'photo',
+              },
+              answer: {
+                value: 'priv_photo',
+              },
+            },
+          ],
+          decryptedEvents: [],
+        },
+      ];
+      // @ts-ignore
+      const result = await getAnswersWithPublicUrls(parsedAnswers);
+
+      // Unity consumes indices 0,1
+      expect(result[0].decryptedAnswers[0].answer.value).toEqual({
+        taskData: ['publicUnity1', 'publicUnity2'],
+      });
+      // Audio gets index 2
+      expect(result[0].decryptedAnswers[1].answer.value).toBe('publicAudio');
+      // Photo gets index 3
+      expect(result[0].decryptedAnswers[2].answer.value).toBe('publicPhoto');
+    });
   });
 });

--- a/src/shared/utils/getParsedAnswers.ts
+++ b/src/shared/utils/getParsedAnswers.ts
@@ -7,12 +7,14 @@ import {
   ExtendedExportAnswerWithoutEncryption,
   FailedDecryption,
   isDrawingAnswerData,
+  isMediaAnswerData,
   isNotMediaAnswerData,
+  isUnityAnswerData,
 } from 'shared/types';
 import { useDecryptedActivityData } from 'modules/Dashboard/hooks';
 import { postFilePresignApi } from 'shared/api';
 
-import { getDrawingUrl, getMediaUrl } from './exportData/getUrls';
+import { getDrawingUrl, getMediaUrl, getUnityMediaUrls } from './exportData/getUrls';
 import { getObjectFromList } from './getObjectFromList';
 import { isSuccessEvent } from './exportData/getReportAndMediaData';
 
@@ -87,13 +89,18 @@ export const getAnswersWithPublicUrls = async (
   if (!parsedAnswers.length) return [];
 
   const privateUrls = parsedAnswers.reduce((acc, data) => {
-    const decryptedAnswers = data.decryptedAnswers.reduce((urlsAcc, item) => {
+    const decryptedAnswers = data.decryptedAnswers.reduce<string[]>((urlsAcc, item) => {
       if (shouldConvertPrivateDrawingUrl(item)) {
         return urlsAcc.concat(getDrawingUrl(item));
       }
-      if (isNotMediaAnswerData(item)) return urlsAcc;
 
-      return urlsAcc.concat(getMediaUrl(item));
+      if (isMediaAnswerData(item)) {
+        return urlsAcc.concat(getMediaUrl(item));
+      } else if (isUnityAnswerData(item)) {
+        return urlsAcc.concat(...getUnityMediaUrls(item));
+      } else {
+        return urlsAcc;
+      }
     }, [] as string[]);
 
     return acc.concat(decryptedAnswers);

--- a/src/shared/utils/getParsedAnswers.ts
+++ b/src/shared/utils/getParsedAnswers.ts
@@ -97,7 +97,12 @@ export const getAnswersWithPublicUrls = async (
       if (isMediaAnswerData(item)) {
         return urlsAcc.concat(getMediaUrl(item));
       } else if (isUnityAnswerData(item)) {
-        return urlsAcc.concat(...getUnityMediaUrls(item));
+        const unityUrls = getUnityMediaUrls(item);
+        if (unityUrls.length) {
+          return urlsAcc.concat(...unityUrls);
+        }
+
+        return urlsAcc.concat(getMediaUrl(item));
       } else {
         return urlsAcc;
       }
@@ -134,13 +139,23 @@ export const getAnswersWithPublicUrls = async (
         }
         if (isUnityAnswerData(item)) {
           const originalUrls = getUnityMediaUrls(item);
-          const publicTaskUrls = originalUrls.map(() => publicUrls[publicUrlIndex++] ?? '');
+          if (originalUrls.length) {
+            const publicTaskUrls = originalUrls.map(() => publicUrls[publicUrlIndex++] ?? '');
+
+            return decryptedAnswersAcc.concat({
+              ...item,
+              answer: {
+                ...item.answer,
+                value: { taskData: publicTaskUrls },
+              },
+            });
+          }
 
           return decryptedAnswersAcc.concat({
             ...item,
             answer: {
               ...item.answer,
-              value: { ...item.answer.value, taskData: publicTaskUrls },
+              value: publicUrls[publicUrlIndex++] ?? '',
             },
           });
         }

--- a/src/shared/utils/getParsedAnswers.ts
+++ b/src/shared/utils/getParsedAnswers.ts
@@ -94,6 +94,8 @@ export const getAnswersWithPublicUrls = async (
         return urlsAcc.concat(getDrawingUrl(item));
       }
 
+      if (!item.answer) return urlsAcc;
+
       if (isMediaAnswerData(item)) {
         return urlsAcc.concat(getMediaUrl(item));
       } else if (isUnityAnswerData(item)) {
@@ -137,6 +139,8 @@ export const getAnswersWithPublicUrls = async (
             },
           });
         }
+        if (!item.answer) return decryptedAnswersAcc.concat(item);
+
         if (isUnityAnswerData(item)) {
           const originalUrls = getUnityMediaUrls(item);
           if (originalUrls.length) {

--- a/src/shared/utils/getParsedAnswers.ts
+++ b/src/shared/utils/getParsedAnswers.ts
@@ -132,6 +132,19 @@ export const getAnswersWithPublicUrls = async (
             },
           });
         }
+        if (isUnityAnswerData(item)) {
+          const originalUrls = getUnityMediaUrls(item);
+          const publicTaskUrls = originalUrls.map(() => publicUrls[publicUrlIndex++] ?? '');
+
+          return decryptedAnswersAcc.concat({
+            ...item,
+            answer: {
+              ...item.answer,
+              value: { ...item.answer.value, taskData: publicTaskUrls },
+            },
+          });
+        }
+
         if (isNotMediaAnswerData(item)) return decryptedAnswersAcc.concat(item);
 
         return decryptedAnswersAcc.concat({

--- a/src/shared/utils/getParsedAnswers.ts
+++ b/src/shared/utils/getParsedAnswers.ts
@@ -22,8 +22,6 @@ export const getParsedAnswers = async (
   result: ExportDataResult,
   getDecryptedActivityData: ReturnType<typeof useDecryptedActivityData>,
 ) => {
-  console.log('[API RESPONSE] Full Export Data:', result);
-
   const activitiesObject = getObjectFromList(
     result.activities,
     (activity: ExportActivity) => activity.idVersion,
@@ -41,7 +39,6 @@ export const getParsedAnswers = async (
       }),
     );
   }
-  console.log('[API RESPONSE] Full Export Data:', parsedAnswers);
 
   return parsedAnswers;
 };

--- a/src/shared/utils/getParsedAnswers.ts
+++ b/src/shared/utils/getParsedAnswers.ts
@@ -22,6 +22,8 @@ export const getParsedAnswers = async (
   result: ExportDataResult,
   getDecryptedActivityData: ReturnType<typeof useDecryptedActivityData>,
 ) => {
+  console.log('[API RESPONSE] Full Export Data:', result);
+
   const activitiesObject = getObjectFromList(
     result.activities,
     (activity: ExportActivity) => activity.idVersion,
@@ -39,6 +41,7 @@ export const getParsedAnswers = async (
       }),
     );
   }
+  console.log('[API RESPONSE] Full Export Data:', parsedAnswers);
 
   return parsedAnswers;
 };


### PR DESCRIPTION
Jira Ticket: https://mindlogger.atlassian.net/browse/M2-9858

  - Add support for exporting Unity activity media files in admin data exports
  - Unity responses containing taskData URLs are now extracted and packaged into `unity-responses-*.zip` files
  - Files in the ZIP use their actual S3 filenames (e.g. `StartNodeData_2_12_2026_3_01_30_PM.txt`) instead of index-based names (0.txt, 1.txt)
  - Handles encrypted file parsing and CachedMediaValue in getMediaUrl
  - Excludes Unity from isMediaAnswerData to prevent misrouting taskData

###   Changes

  Types & Guards
  - `src/shared/types/answer.ts `— Added DecryptedUnityAnswer type, UnityTaskData interface
  - `src/shared/types/guards.ts` — Added isUnityAnswerData guard, excluded Unity from isMediaAnswerData
  - `src/shared/consts.tsx` — Added Unity to ItemsWithFileResponses

###   Export Logic
  -` src/shared/utils/exportData/getUrls.ts `— Added getUnityMediaUrls() to extract URLs from Unity answer.value (handles array, string, and taskData formats)
  - `src/shared/utils/exportData/getReportAndMediaData.ts`  Added getUnityData() to collect Unity media with actual filenames from URLs
  - `src/shared/utils/exportData/prepareData.ts`  Added unityData collection in export pipeline
  - `src/shared/utils/exportData/exportDataSucceed.ts`  Added Unity ZIP export call (unity-responses-*.zip)
  - `src/shared/utils/exportData/getReportName.ts`  Added Unity to ZipFile enum
  - `src/shared/utils/getParsedAnswers.ts`  Added Unity URL presigning and taskData structure preservation during URL replacement
  - `src/shared/mock/index.ts` — Added Unity mock data

###   Tests

  - src/shared/utils/getParsedAnswers.test.ts — Added tests for Unity URL collection and replacement
  - src/shared/utils/exportData/getReportAndMediaData.test.ts — Added tests for getUnityData with taskData format
  - src/shared/utils/exportData/exportDataSucceed.test.ts — Updated expectations for Unity ZIP export
  - src/shared/utils/exportData/prepareData.test.ts — Updated expectations for Unity data in pipeline

###   ZIP Structure

 ```
 unity-responses-{date}.zip
  └── {targetSecretId}-{answerId}-{activityItemName}/
      ├── StartNodeData_2_12_2026_3_01_30_PM.txt
      ├── EndNodeData_2_12_2026_3_01_30_PM.txt
      ├── taskData_2_12_2026_3_01_30_PM.txt
      └── ...
```

  ### Testing

  - All 330 export tests passing
  - Create an applet with a Unity activity
  - Complete the Unity activity on mobile (generates taskData files)
  - Export data from admin dashboard
  - Verify unity-responses-*.zip is downloaded alongside other export files
  - Verify Unity media files are present in the zip with correct filenames