### PR TITLE
feat: Add announcement banner for MFA Release (M2-10461)

### DIFF
--- a/src/modules/Auth/layouts/AuthLayout/AuthLayout.tsx
+++ b/src/modules/Auth/layouts/AuthLayout/AuthLayout.tsx
@@ -5,7 +5,7 @@ import curiousLogo from 'assets/images/curious_logo--white.png';
 import { auth } from 'modules/Auth/state';
 import { Footer, Spinner } from 'shared/components';
 import { Banners } from 'shared/components/Banners';
-// import { AnnouncementBanner } from 'shared/components/Banners/AnnouncementBanner';
+import { AnnouncementBanner } from 'shared/components/Banners/AnnouncementBanner';
 
 import {
   StyledAuthLayout,
@@ -30,7 +30,7 @@ export const AuthLayout = () => {
         </StyledLogoWrapper>
         <Banners />
       </StyledHeader>
-      {/* <AnnouncementBanner /> */}
+      <AnnouncementBanner />
       <StyledOutlet>
         <StyledAuthWrapper>
           <StyledAuthWrapperInner>

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -229,7 +229,7 @@
   "alwaysAvailableWarning": "Once you set this event to always available, all scheduled events for this activity will be removed.",
   "any": "Any",
   "and": "and",
-  "announcementBanner": "<0>We are rebranding! </0> <1>Design updates are on the way — same great app, fresh new look. Curious? </1><2>Click to learn more.</2>",
+  "announcementBanner": "<0>Two Factor Authentication is here! </0> <1>Protect your account with an extra layer of security. Enable it in your account settings. </1><2>Click to learn more.</2>",
   "applet_one": "Applet",
   "applet_other": "Applets",
   "appletActivities": "Applet activities",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -229,7 +229,7 @@
   "alwaysAvailableWarning": "Si vous définissez cet événement comme toujours disponible, tous les événements programmés pour cette activité seront supprimés.",
   "any": "N'importe lequel",
   "and": "et",
-  "announcementBanner": "<0>Nous changeons de marque! </0> <1>Des mises à jour de design sont en cours — même application géniale, nouveau look frais. Curieux? </1><2>Cliquez pour en savoir plus.</2>",
+  "announcementBanner": "<0>L'authentification multifacteur est disponible! </0> <1>Protégez votre compte avec une couche de sécurité supplémentaire. Configurez-la dans les paramètres de votre compte. </1><2>Cliquez pour en savoir plus.</2>",
   "applet_one": "Applet",
   "applet_other": "Applets",
   "appletActivities": "Activités de l'applet",

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -80,6 +80,7 @@ vi.mock('shared/hooks/useFeatureFlags', () => ({
       enableActivityAssign: true,
       enableParticipantMultiInformant: true,
       enableMfa: false,
+      enableAdminAnnouncementBanner: false,
     },
     resetLDContext: vi.fn(),
   })),

--- a/src/shared/components/Banners/AnnouncementBanner/AnnouncementBanner.test.tsx
+++ b/src/shared/components/Banners/AnnouncementBanner/AnnouncementBanner.test.tsx
@@ -3,6 +3,14 @@ import userEvent from '@testing-library/user-event';
 import { vi, type Mock } from 'vitest';
 import { useLocation } from 'react-router-dom';
 
+vi.mock('shared/hooks/useFeatureFlags', () => ({
+  useFeatureFlags: () => ({
+    featureFlags: {
+      enableAdminAnnouncementBanner: true,
+    },
+  }),
+}));
+
 import { AuthSchema, initialStateData } from 'redux/modules';
 import { mockedOwnerId } from 'shared/mock';
 import { getPreloadedState } from 'shared/tests/getPreloadedState';

--- a/src/shared/components/Banners/AnnouncementBanner/AnnouncementBanner.tsx
+++ b/src/shared/components/Banners/AnnouncementBanner/AnnouncementBanner.tsx
@@ -12,7 +12,8 @@ import { Banner, BannerProps } from '../Banner';
 import { StyledImg, StyledLink } from './AnnouncementBanner.styles';
 
 // ─── Update this URL when the announcement changes ────────────────────────────
-const ANNOUNCEMENT_URL = 'https://mindlogger.atlassian.net/servicedesk/customer/portal/3/topic/ca0a323b-b88d-4b32-8f4f-4e6b0157f8f6/article/1545404417';
+const ANNOUNCEMENT_URL =
+  'https://mindlogger.atlassian.net/servicedesk/customer/portal/3/topic/ca0a323b-b88d-4b32-8f4f-4e6b0157f8f6/article/1545404417';
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**

--- a/src/shared/components/Banners/AnnouncementBanner/AnnouncementBanner.tsx
+++ b/src/shared/components/Banners/AnnouncementBanner/AnnouncementBanner.tsx
@@ -5,12 +5,15 @@ import { useLocation } from 'react-router-dom';
 
 import curiousIcon from 'assets/images/curious_icon--white.png';
 import { auth } from 'redux/modules';
+import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 import { variables } from 'shared/styles';
 
 import { Banner, BannerProps } from '../Banner';
 import { StyledImg, StyledLink } from './AnnouncementBanner.styles';
 
-const ANNOUNCEMENT_URL = 'https://www.gettingcurious.com/rebrand';
+// ─── Update this URL when the announcement changes ────────────────────────────
+const ANNOUNCEMENT_URL = 'https://mindlogger.atlassian.net/servicedesk/customer/portal/3/topic/ca0a323b-b88d-4b32-8f4f-4e6b0157f8f6/article/1545404417';
+// ─────────────────────────────────────────────────────────────────────────────
 
 /**
  * Returns a unique key for the announcement banner dismiss state
@@ -24,6 +27,7 @@ export const GLOBAL_DISMISSED_KEY = 'announcement-banner-dismissed-global';
 const DISPLAY_ROUTES = [/^\/auth(?:\/|$)/, /^\/dashboard\/(applets|managers|respondents)$/];
 
 export const AnnouncementBanner = (props: BannerProps) => {
+  const { featureFlags } = useFeatureFlags();
   const userData = auth.useData();
   const userId = userData?.user.id;
   const location = useLocation();
@@ -39,6 +43,8 @@ export const AnnouncementBanner = (props: BannerProps) => {
   };
 
   useEffect(() => {
+    if (!featureFlags.enableAdminAnnouncementBanner) return;
+
     // For auth screen or when user is not logged in yet
     if (!userId) {
       const globalDismissed = localStorage.getItem(GLOBAL_DISMISSED_KEY);
@@ -51,7 +57,9 @@ export const AnnouncementBanner = (props: BannerProps) => {
     const userDismissed = localStorage.getItem(getDismissedKey(userId));
 
     setIsAnnouncementBannerActive(!userDismissed);
-  }, [userId]);
+  }, [userId, featureFlags.enableAdminAnnouncementBanner]);
+
+  if (!featureFlags.enableAdminAnnouncementBanner) return null;
 
   const isDisplayRoute = DISPLAY_ROUTES.some((route) => route.test(location.pathname));
 

--- a/src/shared/hooks/useFeatureFlags.const.ts
+++ b/src/shared/hooks/useFeatureFlags.const.ts
@@ -21,6 +21,7 @@ export const FeatureFlagDefaults: FeatureFlags = {
   enableEhrHealthData: 'unavailable',
   enableEmaExtraFiles: false,
   enableMfa: true,
+  enableAdminAnnouncementBanner: true,
 };
 
 export const PROHIBITED_PII_KEYS = ['firstName', 'lastName', 'email'];

--- a/src/shared/hooks/useFeatureFlags.const.ts
+++ b/src/shared/hooks/useFeatureFlags.const.ts
@@ -21,7 +21,7 @@ export const FeatureFlagDefaults: FeatureFlags = {
   enableEhrHealthData: 'unavailable',
   enableEmaExtraFiles: false,
   enableMfa: true,
-  enableAdminAnnouncementBanner: true,
+  enableAdminAnnouncementBanner: false,
 };
 
 export const PROHIBITED_PII_KEYS = ['firstName', 'lastName', 'email'];

--- a/src/shared/layouts/BaseLayout/BaseLayout.tsx
+++ b/src/shared/layouts/BaseLayout/BaseLayout.tsx
@@ -3,7 +3,7 @@ import { Outlet, useParams } from 'react-router-dom';
 
 import { alerts, auth, workspaces } from 'redux/modules';
 import { useAppDispatch } from 'redux/store';
-// import { AnnouncementBanner } from 'shared/components/Banners/AnnouncementBanner';
+import { AnnouncementBanner } from 'shared/components/Banners/AnnouncementBanner';
 import { Footer } from 'shared/components';
 import { DEFAULT_ROWS_PER_PAGE } from 'shared/consts';
 import { useAlertsWebsocket } from 'shared/hooks';
@@ -40,7 +40,7 @@ export const BaseLayout = () => {
     <StyledBaseLayout>
       {isAuthorized && <LeftBar />}
       <StyledCol isAuthorized={isAuthorized}>
-        {/* <AnnouncementBanner /> */}
+        <AnnouncementBanner />
         <TopBar />
         <Outlet />
         <Footer />

