### PR TITLE
feat: `enableAuditLogs` feature flag (M2-10882)

### DIFF
--- a/src/modules/Dashboard/components/HeaderOptions/HeaderOptions.test.tsx
+++ b/src/modules/Dashboard/components/HeaderOptions/HeaderOptions.test.tsx
@@ -4,6 +4,7 @@ import { vi } from 'vitest';
 import { renderWithProviders } from 'shared/utils/renderWithProviders';
 import { mockedApplet, mockedCurrentWorkspace } from 'shared/mock';
 import { Roles } from 'shared/consts';
+import { useFeatureFlags } from 'shared/hooks';
 import { initialStateData } from 'shared/state';
 import { Mixpanel, MixpanelEventType, MixpanelProps } from 'shared/utils';
 
@@ -91,7 +92,8 @@ describe('HeaderOptions', () => {
     );
   });
 });
-describe('should show or hide header buttons depending on role', () => {
+
+describe('HeaderOptions show or hide depending on role', () => {
   test.each`
     canEdit  | canAccessData | role                 | description
     ${true}  | ${true}       | ${Roles.Manager}     | ${'header for Manager'}
@@ -115,5 +117,25 @@ describe('should show or hide header buttons depending on role', () => {
     canAccessData
       ? expect(exportButtons.length).toBeGreaterThan(0)
       : expect(exportButtons.length).toBe(0);
+  });
+});
+
+describe('HeaderOptions show or hide depending on feature flag', () => {
+  beforeEach(() => {
+    vi.mocked(useFeatureFlags).mockReturnValue({
+      featureFlags: { enableAuditLogs: false },
+      resetLDContext: vi.fn(),
+    });
+    renderWithProviders(<HeaderOptions />, { preloadedState: getPreloadedState() });
+  });
+
+  afterEach(() => {
+    vi.mocked(useFeatureFlags).mockReset();
+  });
+
+  test('header for enableAuditLogs off', () => {
+    fireEvent.click(screen.getByTestId('header-option-export-button'));
+    expect(screen.queryByTestId('header-option-response-data-button')).toBeInTheDocument();
+    expect(screen.queryByTestId('header-option-audit-logs-button')).not.toBeInTheDocument();
   });
 });

--- a/src/modules/Dashboard/components/HeaderOptions/HeaderOptions.tsx
+++ b/src/modules/Dashboard/components/HeaderOptions/HeaderOptions.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 
 import { page } from 'resources';
 import { Menu, Svg } from 'shared/components';
+import { useFeatureFlags } from 'shared/hooks';
 import { ExportDataSetting } from 'shared/features/AppletSettings';
 import { StyledFlexTopCenter, variables } from 'shared/styles';
 import {
@@ -23,6 +24,7 @@ export const HeaderOptions = () => {
   const [isAuditLogsExportOpen, setIsAuditLogsExportOpen] = useState(false);
 
   const { t } = useTranslation('app');
+  const { featureFlags } = useFeatureFlags();
   const { appletId } = useParams();
   const isSettingsSelected = location.pathname.includes('settings');
   const workspaceRoles = workspaces.useRolesData();
@@ -65,20 +67,27 @@ export const HeaderOptions = () => {
   const canAccessData = checkIfCanAccessData(roles);
   const canEdit = checkIfCanEdit(roles);
 
-  const getExportActions = () => [
-    {
-      icon: <Svg id="response-data" />,
-      action: handleOpenResponseData,
-      title: t('dataExport.responseData.menuCaption'),
-      'data-testid': 'header-option-response-data-button',
-    },
-    {
-      icon: <Svg id="audit-logs" />,
-      action: handleOpenAuditLogs,
-      title: t('dataExport.auditLogs.menuCaption'),
-      'data-testid': 'header-option-audit-logs-button',
-    },
-  ];
+  const getExportActions = () => {
+    const actions = [
+      {
+        icon: <Svg id="response-data" />,
+        action: handleOpenResponseData,
+        title: t('dataExport.responseData.menuCaption'),
+        'data-testid': 'header-option-response-data-button',
+      },
+    ];
+
+    if (featureFlags.enableAuditLogs) {
+      actions.push({
+        icon: <Svg id="audit-logs" />,
+        action: handleOpenAuditLogs,
+        title: t('dataExport.auditLogs.menuCaption'),
+        'data-testid': 'header-option-audit-logs-button',
+      });
+    }
+
+    return actions;
+  };
 
   return canEdit || canAccessData ? (
     <StyledFlexTopCenter sx={{ gap: 1, ml: 'auto' }}>
@@ -117,12 +126,14 @@ export const HeaderOptions = () => {
         onExportSettingsClose={handleCloseResponseData}
         data-testid={'response-data-export'}
       />
-      <AuditLogsExportSetting
-        isExportSettingsOpen={isAuditLogsExportOpen}
-        onExportSettingsClose={handleCloseAuditLogsExport}
-        data-testid={'audit-logs-export'}
-        onExportPopupClose={() => setIsAuditLogsExportOpen(false)}
-      />
+      {featureFlags.enableAuditLogs && (
+        <AuditLogsExportSetting
+          isExportSettingsOpen={isAuditLogsExportOpen}
+          onExportSettingsClose={handleCloseAuditLogsExport}
+          data-testid={'audit-logs-export'}
+          onExportPopupClose={() => setIsAuditLogsExportOpen(false)}
+        />
+      )}
     </StyledFlexTopCenter>
   ) : null;
 };

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -81,6 +81,7 @@ vi.mock('shared/hooks/useFeatureFlags', () => ({
       enableParticipantMultiInformant: true,
       enableMfa: false,
       enableAdminAnnouncementBanner: false,
+      enableAuditLogs: true,
     },
     resetLDContext: vi.fn(),
   })),

--- a/src/shared/hooks/useFeatureFlags.const.ts
+++ b/src/shared/hooks/useFeatureFlags.const.ts
@@ -22,6 +22,7 @@ export const FeatureFlagDefaults: FeatureFlags = {
   enableEmaExtraFiles: false,
   enableMfa: true,
   enableAdminAnnouncementBanner: false,
+  enableAuditLogs: false,
 };
 
 export const PROHIBITED_PII_KEYS = ['firstName', 'lastName', 'email'];

--- a/src/shared/types/featureFlags.ts
+++ b/src/shared/types/featureFlags.ts
@@ -25,4 +25,5 @@ export type FeatureFlags = Partial<{
   enableEmaExtraFiles: boolean;
   enableMfa: boolean;
   enableAdminAnnouncementBanner: boolean;
+  enableAuditLogs: boolean;
 }>;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,3 +1,4 @@
+import { availableParallelism } from 'os';
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import { resolve } from 'path';
@@ -15,6 +16,13 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./src/setupTests.ts', 'dotenv/config'],
     globalSetup: './src/vitest.global-setup.ts',
+    poolOptions: {
+      forks: {
+        // cap forks below core count to avoid timeout from resource overload on heavy tests
+        maxForks: Math.ceil(availableParallelism() / 2),
+        minForks: 1,
+      },
+    },
     coverage: {
       reporter: ['text', 'json', 'html'],
       exclude: ['node_modules/', 'src/setupTests.ts'],


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-10882](https://mindlogger.atlassian.net/browse/M2-10882)

Changes include:

- `enableAuditLogs` feature flag to show/hide audit logs export

### ✏️ Notes

We can use LaunchDarkly rules to configure the flag by workspace.