### PR TITLE
fix: update uuid to 14.0.0+

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "react-transition-group": "^4.4.5",
     "react-virtualized-auto-sizer": "^1.0.26",
     "react-window": "^1.8.11",
-    "uuid": "^11.1.0",
+    "uuid": "^14.0.0",
     "web-vitals": "^3.5.0",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "yup": "^1.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8633,10 +8633,10 @@ util@^0.12.4, util@^0.12.5:
     is-typed-array "^1.1.3"
     which-typed-array "^1.1.2"
 
-uuid@^11.1.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
-  integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
+uuid@^14.0.0:
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
+  integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
 
 uuid@^8.0.0, uuid@^8.3.2:
   version "8.3.2"


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-10678](https://mindlogger.atlassian.net/browse/M2-10678)

Update uuid from 11.1.0 to 14.0.0+ to address security vulnerability GHSA-w5hq-g745-h8pq.

Changes include:

- Updated uuid dependency from `^11.1.0` to `^14.0.0`
- Updated yarn.lock