### PR TITLE
fix: Update @tootallnate/once to 3.0.1+

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,6 +182,7 @@
     "@testing-library/user-event": "14.6.1",
     "@types/react": "18.3.26",
     "@types/react-dom": "18.3.7",
+    "@tootallnate/once": ">=3.0.1",
     "aria-query": "5.1.3",
     "js-yaml": ">=4.1.1",
     "qs": ">=6.14.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2310,10 +2310,10 @@
   resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.6.1.tgz#13e09a32d7a8b7060fe38304788ebf4197cd2149"
   integrity sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==
 
-"@tootallnate/once@1":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
-  integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
+"@tootallnate/once@1", "@tootallnate/once@>=3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-3.0.1.tgz#d580decb59cb41a15856387a86800838102daf44"
+  integrity sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==
 
 "@tybys/wasm-util@^0.10.0":
   version "0.10.1"


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-10678](https://mindlogger.atlassian.net/browse/M2-10678)

Update @tootallnate/once to 3.0.1+ via Yarn resolution to address security vulnerability CVE-2026-3449 (GHSA-vpq2-c234-7xj6) affecting versions < 3.0.1.

Changes include:

- Added @tootallnate/once resolution (`>=3.0.1`) in package.json
- Updated yarn.lock