### PR TITLE
feat: replace mindlogger links with curious (M2-10875)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository is used for the A* `yarn eject`
 
-    **Note: this is a one-way operation. Once you `eject`, you can't go back!**n Panel of the [Curious](https://mindlogger.org/) application stack.
+    **Note: this is a one-way operation. Once you `eject`, you can't go back!**n Panel of the [Curious](https://gettingcurious.com/) application stack.
 
 ## Getting Started
 

--- a/src/modules/Auth/features/SignUp/SignUpForm/SignUpForm.tsx
+++ b/src/modules/Auth/features/SignUp/SignUpForm/SignUpForm.tsx
@@ -128,7 +128,7 @@ export const SignUpForm = () => {
           label={
             <StyledLabel>
               {t('agreement')}
-              <StyledLink href="https://mindlogger.org/terms" target="_blank">
+              <StyledLink href="https://gettingcurious.com/terms" target="_blank">
                 {t('termsOfService')}
               </StyledLink>
             </StyledLabel>

--- a/src/modules/Auth/features/SignUp/SignUpForm/SignUpForm.tsx
+++ b/src/modules/Auth/features/SignUp/SignUpForm/SignUpForm.tsx
@@ -128,7 +128,7 @@ export const SignUpForm = () => {
           label={
             <StyledLabel>
               {t('agreement')}
-              <StyledLink href="https://gettingcurious.com/terms" target="_blank">
+              <StyledLink href="https://www.gettingcurious.com/terms" target="_blank">
                 {t('termsOfService')}
               </StyledLink>
             </StyledLabel>

--- a/src/shared/components/Footer/Footer.const.ts
+++ b/src/shared/components/Footer/Footer.const.ts
@@ -1,6 +1,6 @@
 export const CMI_LINK = 'https://childmind.org';
-export const PRIVACY_LINK = 'https://mindlogger.org/privacy-policy';
-export const TERMS_LINK = 'https://mindlogger.org/terms';
-export const ABOUT_LINK = 'https://mindlogger.org';
+export const PRIVACY_LINK = 'https://gettingcurious.com/privacy-policy';
+export const TERMS_LINK = 'https://gettingcurious.com/terms';
+export const ABOUT_LINK = 'https://gettingcurious.com';
 export const CREDITS_LINK = 'https://www.gettingcurious.com/open-source-credits';
-export const SUPPORT_LINK = 'https://help.mindlogger.org';
+export const SUPPORT_LINK = 'https://help.gettingcurious.com';

--- a/src/shared/components/Footer/Footer.const.ts
+++ b/src/shared/components/Footer/Footer.const.ts
@@ -1,6 +1,6 @@
 export const CMI_LINK = 'https://childmind.org';
-export const PRIVACY_LINK = 'https://gettingcurious.com/privacy-policy';
-export const TERMS_LINK = 'https://gettingcurious.com/terms';
-export const ABOUT_LINK = 'https://gettingcurious.com';
+export const PRIVACY_LINK = 'https://www.gettingcurious.com/privacy-policy';
+export const TERMS_LINK = 'https://www.gettingcurious.com/terms';
+export const ABOUT_LINK = 'https://www.gettingcurious.com';
 export const CREDITS_LINK = 'https://www.gettingcurious.com/open-source-credits';
 export const SUPPORT_LINK = 'https://help.gettingcurious.com';


### PR DESCRIPTION
- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to Curious [open source credit page](https://mindlogger.atlassian.net/wiki/spaces/MINDLOGGER1/pages/263127186/Admin+Panel+Applet+Builder+Library)
- [ ] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

🔗 [Jira Ticket M2-10875](https://mindlogger.atlassian.net/browse/M2-10875)

Replace all `mindlogger.org` references in the Admin Panel with the new `gettingcurious.com` domain.

Changes include:

- Updated `Footer.const.ts` - replaced `PRIVACY_LINK`, `TERMS_LINK`, `ABOUT_LINK`, and `SUPPORT_LINK` constants to use `gettingcurious.com`
- Updated `SignUpForm.tsx` - replaced hardcoded `mindlogger.org/terms` link with `gettingcurious.com/terms`
- Updated `README.md` - replaced `mindlogger.org` doc link with `gettingcurious.com`

### 🪤 Peer Testing

- Navigate to the app footer and click **About**, **Terms**, **Privacy**, and **Support** links.

  **Expected outcome:** Each link opens the correct `gettingcurious.com` page.

- Go to the **Sign Up** page and click the **Terms of Service** link in the checkbox label.

  **Expected outcome:** Opens `https://gettingcurious.com/terms`.

