### PR TITLE
fix: No Export dropdown if audit log disabled (M2-10978)

### DIFF
--- a/src/modules/Dashboard/components/HeaderOptions/HeaderOptions.test.tsx
+++ b/src/modules/Dashboard/components/HeaderOptions/HeaderOptions.test.tsx
@@ -135,7 +135,9 @@ describe('HeaderOptions show or hide depending on feature flag', () => {
 
   test('header for enableAuditLogs off', () => {
     fireEvent.click(screen.getByTestId('header-option-export-button'));
-    expect(screen.queryByTestId('header-option-response-data-button')).toBeInTheDocument();
-    expect(screen.queryByTestId('header-option-audit-logs-button')).not.toBeInTheDocument();
+
+    expect(screen.queryByTestId('header-option-export-menu')).not.toBeInTheDocument();
+    expect(screen.getByTestId('response-data-export-settings')).toBeInTheDocument();
+    expect(spyMixpanelTrack).toHaveBeenCalledWith({ action: MixpanelEventType.ExportDataClick });
   });
 });

--- a/src/modules/Dashboard/components/HeaderOptions/HeaderOptions.tsx
+++ b/src/modules/Dashboard/components/HeaderOptions/HeaderOptions.tsx
@@ -33,9 +33,9 @@ export const HeaderOptions = () => {
   const exportButtonRef = useRef<HTMLButtonElement>(null);
 
   const handleOpenExportMenu = () => {
-    const fullAccess = checkIfFullAccess(roles);
+    const canExportAuditLogs = checkIfFullAccess(roles) && featureFlags.enableAuditLogs;
 
-    if (fullAccess) {
+    if (canExportAuditLogs) {
       setShowExportMenu(true);
     } else {
       setIsResponseDataExportOpen(true);
@@ -67,27 +67,20 @@ export const HeaderOptions = () => {
   const canAccessData = checkIfCanAccessData(roles);
   const canEdit = checkIfCanEdit(roles);
 
-  const getExportActions = () => {
-    const actions = [
-      {
-        icon: <Svg id="response-data" />,
-        action: handleOpenResponseData,
-        title: t('dataExport.responseData.menuCaption'),
-        'data-testid': 'header-option-response-data-button',
-      },
-    ];
-
-    if (featureFlags.enableAuditLogs) {
-      actions.push({
-        icon: <Svg id="audit-logs" />,
-        action: handleOpenAuditLogs,
-        title: t('dataExport.auditLogs.menuCaption'),
-        'data-testid': 'header-option-audit-logs-button',
-      });
-    }
-
-    return actions;
-  };
+  const getExportActions = () => [
+    {
+      icon: <Svg id="response-data" />,
+      action: handleOpenResponseData,
+      title: t('dataExport.responseData.menuCaption'),
+      'data-testid': 'header-option-response-data-button',
+    },
+    {
+      icon: <Svg id="audit-logs" />,
+      action: handleOpenAuditLogs,
+      title: t('dataExport.auditLogs.menuCaption'),
+      'data-testid': 'header-option-audit-logs-button',
+    },
+  ];
 
   return canEdit || canAccessData ? (
     <StyledFlexTopCenter sx={{ gap: 1, ml: 'auto' }}>


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-10978](https://mindlogger.atlassian.net/browse/M2-10978)

Changes include:

- Display export modal immediately instead of opening dropdown with a single **Responses** option.