--- a/src/shared/types/featureFlags.ts
+++ b/src/shared/types/featureFlags.ts
@@ -24,4 +24,5 @@ export type FeatureFlags = Partial<{
   enableEhrHealthData: 'unavailable' | 'available' | 'active';
   enableEmaExtraFiles: boolean;
   enableMfa: boolean;
+  enableAdminAnnouncementBanner: boolean;
 }>;


### PR DESCRIPTION
- Tests for the changes have been added
  - Related documentation has been added / updated
  - OSS packages added to Curious open source credit page
  - Delivered the fix or feature branches into develop or release branches via Squash and Merge (to keep clean history)

  📝 Description

🔗 [Jira Ticket M2-10461](https://mindlogger.atlassian.net/browse/M2-10461)

  Re-enables the AnnouncementBanner component (previously used for the rebranding campaign and then commented out) as an MFA launch announcement. The banner is now gated behind a LaunchDarkly flag (enable-admin-announcement-banner) so it can be toggled on/off without a deployment. Banner text lives in the i18n files (announcementBanner key) and the link URL is a named constant at the top of the component — the only changes needed for a future announcement campaign.

  Changes include:

  - Added enableAdminAnnouncementBanner feature flag to FeatureFlags type and FeatureFlagDefaults (default: false)
  - Re-enabled <AnnouncementBanner /> in BaseLayout and AuthLayout (previously commented out)
  - Updated AnnouncementBanner to gate rendering on the enableAdminAnnouncementBanner flag
  - Updated announcementBanner i18n key in app-en.json and app-fr.json with MFA announcement copy
  - Added useFeatureFlags mock to AnnouncementBanner.test.tsx so existing tests continue to pass

  🪤 Peer Testing

  To test with the LaunchDarkly flag:

  - Ensure the enable-admin-announcement-banner flag exists in your target LD environment
  - Enable the flag in LaunchDarkly
  - Navigate to /auth/login (or any other /auth/ page before login)
  - Navigate to to post-login page(s) (/dashboard/applets, /dashboard/managers, or /dashboard/respondents, etc)

  -   Expected outcome: Announcement banner appears at the top of the page with MFA messaging and a "Click to learn more" link
  - Navigate to 

  - Dismiss the banner using the close button
  -   Expected outcome: Banner animates closed and does not reappear on refresh (dismissal is stored in localStorage per user)
  - Disable the flag in LaunchDarkly
  -   Expected outcome: Banner does not appear on any route (no deployment required)


