### PR TITLE
fix: replace 'Unity' with 'Merit Task' in user-facing translations (M2-10594)

### DIFF
--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -1175,14 +1175,14 @@
     "flanker": "Simple & Choice Reaction Time Task Builder",
     "gyroscope": "CST Gyroscope",
     "touch": "CST Touch",
-    "unity": "Unity"
+    "unity": "MERIT Task"
   },
   "performanceTasksDesc": {
     "abTrails": "A/B Trails",
     "flanker": "This Activity contains Flanker Item. The timestamps collected for an android are not as accurate as iOS devices.",
     "gyroscope": "This Activity contains Stability Tracker (Gyroscope) Item.",
     "touch": "This Activity contains Stability Tracker (Touch) Item.",
-    "unity": "New Unity Task"
+    "unity": "New MERIT Task"
   },
   "percentageOfScores": "Percentage of Item Scores",
   "periodRequired": "Period is required",
@@ -1691,7 +1691,7 @@
   "underline": "Underline",
   "undo": "Undo",
   "unityInstructions": "Upload Configurations",
-  "unityTaskConfigurationFile": "Unity Task Configuration File",
+  "unityTaskConfigurationFile": "MERIT Task Configuration File",
   "unorderedList": "Unordered list",
   "unread": "Unread",
   "unselected": "Unselected",
@@ -1713,7 +1713,7 @@
   "uploadMdImg": "Upload Image",
   "uploadSchedule": "Please upload a schedule in one of the following formats: <1>.csv, .xls, .xlsx, .ods.</1>",
   "uploadTransfluent": "Please upload JPG or transfluent PNG image less than {{size}}.",
-  "uploadUnityConfigFile": "Upload Unity Configuration File",
+  "uploadUnityConfigFile": "Upload MERIT Configuration File",
   "uploadVideo": "Upload Video",
   "urlPlaceholder": "Type url",
   "userBuilder": "{{userName}}'s Builder",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -1174,14 +1174,14 @@
     "flanker": "Constructeur de tâches de temps de réaction simple et au choix",
     "gyroscope": "CST Gyroscope",
     "touch": "CST Touch",
-    "unity": "Unity"
+    "unity": "MERIT Task"
   },
   "performanceTasksDesc": {
     "abTrails": "Parcours A/B",
     "flanker": "Cette Activité contient un Élément Flanker. Les horodatages collectés pour un appareil Android ne sont pas aussi précis que ceux des appareils iOS.",
     "gyroscope": "Cette Activité contient un Élément de Suivi de Stabilité (Gyroscope).",
     "touch": "Cette Activité contient un Élément de Suivi de Stabilité (Toucher).",
-    "unity": "Nouvelle tâche Unity"
+    "unity": "Nouvelle tâche MERIT"
   },
   "percentageOfScores": "Pourcentage des scores des éléments",
   "periodRequired": "La période est requise",
@@ -1690,7 +1690,7 @@
   "underline": "Souligner",
   "undo": "Annuler",
   "unityInstructions": "Upload Configurations",
-  "unityTaskConfigurationFile": "Fichier de configuration des tâches Unity",
+  "unityTaskConfigurationFile": "Fichier de configuration des tâches MERIT",
   "unorderedList": "Liste non ordonnée",
   "unread": "Non lu",
   "unselected": "Non sélectionné",
@@ -1712,7 +1712,7 @@
   "uploadMdImg": "Uploader une image",
   "uploadSchedule": "Veuillez uploader un programme dans l'un des formats suivants : <1>.csv, .xls, .xlsx, .ods.</1>",
   "uploadTransfluent": "Veuillez uploader une image JPG ou PNG transfluent de moins de {{size}}.",
-  "uploadUnityConfigFile": "Télécharger le fichier de configuration Unity",
+  "uploadUnityConfigFile": "Télécharger le fichier de configuration MERIT",
   "uploadVideo": "Uploader une vidéo",
   "urlPlaceholder": "Saisissez l'URL",
   "userBuilder": "Constructeur de {{userName}}",

--- a/src/shared/layouts/BaseLayout/components/TopBar/Breadcrumbs/Breadcrumbs.hooks.test.ts
+++ b/src/shared/layouts/BaseLayout/components/TopBar/Breadcrumbs/Breadcrumbs.hooks.test.ts
@@ -442,7 +442,7 @@ describe('useBreadcrumbs', () => {
   const label1 = 'CST Touch';
   const label2 = 'CST Gyroscope';
   const label3 = 'Simple & Choice Reaction Time Task Builder';
-  const label4 = 'Unity';
+  const label4 = 'MERIT Task';
 
   test.each`
     route         | routePath                 | label


### PR DESCRIPTION

<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to Curious [open source credit page](https://mindlogger.atlassian.net/wiki/spaces/MINDLOGGER1/pages/263127186/Admin+Panel+Applet+Builder+Library)
- [ ] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [M2-10594](https://mindlogger.atlassian.net/browse/M2-10594)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Update user-facing translations to replace "Unity" terminology with "Merit Task" across the admin panel. Changes applied to both English and French language files.

Changes include:

- `performanceTasks.unity`: "Unity" → "Merit Task"
- `performanceTasksDesc.unity`: "New Unity Task" → "New Merit Task"  
- `unityTaskConfigurationFile`: "Unity Task Configuration File" → "Merit Task Configuration File"
- `uploadUnityConfigFile`: "Upload Unity Configuration File" → "Upload Merit Configuration File"


### ✏️ Notes

<!--
Replace this line with anything else you think may be relevant or related PRs

If there are no notes, then delete this section.
-->
- Changes applied to both `app-en.json` and `app-fr.json`

[M2-10594]: https://mindlogger.atlassian.net/browse/M2-10594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