### PR TITLE
fix: Assign drawer drops search-selected participant (M2-10902)

### DIFF
--- a/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityAssignDrawer.tsx
+++ b/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityAssignDrawer.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { Box, Button, Drawer, Fade, IconButton } from '@mui/material';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import unionBy from 'lodash/unionBy';
 import { Controller, SubmitHandler, useForm, useWatch } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 
@@ -32,7 +33,11 @@ import {
 } from 'api';
 import { hydrateActivityFlows } from 'modules/Dashboard/utils';
 import { Activity } from 'redux/modules';
-import { AssignmentCounts, useParticipantDropdown } from 'modules/Dashboard/components';
+import {
+  AssignmentCounts,
+  ParticipantDropdownOption,
+  useParticipantDropdown,
+} from 'modules/Dashboard/components';
 import { Mixpanel, MixpanelEventType, MixpanelProps } from 'shared/utils';
 import { useGetAppletActivitiesQuery } from 'modules/Dashboard/api/apiSlice';
 
@@ -94,6 +99,18 @@ export const ActivityAssignDrawer = React.memo(
     } = useParticipantDropdown({
       appletId,
     });
+
+    // Remember participants picked via search so they remain resolvable after selection
+    const [selectedParticipants, setSelectedParticipants] = useState<ParticipantDropdownOption[]>(
+      [],
+    );
+    const knownParticipants = useMemo(
+      () => unionBy(allParticipants, selectedParticipants, 'id'),
+      [allParticipants, selectedParticipants],
+    );
+    const handleParticipantSelect = useCallback((option: ParticipantDropdownOption | null) => {
+      if (option) setSelectedParticipants((prev) => unionBy(prev, [option], 'id'));
+    }, []);
 
     const {
       data: activitiesData,
@@ -438,6 +455,8 @@ export const ActivityAssignDrawer = React.memo(
         }, 300);
       } else {
         removeAllBanners();
+        // Drop remembered search selections so they don't linger into the next session
+        setSelectedParticipants([]);
       }
     }, [open, allParticipants]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -603,6 +622,8 @@ export const ActivityAssignDrawer = React.memo(
                       <AssignmentsTable
                         {...dropdownProps}
                         allParticipants={allParticipants}
+                        knownParticipants={knownParticipants}
+                        onParticipantSelect={handleParticipantSelect}
                         assignments={value}
                         onChange={onChange}
                         onAdd={() =>
@@ -645,6 +666,7 @@ export const ActivityAssignDrawer = React.memo(
                     <ActivityReview
                       {...dropdownProps}
                       allParticipants={allParticipants}
+                      knownParticipants={knownParticipants}
                       key={flow.id}
                       isSingleActivity={flowIds.length + activityIds.length === 1}
                       index={index}
@@ -666,6 +688,7 @@ export const ActivityAssignDrawer = React.memo(
                     <ActivityReview
                       {...dropdownProps}
                       allParticipants={allParticipants}
+                      knownParticipants={knownParticipants}
                       key={activity.id}
                       isSingleActivity={flowIds.length + activityIds.length === 1}
                       index={index + flowIds.length}

--- a/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityReview/ActivityReview.types.ts
+++ b/src/modules/Dashboard/components/ActivityAssignDrawer/ActivityReview/ActivityReview.types.ts
@@ -1,6 +1,6 @@
 import { Activity } from 'redux/modules';
 import { HydratedActivityFlow } from 'modules/Dashboard/types';
-import { useParticipantDropdown } from 'modules/Dashboard/components';
+import { ParticipantDropdownOption, useParticipantDropdown } from 'modules/Dashboard/components';
 
 import { ValidActivityAssignment } from '../ActivityAssignDrawer.types';
 
@@ -19,6 +19,8 @@ export type ActivityReviewProps = {
   index: number;
   assignments: ValidActivityAssignment[];
   onDelete: (activityOrFlow: Activity | HydratedActivityFlow) => void;
+  // Forwarded to the read-only table so search-selected participants resolve
+  knownParticipants?: ParticipantDropdownOption[];
   'data-testid': string;
 } & (ActivityReviewWithActivity | ActivityReviewWithFlow) &
   Omit<ReturnType<typeof useParticipantDropdown>, 'isLoading'>;

--- a/src/modules/Dashboard/components/ActivityAssignDrawer/AssignmentsTable/AssignmentsTable.tsx
+++ b/src/modules/Dashboard/components/ActivityAssignDrawer/AssignmentsTable/AssignmentsTable.tsx
@@ -19,6 +19,8 @@ import { getHeadCells } from './AssignmentsTable.utils';
 
 export const AssignmentsTable = ({
   allParticipants,
+  knownParticipants,
+  onParticipantSelect,
   participantsOnly,
   fullAccountParticipantsAndTeamMembers,
   teamMembersOnly,
@@ -34,12 +36,18 @@ export const AssignmentsTable = ({
   const {
     featureFlags: { enableParticipantMultiInformant },
   } = useFeatureFlags();
+  // Resolve selected ids from the wider list when provided, falling back to the snapshot
+  const resolveParticipants = knownParticipants ?? allParticipants;
   const lastAssignment = assignments[assignments.length - 1];
   const showAddButton =
     !isReadOnly && lastAssignment?.respondentSubjectId && lastAssignment?.targetSubjectId;
 
   const handleChange = useCallback(
-    ({ respondentSubjectId, targetSubjectId }: ActivityAssignment, index: number) => {
+    (
+      { respondentSubjectId, targetSubjectId }: ActivityAssignment,
+      index: number,
+      respondentOption?: ParticipantDropdownOption | null,
+    ) => {
       const updatedAssignments = [...assignments];
 
       if (respondentSubjectId !== undefined || targetSubjectId !== undefined) {
@@ -47,7 +55,9 @@ export const AssignmentsTable = ({
           // Set as self-assigned if newly selected respondent is a full account, and either:
           // - no target subject has been selected yet, or
           // - current assignment is a self-assignment (to preserve "Self" in the right column)
-          const respondent = allParticipants.find(({ id }) => id === respondentSubjectId);
+          // Prefer the just-picked option since it may not be in the resolve list yet
+          const respondent =
+            respondentOption ?? resolveParticipants.find(({ id }) => id === respondentSubjectId);
           if (respondent?.userId && !respondent.isTeamMember) {
             if (
               !assignments[index].targetSubjectId ||
@@ -65,7 +75,7 @@ export const AssignmentsTable = ({
         onChange?.(updatedAssignments);
       }
     },
-    [allParticipants, assignments, onChange],
+    [resolveParticipants, assignments, onChange],
   );
 
   const handleAdd = useCallback(() => {
@@ -105,11 +115,13 @@ export const AssignmentsTable = ({
   const rows: DashboardTableProps['rows'] = useMemo(
     () =>
       assignments.map(({ respondentSubjectId, targetSubjectId }, index) => {
+        // Resolve from the wider list so search-selected participants still render
         const respondent =
-          (respondentSubjectId && allParticipants.find(({ id }) => id === respondentSubjectId)) ||
+          (respondentSubjectId &&
+            resolveParticipants.find(({ id }) => id === respondentSubjectId)) ||
           null;
         const subject =
-          (targetSubjectId && allParticipants.find(({ id }) => id === targetSubjectId)) || null;
+          (targetSubjectId && resolveParticipants.find(({ id }) => id === targetSubjectId)) || null;
 
         const selfOption: ParticipantDropdownOption | null =
           respondent && !respondent.isTeamMember
@@ -143,9 +155,10 @@ export const AssignmentsTable = ({
                     ? fullAccountParticipantsAndTeamMembers
                     : teamMembersOnly
                 }
-                onChange={(value) =>
-                  handleChange({ respondentSubjectId: value && value.id }, index)
-                }
+                onChange={(value) => {
+                  onParticipantSelect?.(value);
+                  handleChange({ respondentSubjectId: value && value.id }, index, value);
+                }}
                 handleSearch={handleRespondentSearch}
                 showGroups
                 emptyValueError={subjectValue && !subject?.userId ? t('addRespondent') : undefined}
@@ -163,7 +176,10 @@ export const AssignmentsTable = ({
                 isReadOnly={isReadOnly}
                 value={subjectValue}
                 options={subjectOptions}
-                onChange={(value) => handleChange({ targetSubjectId: value && value.id }, index)}
+                onChange={(value) => {
+                  onParticipantSelect?.(value);
+                  handleChange({ targetSubjectId: value && value.id }, index);
+                }}
                 handleSearch={(query) => handleSubjectSearch(query, selfOption)}
                 groupBy={(option) => (option.id === selfOption?.id ? 'self' : 'other')}
                 renderGroup={(params) => (
@@ -186,7 +202,8 @@ export const AssignmentsTable = ({
         };
       }),
     [
-      allParticipants,
+      resolveParticipants,
+      onParticipantSelect,
       assignments,
       dataTestId,
       enableParticipantMultiInformant,

--- a/src/modules/Dashboard/components/ActivityAssignDrawer/AssignmentsTable/AssignmentsTable.types.ts
+++ b/src/modules/Dashboard/components/ActivityAssignDrawer/AssignmentsTable/AssignmentsTable.types.ts
@@ -15,6 +15,10 @@ export type AssignmentsTableProps = Omit<ReturnType<typeof useParticipantDropdow
   errors?: {
     duplicateRows?: `${string}_${string}`[];
   };
+  // Superset of allParticipants used to resolve selected ids (e.g. ones found via search)
+  knownParticipants?: ParticipantDropdownOption[];
+  // Reports each picked option so the parent can remember participants not in the snapshot
+  onParticipantSelect?: (option: ParticipantDropdownOption | null) => void;
   'data-testid': string;
 };
 


### PR DESCRIPTION
- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to Curious [open source credit page](https://mindlogger.atlassian.net/wiki/spaces/MINDLOGGER1/pages/263127186/Admin+Panel+Applet+Builder+Library)
- [ ] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

🔗 [Jira Ticket M2-10902](https://mindlogger.atlassian.net/browse/M2-10902)

The Assign drawer loads the participant list once when it opens. If we search for a participant who isn't in that list (e.g. one who accepted their invite after the drawer loaded), selecting them worked, but the **Assign to** field then went blank and showed a false "Add Respondent" warning. The assignment was saving correctly , it was only the display that was wrong.

This happened because the field's displayed value was always rebuilt from that initial list, which didn't include search-only participants.

Changes include:

- Remember participants picked from search in the Assign drawer, and use that list (plus the original one) to resolve what's shown in the dropdowns.
- Apply the same on the review step so the participant shows there too.
- No changes to search itself or the shared participant dropdown hook (avoids re-renders that affect the Take Now modal).

### 🪤 Peer Testing

Preconditions: an activity/flow with Auto-assign off, on the Applet > Participant page.

- Add a new full participant and accept the invite from the email. **Do not refresh the admin page.**
- Switch to **Activities**, click **Assign** → **Assign to**, and note the new participant isn't in the list.
- Search for them, then select them.

    **Expected outcome:** The participant stays shown in the **Assign to** field.

- Pick a user in **Who is activity about**.

    **Expected outcome:** The **Assign to** field still shows the selected participant - no "Add Respondent" warning. Completing the assignment works as normal.

### ✏️ Notes

Scoped to the display issue when searching/selecting a participant. It does not make a just-accepted participant appear in the list automatically - we still search for them (or refresh). 