### PR TITLE
Feat: add south african language support (M2-10765)

### DIFF
--- a/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantForm/AddParticipantForm.test.tsx
+++ b/src/modules/Dashboard/features/Applet/Popups/AddParticipantPopup/AddParticipantForm/AddParticipantForm.test.tsx
@@ -64,4 +64,27 @@ describe('AddParticipantForm component tests', () => {
 
     expect(mockOnSubmit).toHaveBeenCalled();
   });
+
+  test('Invitation language dropdown lists every ApiLanguages value with its translated label', () => {
+    render(<AddParticipantFormTest accountType={AccountType.Full} />);
+
+    const trigger = screen.getByTestId(`${dataTestid}-lang`).querySelector('[role="combobox"]');
+    expect(trigger).not.toBeNull();
+    fireEvent.mouseDown(trigger as Element);
+
+    const expectedLabels: Record<ApiLanguages, string> = {
+      [ApiLanguages.EN]: 'English',
+      [ApiLanguages.FR]: 'French',
+      [ApiLanguages.EL]: 'Greek',
+      [ApiLanguages.ES]: 'Spanish',
+      [ApiLanguages.PT]: 'Portuguese',
+      [ApiLanguages.AF]: 'Afrikaans',
+      [ApiLanguages.XH]: 'Xhosa',
+      [ApiLanguages.ZU]: 'Zulu',
+    };
+
+    Object.values(ApiLanguages).forEach((lang) => {
+      expect(screen.getByRole('option', { name: expectedLabels[lang] })).toBeInTheDocument();
+    });
+  });
 });

--- a/src/modules/Dashboard/features/Managers/Popups/AddManagerPopup/AddManagerForm/AddManagerForm.test.tsx
+++ b/src/modules/Dashboard/features/Managers/Popups/AddManagerPopup/AddManagerForm/AddManagerForm.test.tsx
@@ -4,6 +4,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 
 import { mockedFullParticipant1, mockedFullParticipant2 } from 'shared/mock';
 import { ParticipantTag, Roles } from 'shared/consts';
+import { ApiLanguages } from 'api';
 
 import { AddManagerForm } from './AddManagerForm';
 import { AddManagerFormValues } from '../AddManagerPopup.types';
@@ -108,5 +109,28 @@ describe('AddManagerForm component tests', () => {
     fireEvent.submit(form);
 
     expect(mockOnSubmit).toHaveBeenCalled();
+  });
+
+  test('Invitation language dropdown lists every ApiLanguages value with its translated label', () => {
+    render(<AddManagerFormTest />);
+
+    const trigger = screen.getByTestId(`${dataTestid}-lang`).querySelector('[role="combobox"]');
+    expect(trigger).not.toBeNull();
+    fireEvent.mouseDown(trigger as Element);
+
+    const expectedLabels: Record<ApiLanguages, string> = {
+      [ApiLanguages.EN]: 'English',
+      [ApiLanguages.FR]: 'French',
+      [ApiLanguages.EL]: 'Greek',
+      [ApiLanguages.ES]: 'Spanish',
+      [ApiLanguages.PT]: 'Portuguese',
+      [ApiLanguages.AF]: 'Afrikaans',
+      [ApiLanguages.XH]: 'Xhosa',
+      [ApiLanguages.ZU]: 'Zulu',
+    };
+
+    Object.values(ApiLanguages).forEach((lang) => {
+      expect(screen.getByRole('option', { name: expectedLabels[lang] })).toBeInTheDocument();
+    });
   });
 });

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -1798,6 +1798,7 @@
   "workspaceSelection": "Select Workspace",
   "workspacesLoading": "Checking your workspaces",
   "workspaceTooltip": "Workspace name displays to the managers you have invited to your applet within their interface.",
+  "xh": "Xhosa",
   "year": "Year",
   "years": "Years",
   "yes": "Yes",

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -1805,6 +1805,7 @@
   "yesAuthorize": "Yes, authorize",
   "yesRemove": "Yes, Remove",
   "youNeedToAuthorize": "You Need to Authorize",
+  "zu": "Zulu",
   "positiveIntegerRequired": "A positive integer is required",
   "positiveIntegerOrZeroRequired": "A positive integer or 0 is required",
   "fromToHint": "From {{min}} to {{max}}",

--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -203,6 +203,7 @@
   "addUsers": "Add Users",
   "addViaCSV": "Add via CSV",
   "advancedSettings": "Advanced Settings",
