### PR TITLE
fix: Rename MERIT task performance (M2-10625)

### DIFF
--- a/src/modules/Builder/components/ToggleItemContainer/ToggleItemContainer.tsx
+++ b/src/modules/Builder/components/ToggleItemContainer/ToggleItemContainer.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@mui/material';
-import { MouseEvent, useState } from 'react';
+import { memo, MouseEvent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Svg, Tooltip } from 'shared/components';
@@ -23,87 +23,89 @@ import {
 } from './ToggleItemContainer.styles';
 import { ToggleItemProps } from './ToggleItemContainer.types';
 
-export const ToggleItemContainer = ({
-  title,
-  HeaderContent,
-  Content,
-  headerContentProps,
-  contentProps,
-  uiType,
-  isOpenByDefault,
-  isOpenDisabled,
-  tooltip,
-  errorMessage,
-  hasError,
-  headerToggling,
-  'data-testid': dataTestid,
-}: ToggleItemProps) => {
-  const { t } = useTranslation();
-  const [open, setOpen] = useState(isOpenByDefault ?? true);
-  const handleToggle = toggleBooleanState(setOpen);
-  const handleToggleBtnClick = (event: MouseEvent<HTMLButtonElement>) => {
-    event.stopPropagation();
-    handleToggle();
-  };
+export const ToggleItemContainer = memo(
+  ({
+    title,
+    HeaderContent,
+    Content,
+    headerContentProps,
+    contentProps,
+    uiType,
+    isOpenByDefault,
+    isOpenDisabled,
+    tooltip,
+    errorMessage,
+    hasError,
+    headerToggling,
+    'data-testid': dataTestid,
+  }: ToggleItemProps) => {
+    const { t } = useTranslation();
+    const [open, setOpen] = useState(isOpenByDefault ?? true);
+    const handleToggle = toggleBooleanState(setOpen);
+    const handleToggleBtnClick = (event: MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+      handleToggle();
+    };
 
-  const hasErrorMessage = !open && !!errorMessage;
-  const titleErrorVisible = !open && (!!errorMessage || hasError);
-  const isHeaderClickable = headerToggling && !isOpenDisabled;
+    const hasErrorMessage = !open && !!errorMessage;
+    const titleErrorVisible = !open && (!!errorMessage || hasError);
+    const isHeaderClickable = headerToggling && !isOpenDisabled;
 
-  return (
-    <StyledItemOption uiType={uiType} data-testid={dataTestid}>
-      <StylesTitleWrapper
-        open={open}
-        uiType={uiType}
-        isError={titleErrorVisible}
-        headerClickable={isHeaderClickable}
-        data-testid={`${dataTestid}-header`}
-        onClick={isHeaderClickable ? handleToggle : undefined}
-      >
-        <StyledFlexTopCenter
-          sx={{ flexGrow: 1, overflow: titleErrorVisible ? 'visible' : 'hidden' }}
+    return (
+      <StyledItemOption uiType={uiType} data-testid={dataTestid}>
+        <StylesTitleWrapper
+          open={open}
+          uiType={uiType}
+          isError={titleErrorVisible}
+          headerClickable={isHeaderClickable}
+          data-testid={`${dataTestid}-header`}
+          onClick={isHeaderClickable ? handleToggle : undefined}
         >
-          <StyledFlexTopCenter>
-            <StyledClearedButton
-              onClick={handleToggleBtnClick}
-              sx={{ p: theme.spacing(0.8) }}
-              disabled={isOpenDisabled}
-              data-testid={`${dataTestid}-collapse`}
-            >
-              <Svg id={open ? 'navigate-up' : 'navigate-down'} />
-            </StyledClearedButton>
-            {title && (
-              <StyledFlexColumn data-testid={`${dataTestid}-title`}>
-                <StyledTitleContainer hasError={!!titleErrorVisible}>
-                  {titleErrorVisible && <StyledBadge variant="dot" color="error" />}
-                  <StyledFlexTopCenter>
-                    <StyledLabelBoldLarge>{title}</StyledLabelBoldLarge>
-                  </StyledFlexTopCenter>
-                </StyledTitleContainer>
-                {hasErrorMessage && (
-                  <StyledBodyMedium
-                    sx={{ p: theme.spacing(0.5, 0, 0, 1.5) }}
-                    color={variables.palette.error}
-                  >
-                    {t(errorMessage)}
-                  </StyledBodyMedium>
-                )}
-              </StyledFlexColumn>
+          <StyledFlexTopCenter
+            sx={{ flexGrow: 1, overflow: titleErrorVisible ? 'visible' : 'hidden' }}
+          >
+            <StyledFlexTopCenter>
+              <StyledClearedButton
+                onClick={handleToggleBtnClick}
+                sx={{ p: theme.spacing(0.8) }}
+                disabled={isOpenDisabled}
+                data-testid={`${dataTestid}-collapse`}
+              >
+                <Svg id={open ? 'navigate-up' : 'navigate-down'} />
+              </StyledClearedButton>
+              {title && (
+                <StyledFlexColumn data-testid={`${dataTestid}-title`}>
+                  <StyledTitleContainer hasError={!!titleErrorVisible}>
+                    {titleErrorVisible && <StyledBadge variant="dot" color="error" />}
+                    <StyledFlexTopCenter>
+                      <StyledLabelBoldLarge>{title}</StyledLabelBoldLarge>
+                    </StyledFlexTopCenter>
+                  </StyledTitleContainer>
+                  {hasErrorMessage && (
+                    <StyledBodyMedium
+                      sx={{ p: theme.spacing(0.5, 0, 0, 1.5) }}
+                      color={variables.palette.error}
+                    >
+                      {t(errorMessage)}
+                    </StyledBodyMedium>
+                  )}
+                </StyledFlexColumn>
+              )}
+            </StyledFlexTopCenter>
+            {HeaderContent && (
+              <HeaderContent open={open} onToggle={handleToggle} {...headerContentProps} />
             )}
           </StyledFlexTopCenter>
-          {HeaderContent && (
-            <HeaderContent open={open} onToggle={handleToggle} {...headerContentProps} />
+          {tooltip && (
+            <Tooltip tooltipTitle={tooltip}>
+              <Box component="span" sx={{ height: '2rem' }}>
+                <StyledTitleTooltipIcon width="2rem" height="2rem" id="more-info-outlined" />
+              </Box>
+            </Tooltip>
           )}
-        </StyledFlexTopCenter>
-        {tooltip && (
-          <Tooltip tooltipTitle={tooltip}>
-            <Box component="span" sx={{ height: '2rem' }}>
-              <StyledTitleTooltipIcon width="2rem" height="2rem" id="more-info-outlined" />
-            </Box>
-          </Tooltip>
-        )}
-      </StylesTitleWrapper>
-      {open && <Content {...contentProps} />}
-    </StyledItemOption>
-  );
-};
+        </StylesTitleWrapper>
+        {open && <Content {...contentProps} />}
+      </StyledItemOption>
+    );
+  },
+);

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/AudioPlayer/AudioPlayer.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/AudioPlayer/AudioPlayer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { MediaType } from 'modules/Builder/components/MediaUploader';
@@ -27,14 +27,17 @@ export const AudioPlayer = ({ name }: AudioPlayerProps) => {
     setMedia({ ...media, name: getMediaName(url) });
   }, [url]);
 
+  const headerContentProps = useMemo(() => ({ media }), [media]);
+  const contentProps = useMemo(() => ({ media, setMedia, name }), [media, setMedia, name]);
+
   return (
     <>
       <ToggleItemContainer
         title={t('audioPlayer')}
         HeaderContent={AudioPlayerHeader}
         Content={AudioPlayerContent}
-        headerContentProps={{ media }}
-        contentProps={{ media, setMedia, name }}
+        headerContentProps={headerContentProps}
+        contentProps={contentProps}
         data-testid="builder-activity-items-item-configuration-audio-player"
       />
     </>

--- a/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/Drawing/Drawing.tsx
+++ b/src/modules/Builder/features/ActivityItems/ItemConfiguration/InputTypeItems/Drawing/Drawing.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { ToggleItemContainer } from 'modules/Builder/components/ToggleItemContainer';
@@ -9,13 +10,15 @@ import { DrawingProps } from './Drawing.types';
 export const Drawing = ({ name }: DrawingProps) => {
   const { t } = useTranslation();
 
+  const contentProps = useMemo(() => ({ name }), [name]);
+
   return (
     <ToggleItemContainer
       title={t('drawing')}
       HeaderContent={DrawingHeader}
       Content={DrawingContent}
-      contentProps={{ name }}
-      headerContentProps={{ name }}
+      contentProps={contentProps}
+      headerContentProps={contentProps}
       data-testid="builder-activity-items-item-configuration-drawing"
     />
   );

--- a/src/modules/Builder/features/PerformanceTasks/Instruction/Instruction.tsx
+++ b/src/modules/Builder/features/PerformanceTasks/Instruction/Instruction.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { ToggleContainerUiType, ToggleItemContainer } from 'modules/Builder/components';
@@ -15,13 +16,18 @@ export const Instruction = ({
 }: InstructionProps) => {
   const { t } = useTranslation();
 
+  const contentProps = useMemo(
+    () => ({ description, name, hasError, instructionId, 'data-testid': dataTestid }),
+    [description, name, hasError, instructionId, dataTestid],
+  );
+
   return (
     <ToggleItemContainer
       uiType={ToggleContainerUiType.PerformanceTask}
       title={title || t('overviewInstruction')}
       isOpenByDefault={false}
       Content={InstructionContent}
-      contentProps={{ description, name, hasError, instructionId, 'data-testid': dataTestid }}
+      contentProps={contentProps}
       errorMessage={hasError ? 'blockIsNecessary' : null}
       headerToggling
       data-testid={dataTestid}

--- a/src/modules/Builder/features/PerformanceTasks/NameDescription/NameDescription.tsx
+++ b/src/modules/Builder/features/PerformanceTasks/NameDescription/NameDescription.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { ToggleContainerUiType, ToggleItemContainer } from 'modules/Builder/components';
@@ -8,12 +9,14 @@ import { NameDescriptionProps } from './NameDescription.types';
 export const NameDescription = ({ 'data-testid': dataTestid }: NameDescriptionProps) => {
   const { t } = useTranslation();
 
+  const contentProps = useMemo(() => ({ 'data-testid': dataTestid }), [dataTestid]);
+
   return (
     <ToggleItemContainer
       uiType={ToggleContainerUiType.PerformanceTask}
       title={t('nameAndDescription')}
       Content={NameDescriptionContent}
-      contentProps={{ 'data-testid': dataTestid }}
+      contentProps={contentProps}
       headerToggling
       data-testid={`${dataTestid}-common`}
     />

--- a/src/modules/Builder/features/PerformanceTasks/NameDescription/NameDescriptionContent/NameDescriptionContent.tsx
+++ b/src/modules/Builder/features/PerformanceTasks/NameDescription/NameDescriptionContent/NameDescriptionContent.tsx
@@ -2,7 +2,11 @@ import { useTranslation } from 'react-i18next';
 import { Box } from '@mui/material';
 
 import { theme } from 'shared/styles';
-import { useCurrentActivity, useCustomFormContext } from 'modules/Builder/hooks';
+import {
+  useCurrentActivity,
+  useCustomFormContext,
+  useImmediateValidation,
+} from 'modules/Builder/hooks';
 import { InputController } from 'shared/components/FormComponents';
 import { MAX_NAME_LENGTH, MAX_DESCRIPTION_LENGTH, TEXTAREA_ROWS_COUNT } from 'shared/consts';
 
@@ -14,6 +18,9 @@ export const NameDescriptionContent = ({
   const { t } = useTranslation();
   const { control } = useCustomFormContext();
   const { fieldName } = useCurrentActivity();
+
+  const handleNameChange = useImmediateValidation(`${fieldName}.name`);
+  const handleDescriptionChange = useImmediateValidation(`${fieldName}.description`);
 
   const commonProps = {
     control,
@@ -31,6 +38,7 @@ export const NameDescriptionContent = ({
           label={t('activityName')}
           maxLength={MAX_NAME_LENGTH}
           data-testid={`${dataTestid}-name`}
+          onChange={handleNameChange}
         />
       </Box>
       <Box sx={{ mb: theme.spacing(1.6) }}>
@@ -43,6 +51,7 @@ export const NameDescriptionContent = ({
           multiline
           rows={TEXTAREA_ROWS_COUNT}
           data-testid={`${dataTestid}-description`}
+          onChange={handleDescriptionChange}
         />
       </Box>
     </>

--- a/src/modules/Builder/features/PerformanceTasks/Unity/Unity.tsx
+++ b/src/modules/Builder/features/PerformanceTasks/Unity/Unity.tsx
@@ -1,16 +1,15 @@
 import { useTranslation } from 'react-i18next';
-import { Box, Button } from '@mui/material';
+import { Box } from '@mui/material';
 import { useEffect, useState } from 'react';
 
 import { StyledHeadlineLarge, StyledTitleLarge, theme } from 'shared/styles';
 import { ToggleContainerUiType, ToggleItemContainer } from 'modules/Builder/components';
-import { Svg } from 'shared/components';
 import { useCurrentActivity, useCustomFormContext } from 'modules/Builder/hooks';
 
 import { NameDescription } from '../NameDescription';
 import { StyledPerformanceTaskBody } from '../PerformanceTasks.styles';
 import UnityFileModal from './UnityFileModal/UnityFileModal';
-import { UnityFilePreview } from './UnityFilePreview';
+import { UnityFileButton } from './UnityFileButton';
 
 export const Unity = () => {
   const { t } = useTranslation();
@@ -69,24 +68,6 @@ export const Unity = () => {
     }
   }, [url]);
 
-  // TODO Upload a new file if already uploaded should be implemented - TASK https://mindlogger.atlassian.net/browse/M2-7779
-  const OpenModalButton = () =>
-    isValidFile ? (
-      <UnityFilePreview fileContent={fileContent} />
-    ) : (
-      <Box sx={{ display: 'flex', justifyContent: 'flex-start' }}>
-        <Button
-          variant="text"
-          startIcon={<Svg id="add" width={18} height={18} />}
-          onClick={handleOpenModal}
-          sx={{ ml: theme.spacing(-1) }}
-          data-testid="builder-activities-add-activity"
-        >
-          {t('upload')}
-        </Button>
-      </Box>
-    );
-
   return (
     <Box sx={{ overflowY: 'auto' }}>
       <StyledPerformanceTaskBody sx={{ p: theme.spacing(2.4, 6.4) }}>
@@ -101,7 +82,8 @@ export const Unity = () => {
         <ToggleItemContainer
           uiType={ToggleContainerUiType.PerformanceTask}
           title={t('unityTaskConfigurationFile')}
-          Content={OpenModalButton}
+          Content={UnityFileButton}
+          contentProps={{ isValidFile, fileContent, onOpenModal: handleOpenModal }}
           data-testid="builder-activity-unity-file-uploader"
         />
       </StyledPerformanceTaskBody>

--- a/src/modules/Builder/features/PerformanceTasks/Unity/Unity.tsx
+++ b/src/modules/Builder/features/PerformanceTasks/Unity/Unity.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { Box } from '@mui/material';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { StyledHeadlineLarge, StyledTitleLarge, theme } from 'shared/styles';
 import { ToggleContainerUiType, ToggleItemContainer } from 'modules/Builder/components';
@@ -58,15 +58,20 @@ export const Unity = () => {
     setIsModalOpen(false);
   };
 
-  const handleOpenModal = () => {
+  const handleOpenModal = useCallback(() => {
     setIsModalOpen(true);
-  };
+  }, []);
 
   useEffect(() => {
     if (url && url.length > 0) {
       setFileContent(url);
     }
   }, [url]);
+
+  const contentProps = useMemo(
+    () => ({ isValidFile, fileContent, onOpenModal: handleOpenModal }),
+    [isValidFile, fileContent, handleOpenModal],
+  );
 
   return (
     <Box sx={{ overflowY: 'auto' }}>
@@ -83,7 +88,7 @@ export const Unity = () => {
           uiType={ToggleContainerUiType.PerformanceTask}
           title={t('unityTaskConfigurationFile')}
           Content={UnityFileButton}
-          contentProps={{ isValidFile, fileContent, onOpenModal: handleOpenModal }}
+          contentProps={contentProps}
           data-testid="builder-activity-unity-file-uploader"
         />
       </StyledPerformanceTaskBody>

--- a/src/modules/Builder/features/PerformanceTasks/Unity/Unity.tsx
+++ b/src/modules/Builder/features/PerformanceTasks/Unity/Unity.tsx
@@ -37,26 +37,29 @@ export const Unity = () => {
 
   const dataTestid = 'builder-activity-unity';
 
-  const handleUpload = (uploadedFile: File) => {
-    setFile(uploadedFile);
-    const formFile = watch(urlName);
-    if (formFile === null) {
-      setFileContent('');
+  const handleUpload = useCallback(
+    (uploadedFile: File) => {
+      setFile(uploadedFile);
+      const formFile = watch(urlName);
+      if (formFile === null) {
+        setFileContent('');
 
-      return;
-    }
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      const fileContentString = e.target?.result as string;
-      setFileContent(fileContentString);
-      setValue(urlName, fileContentString);
-    };
-    reader.readAsText(uploadedFile);
-  };
+        return;
+      }
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        const fileContentString = e.target?.result as string;
+        setFileContent(fileContentString);
+        setValue(urlName, fileContentString);
+      };
+      reader.readAsText(uploadedFile);
+    },
+    [watch, urlName, setValue],
+  );
 
-  const handleCloseModal = () => {
+  const handleCloseModal = useCallback(() => {
     setIsModalOpen(false);
-  };
+  }, []);
 
   const handleOpenModal = useCallback(() => {
     setIsModalOpen(true);
@@ -95,7 +98,7 @@ export const Unity = () => {
       <UnityFileModal
         dataTestid={dataTestid}
         onUpload={handleUpload}
-        onClose={() => handleCloseModal()}
+        onClose={handleCloseModal}
         isOpen={isModalOpen}
       />
     </Box>

--- a/src/modules/Builder/features/PerformanceTasks/Unity/UnityFileButton/UnityFileButton.tsx
+++ b/src/modules/Builder/features/PerformanceTasks/Unity/UnityFileButton/UnityFileButton.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Box, Button } from '@mui/material';
+
+import { theme } from 'shared/styles';
+import { Svg } from 'shared/components';
+
+import { UnityFilePreview } from '../UnityFilePreview';
+
+interface UnityFileButtonProps {
+  isValidFile: boolean;
+  fileContent: string;
+  onOpenModal: () => void;
+}
+
+// TODO Upload a new file if already uploaded should be implemented - TASK https://mindlogger.atlassian.net/browse/M2-7779
+export const UnityFileButton: React.FC<UnityFileButtonProps> = ({
+  isValidFile,
+  fileContent,
+  onOpenModal,
+}) => {
+  const { t } = useTranslation();
+
+  return isValidFile ? (
+    <UnityFilePreview fileContent={fileContent} />
+  ) : (
+    <Box sx={{ display: 'flex', justifyContent: 'flex-start' }}>
+      <Button
+        variant="text"
+        startIcon={<Svg id="add" width={18} height={18} />}
+        onClick={onOpenModal}
+        sx={{ ml: theme.spacing(-1) }}
+        data-testid="builder-activities-add-activity"
+      >
+        {t('upload')}
+      </Button>
+    </Box>
+  );
+};

--- a/src/modules/Builder/features/PerformanceTasks/Unity/UnityFileButton/index.ts
+++ b/src/modules/Builder/features/PerformanceTasks/Unity/UnityFileButton/index.ts
@@ -1,0 +1,1 @@
+export * from './UnityFileButton';

--- a/src/modules/Builder/features/PerformanceTasks/Unity/UnityFileModal/UnityFileModal.tsx
+++ b/src/modules/Builder/features/PerformanceTasks/Unity/UnityFileModal/UnityFileModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Modal } from 'shared/components';
@@ -11,48 +11,45 @@ interface UnityFileModalProps {
   dataTestid: string;
 }
 
-const UnityFileModal: React.FC<UnityFileModalProps> = ({
-  isOpen,
-  onClose,
-  dataTestid,
-  onUpload,
-}) => {
-  const { t } = useTranslation('app');
+const UnityFileModal: React.FC<UnityFileModalProps> = memo(
+  ({ isOpen, onClose, dataTestid, onUpload }) => {
+    const { t } = useTranslation('app');
 
-  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+    const [selectedFile, setSelectedFile] = useState<File | null>(null);
 
-  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (file) {
-      setSelectedFile(file);
-    }
-  };
+    const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (file) {
+        setSelectedFile(file);
+      }
+    };
 
-  const handleSubmit = () => {
-    if (selectedFile) {
-      onUpload(selectedFile);
-    }
-    onClose();
-  };
+    const handleSubmit = () => {
+      if (selectedFile) {
+        onUpload(selectedFile);
+      }
+      onClose();
+    };
 
-  return (
-    <Modal
-      open={isOpen}
-      onClose={onClose}
-      onSubmit={handleSubmit}
-      onSecondBtnSubmit={onClose}
-      title={t('uploadUnityConfigFile')}
-      buttonText={t('import')}
-      secondBtnText={t('cancel')}
-      hasSecondBtn={false}
-      submitBtnColor="primary"
-      data-testid={dataTestid}
-    >
-      <StyledModalWrapper>
-        <input type="file" onChange={handleFileChange} />
-      </StyledModalWrapper>
-    </Modal>
-  );
-};
+    return (
+      <Modal
+        open={isOpen}
+        onClose={onClose}
+        onSubmit={handleSubmit}
+        onSecondBtnSubmit={onClose}
+        title={t('uploadUnityConfigFile')}
+        buttonText={t('import')}
+        secondBtnText={t('cancel')}
+        hasSecondBtn={false}
+        submitBtnColor="primary"
+        data-testid={dataTestid}
+      >
+        <StyledModalWrapper>
+          <input type="file" onChange={handleFileChange} />
+        </StyledModalWrapper>
+      </Modal>
+    );
+  },
+);
 
 export default UnityFileModal;

--- a/src/modules/Builder/features/SaveAndPublish/SaveAndPublish.hooks.ts
+++ b/src/modules/Builder/features/SaveAndPublish/SaveAndPublish.hooks.ts
@@ -139,10 +139,10 @@ export const useCheckIfHasAtLeastOneItem = () => {
 export const useCheckIfHasEmptyRequiredFields = () => {
   const { getValues } = useCustomFormContext();
   const { featureFlags } = useFeatureFlags();
-  const appletSchema = AppletSchema(featureFlags);
 
   return async () => {
     const body = getValues();
+    const appletSchema = AppletSchema(featureFlags);
 
     try {
       await appletSchema.validate(body, { abortEarly: false });
@@ -157,10 +157,10 @@ export const useCheckIfHasEmptyRequiredFields = () => {
 export const useCheckIfHasErrorsInFields = () => {
   const { getValues } = useCustomFormContext();
   const { featureFlags } = useFeatureFlags();
-  const appletSchema = AppletSchema(featureFlags);
 
   return async () => {
     const body = getValues();
+    const appletSchema = AppletSchema(featureFlags);
 
     try {
       await appletSchema.validate(body, { abortEarly: false });

--- a/src/modules/Builder/hooks/useCustomFormContext.ts
+++ b/src/modules/Builder/hooks/useCustomFormContext.ts
@@ -1,11 +1,15 @@
+import { useCallback } from 'react';
 import { FieldValues, useFormContext, UseFormSetValue } from 'react-hook-form';
 
 export function useCustomFormContext() {
   const { setValue: originalSetValue, ...formContext } = useFormContext() || {};
 
-  const setValue: UseFormSetValue<FieldValues> = (name, value, options = {}) => {
-    originalSetValue(name, value, { shouldDirty: true, ...options });
-  };
+  const setValue: UseFormSetValue<FieldValues> = useCallback(
+    (name, value, options = {}) => {
+      originalSetValue(name, value, { shouldDirty: true, ...options });
+    },
+    [originalSetValue],
+  );
 
   return { ...formContext, setValue };
 }

--- a/src/modules/Builder/pages/BuilderApplet/BuilderApplet.tsx
+++ b/src/modules/Builder/pages/BuilderApplet/BuilderApplet.tsx
@@ -141,11 +141,15 @@ export const BuilderApplet = () => {
     name: ['displayName', 'activityFlows', 'activities'],
   });
 
-  const tabErrors = {
-    hasAboutAppletErrors: !!errors.displayName,
-    hasAppletActivitiesErrors: !!errors.activities,
-    hasAppletActivityFlowErrors: !!errors.activityFlows,
-  };
+  const tabErrors = useMemo(
+    () => ({
+      hasAboutAppletErrors: !!errors.displayName,
+      hasAppletActivitiesErrors: !!errors.activities,
+      hasAppletActivityFlowErrors: !!errors.activityFlows,
+    }),
+    [errors.displayName, errors.activities, errors.activityFlows],
+  );
+  const tabs = useMemo(() => getAppletTabs(tabErrors), [tabErrors]);
 
   if (isForbidden) return noPermissionsComponent;
 
@@ -155,7 +159,7 @@ export const BuilderApplet = () => {
         {isAppletInitialized ? (
           <>
             {isLoading && <Spinner />}
-            <LinkedTabs hiddenHeader={hiddenHeader} tabs={getAppletTabs(tabErrors)} isBuilder />
+            <LinkedTabs hiddenHeader={hiddenHeader} tabs={tabs} isBuilder />
             <SaveAndPublish />
           </>
         ) : (

--- a/src/modules/Builder/pages/BuilderApplet/BuilderApplet.tsx
+++ b/src/modules/Builder/pages/BuilderApplet/BuilderApplet.tsx
@@ -68,9 +68,14 @@ export const BuilderApplet = () => {
 
   const { featureFlags } = useFeatureFlags();
 
+  const resolver = useMemo(
+    () => yupResolver(AppletSchema(featureFlags) as ObjectSchema<AppletFormValues>),
+    [featureFlags],
+  );
+
   const methods = useForm<AppletFormValues>({
     defaultValues,
-    resolver: yupResolver(AppletSchema(featureFlags) as ObjectSchema<AppletFormValues>),
+    resolver,
     mode: 'onSubmit',
     reValidateMode: 'onSubmit',
   });

--- a/src/shared/components/Tabs/LinkedTabs/LinkedTabs.tsx
+++ b/src/shared/components/Tabs/LinkedTabs/LinkedTabs.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { memo, useMemo } from 'react';
 import { Link, Outlet, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Badge, Tab } from '@mui/material';
@@ -12,112 +12,115 @@ interface LinkedTabsProps extends TabsProps {
   panelProps?: Omit<TabPanelProps, 'index' | 'value'>;
 }
 
-export const LinkedTabs = ({
-  tabs,
-  uiType = UiType.Primary,
-  hiddenHeader = false,
-  isBuilder = false,
-  isCentered = true,
-  deepPathCompare = false,
-  defaultToFirstTab = true,
-  animateTabIndicator = true,
-  panelProps,
-}: LinkedTabsProps) => {
-  const { t } = useTranslation('app');
-  const { pathname } = useLocation();
+export const LinkedTabs = memo(
+  ({
+    tabs,
+    uiType = UiType.Primary,
+    hiddenHeader = false,
+    isBuilder = false,
+    isCentered = true,
+    deepPathCompare = false,
+    defaultToFirstTab = true,
+    animateTabIndicator = true,
+    panelProps,
+  }: LinkedTabsProps) => {
+    const { t } = useTranslation('app');
+    const { pathname } = useLocation();
 
-  const { tabIndex, content, header } = useMemo(() => {
-    const index = tabs?.findIndex(
-      (tab) => tab.path && (deepPathCompare ? pathname === tab.path : pathname.includes(tab.path)),
-    );
-    const tabIndex = index === -1 && defaultToFirstTab ? 0 : index;
+    const { tabIndex, content, header } = useMemo(() => {
+      const index = tabs?.findIndex(
+        (tab) =>
+          tab.path && (deepPathCompare ? pathname === tab.path : pathname.includes(tab.path)),
+      );
+      const tabIndex = index === -1 && defaultToFirstTab ? 0 : index;
 
-    const { header, content } = tabs.reduce(
-      (
-        tabs: RenderTabs,
-        {
-          id,
-          icon,
-          activeIcon,
-          labelKey,
-          isMinHeightAuto,
-          path,
-          hasError,
-          onClick,
-          'data-testid': dataTestId,
+      const { header, content } = tabs.reduce(
+        (
+          tabs: RenderTabs,
+          {
+            id,
+            icon,
+            activeIcon,
+            labelKey,
+            isMinHeightAuto,
+            path,
+            hasError,
+            onClick,
+            'data-testid': dataTestId,
+          },
+          index,
+        ) => {
+          tabs.header.push(
+            <Tab
+              key={id}
+              component={Link}
+              label={t(labelKey)}
+              to={path || ''}
+              onClick={onClick}
+              icon={
+                <>
+                  {tabIndex === index ? activeIcon : icon}
+                  {hasError && <Badge variant="dot" invisible={!hasError} color="error" />}
+                </>
+              }
+              data-testid={dataTestId}
+            />,
+          );
+
+          tabs.content.push(
+            <TabPanel
+              id={id}
+              key={id}
+              value={tabIndex}
+              index={index}
+              isMinHeightAuto={isMinHeightAuto}
+              hiddenHeader={hiddenHeader}
+              {...panelProps}
+            >
+              <Outlet />
+            </TabPanel>,
+          );
+
+          return tabs;
         },
-        index,
-      ) => {
-        tabs.header.push(
-          <Tab
-            key={id}
-            component={Link}
-            label={t(labelKey)}
-            to={path || ''}
-            onClick={onClick}
-            icon={
-              <>
-                {tabIndex === index ? activeIcon : icon}
-                {hasError && <Badge variant="dot" invisible={!hasError} color="error" />}
-              </>
-            }
-            data-testid={dataTestId}
-          />,
-        );
+        { header: [], content: [] },
+      );
 
-        tabs.content.push(
-          <TabPanel
-            id={id}
-            key={id}
-            value={tabIndex}
-            index={index}
-            isMinHeightAuto={isMinHeightAuto}
-            hiddenHeader={hiddenHeader}
-            {...panelProps}
-          >
-            <Outlet />
-          </TabPanel>,
-        );
+      return { tabIndex, content, header };
+    }, [defaultToFirstTab, deepPathCompare, hiddenHeader, pathname, t, tabs]);
 
-        return tabs;
-      },
-      { header: [], content: [] },
+    return (
+      <>
+        <StyledTabs
+          uiType={uiType}
+          // Note: This is currently causing MUI to complain about -1 not being a
+          // valid value when the user navigates to /dashboard/[applet_id]/settings.
+          //
+          // This is a temporary issue while the settings functionality is still a
+          // separate route instead of appearing as a slideover, which will be
+          // implemented in https://mindlogger.atlassian.net/browse/M2-5987.
+          //
+          // There is a note to remove this comment in that ticket when it is worked on.
+          value={tabIndex}
+          TabIndicatorProps={{
+            children: <span />,
+            ...(animateTabIndicator
+              ? {}
+              : {
+                  style: {
+                    transition: 'none',
+                  },
+                }),
+          }}
+          hiddenHeader={hiddenHeader}
+          isBuilder={isBuilder}
+          isCentered={isCentered}
+          data-testid="linked-tabs"
+        >
+          {!hiddenHeader && header}
+        </StyledTabs>
+        {content}
+      </>
     );
-
-    return { tabIndex, content, header };
-  }, [defaultToFirstTab, deepPathCompare, hiddenHeader, pathname, t, tabs]);
-
-  return (
-    <>
-      <StyledTabs
-        uiType={uiType}
-        // Note: This is currently causing MUI to complain about -1 not being a
-        // valid value when the user navigates to /dashboard/[applet_id]/settings.
-        //
-        // This is a temporary issue while the settings functionality is still a
-        // separate route instead of appearing as a slideover, which will be
-        // implemented in https://mindlogger.atlassian.net/browse/M2-5987.
-        //
-        // There is a note to remove this comment in that ticket when it is worked on.
-        value={tabIndex}
-        TabIndicatorProps={{
-          children: <span />,
-          ...(animateTabIndicator
-            ? {}
-            : {
-                style: {
-                  transition: 'none',
-                },
-              }),
-        }}
-        hiddenHeader={hiddenHeader}
-        isBuilder={isBuilder}
-        isCentered={isCentered}
-        data-testid="linked-tabs"
-      >
-        {!hiddenHeader && header}
-      </StyledTabs>
-      {content}
-    </>
-  );
-};
+  },
+);

--- a/src/shared/hooks/useFeatureFlags.ts
+++ b/src/shared/hooks/useFeatureFlags.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useFlags, useLDClient } from 'launchdarkly-react-client-sdk';
 
 import { FeatureFlagDefaults } from 'shared/hooks/useFeatureFlags.const';
@@ -20,13 +21,13 @@ export const useFeatureFlags = () => {
     });
   };
 
-  const featureFlags = () => {
+  const featureFlags = useMemo(() => {
     const keys = Object.keys(FeatureFlagDefaults) as (keyof typeof FeatureFlagDefaults)[];
     const features: FeatureFlags = {};
     keys.forEach((key) => (features[key] = flags[key] ?? FeatureFlagDefaults[key]));
 
     return features;
-  };
+  }, [flags]);
 
-  return { resetLDContext, featureFlags: featureFlags() };
+  return { resetLDContext, featureFlags };
 };


### PR DESCRIPTION
🔗 [Jira Ticket M2-10625](https://mindlogger.atlassian.net/browse/M2-10625)

Changes include:

- Extract `OpenModalButton` as a separate `UnityFileButton` component
- `useMemo` to avoid building `AppletSchema` on every keystroke
- `useMemo` to avoid duplicate LaunchDarkly requests
- `useMemo` and `React.memo` to avoid `LinkedTabs` rerenders
- `useMemo` and `React.memo` to avoid `ToggleItemContainer` rerenders
- `useMemo` and `React.memo` to avoid `UnityFileModal` rerenders
- `useImmediateValidation` for `NameDescription` fields

These changes reduce the time needed to rerender `BuilderApplet`. A remaining optimization we could make is breaking `BuilderApplet` into separate components we don’t rerender the whole thing on each keystroke. This is a bigger refactor that we should tackle only if needed.