+  "af": "Afrikaans",
   "ageQuestion": "How old are you?<br><br>*Please provide your response as accurately as possible. The information you provide is important for ensuring the accuracy of your results. If you have any concerns about how your information will be used, please refer to our Terms of Service.*",
   "ageFieldTypeLabel": "Age field type:",
   "ageFieldTypeText": "Text Field",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -1797,6 +1797,7 @@
   "workspaceSelection": "Sélectionnez l'espace de travail",
   "workspacesLoading": "Vérification de vos espaces de travail",
   "workspaceTooltip": "Le nom de l'espace de travail s'affiche pour les gestionnaires que vous avez invités à votre applet dans leur interface.",
+  "xh": "Xhosa",
   "year": "Année",
   "years": "Années",
   "yes": "Oui",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -203,6 +203,7 @@
   "addUsers": "Ajouter des utilisateurs",
   "addViaCSV": "Ajouter via CSV",
   "advancedSettings": "Paramètres avancés",
+  "af": "Afrikaans",
   "ageQuestion": "Quel âge avez-vous?<br><br>*Veuillez fournir votre réponse aussi précisément que possible. Les informations que vous fournissez sont importantes pour garantir l'exactitude de vos résultats. Si vous avez des inquiétudes quant à la manière dont vos informations seront utilisées, veuillez vous référer à nos Conditions d'utilisation.*",
   "ageFieldTypeLabel": "Type de champ d'âge :",
   "ageFieldTypeText": "Champ de texte",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -1804,6 +1804,7 @@
   "yesAuthorize": "Oui, autoriser",
   "yesRemove": "Oui, supprimer",
   "youNeedToAuthorize": "Vous devez autoriser",
+  "zu": "Zoulou",
   "positiveIntegerRequired": "Un entier positif est requis",
   "positiveIntegerOrZeroRequired": "Un entier positif ou 0 est requis",
   "fromToHint": "De {{min}} à {{max}}",

--- a/src/shared/api/api.const.ts
+++ b/src/shared/api/api.const.ts
@@ -6,6 +6,7 @@ export enum ApiLanguages {
   PT = 'pt',
   AF = 'af',
   XH = 'xh',
+  ZU = 'zu',
 }
 
 export const DEFAULT_CONFIG = {

--- a/src/shared/api/api.const.ts
+++ b/src/shared/api/api.const.ts
@@ -5,6 +5,7 @@ export enum ApiLanguages {
   ES = 'es',
   PT = 'pt',
   AF = 'af',
+  XH = 'xh',
 }
 
 export const DEFAULT_CONFIG = {

--- a/src/shared/api/api.const.ts
+++ b/src/shared/api/api.const.ts
@@ -4,6 +4,7 @@ export enum ApiLanguages {
   EL = 'el',
   ES = 'es',
   PT = 'pt',
+  AF = 'af',
 }
 
 export const DEFAULT_CONFIG = {


### PR DESCRIPTION
- [x] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to Curious [open source credit page](https://mindlogger.atlassian.net/wiki/spaces/MINDLOGGER1/pages/263127186/Admin+Panel+Applet+Builder+Library)
- [ ] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

🔗 [Jira Ticket M2-10765](https://mindlogger.atlassian.net/browse/M2-10765)

Adds Afrikaans, isiXhosa and isiZulu as invitation email language options, same pattern as PR #2123 (Portuguese). Admin UI itself stays en/fr - only the invitation language dropdown picks up the new entries.

Changes:

- Added `AF`, `XH`, `ZU` to the `ApiLanguages` enum
- Added the labels in `app-en.json` and `app-fr.json`
- Added unit tests on `AddParticipantForm` and `AddManagerForm` to assert the dropdown lists all 8 options

The forms and Yup schemas iterate over `Object.values(ApiLanguages)`, so nothing else needed changing.

### 🪤 Peer Testing

- Open Add Manager / Add Participant / Upgrade Account, click the Invitation Language dropdown.

    **Expected:** 8 options - English, French, Greek, Spanish, Portuguese, Afrikaans, Xhosa, Zulu.

- Switch the admin UI to French via the footer language picker and reopen the dropdown.

    **Expected:** Same 8 entries with French labels (Anglais, Français, Grec, Espagnol, Portugais, Afrikaans, Xhosa, Zoulou).

### ✏️ Notes

Backend email template support for these languages is in a separate PR on `mindlogger-backend-refactor`. Until that deploys, picking any of the three new languages falls back to the English email template.
