### PR TITLE
feat: Share session between tabs via BroadcastChannel (M2-11052)

### DIFF
--- a/src/modules/Auth/state/Auth.thunk.test.ts
+++ b/src/modules/Auth/state/Auth.thunk.test.ts
@@ -2,6 +2,7 @@ import { vi } from 'vitest';
 
 import { verifyMFATOTPApi, verifyMFARecoveryCodeApi } from 'api';
 import { setupStore } from 'redux/store';
+import { getLoginAt } from 'shared/hooks/useSessionKeepAlive/sessionSync.utils';
 
 import { verifyMFATOTP, verifyMFARecoveryCode } from './Auth.thunk';
 
@@ -54,6 +55,7 @@ const getPreloadedState = () => ({
 describe('Auth MFA thunks', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    sessionStorage.clear();
   });
 
   it('rejects TOTP verification responses that do not include tokens', async () => {
@@ -89,5 +91,33 @@ describe('Auth MFA thunks', () => {
     expect(state.recoveryVerification.status).toBe('error');
     expect(state.recoveryVerification.displayError).toBeDefined();
     expect(state.mfaSession).toBeDefined();
+  });
+
+  it('stamps the login time once TOTP verification succeeds', async () => {
+    mockVerifyMFATOTPApi.mockResolvedValueOnce({
+      data: {
+        result: {
+          token: { accessToken: 'access-token', refreshToken: 'refresh-token' },
+          user: { id: 'user-1' },
+        },
+      },
+    } as never);
+
+    const store = setupStore(getPreloadedState());
+    const before = Date.now();
+
+    await store.dispatch(verifyMFATOTP({ totpCode: '123456' }));
+
+    expect(getLoginAt()).toBeGreaterThanOrEqual(before);
+  });
+
+  it('does not stamp the login time when TOTP verification is rejected', async () => {
+    mockVerifyMFATOTPApi.mockResolvedValueOnce({ data: { message: 'Invalid TOTP code' } } as never);
+
+    const store = setupStore(getPreloadedState());
+
+    await store.dispatch(verifyMFATOTP({ totpCode: '123456' }));
+
+    expect(getLoginAt()).toBeNull();
   });
 });

--- a/src/modules/Auth/state/Auth.thunk.ts
+++ b/src/modules/Auth/state/Auth.thunk.ts
@@ -8,6 +8,7 @@ import { Mixpanel } from 'shared/utils/mixpanel';
 import { getApiErrorResult, getErrorMessage } from 'shared/utils/errors';
 import { ApiErrorResponse } from 'shared/state/Base';
 import { FeatureFlags } from 'shared/utils/featureFlags';
+import { stampLoginAt } from 'shared/hooks/useSessionKeepAlive/sessionSync.utils';
 import {
   getUserDetailsApi,
   ResetPassword,
@@ -80,6 +81,7 @@ export const signIn = createAsyncThunk(
         const { accessToken, refreshToken } = data.result.token;
         authStorage.setRefreshToken(refreshToken);
         authStorage.setAccessToken(accessToken);
+        stampLoginAt();
 
         datadogRum.setUser({ id: data.result.user.id });
         Mixpanel.login(data.result.user.id);
@@ -177,6 +179,7 @@ export const verifyMFATOTP = createAsyncThunk(
         const { accessToken, refreshToken } = data.result.token;
         authStorage.setRefreshToken(refreshToken);
         authStorage.setAccessToken(accessToken);
+        stampLoginAt();
 
         datadogRum.setUser({ id: data.result.user.id });
         Mixpanel.login(data.result.user.id);
@@ -221,6 +224,7 @@ export const verifyMFARecoveryCode = createAsyncThunk(
         const { accessToken, refreshToken } = data.result.token;
         authStorage.setRefreshToken(refreshToken);
         authStorage.setAccessToken(accessToken);
+        stampLoginAt();
 
         datadogRum.setUser({ id: data.result.user.id });
         Mixpanel.login(data.result.user.id);

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -33,10 +33,12 @@ const AppRoutes = () => {
   const loaded = (!token || status === 'error' || status === 'success') && !isAdopting;
 
   useEffect(() => {
-    if (!isAuthorized && token) {
+    // Held back while adopting too: a tab reloading with tokens that expired while it was
+    // discarded would 401 here, and the retry would spend a refresh token the session retired.
+    if (!isAuthorized && token && !isAdopting) {
       dispatch(auth.thunk.getUserDetails());
     }
-  }, [isAuthorized, token, dispatch]);
+  }, [isAuthorized, token, isAdopting, dispatch]);
 
   useSessionBanners();
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -13,7 +13,7 @@ import { AppletNotFoundPopup } from 'shared/components';
 import { NoPermissionPopup } from 'shared/components/NoPermissionPopup';
 import { useSessionBanners } from 'shared/hooks/useSessionBanners';
 import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
-import { SessionKeepAlive } from 'shared/hooks/useSessionKeepAlive';
+import { SessionKeepAlive, useSessionAdoption } from 'shared/hooks/useSessionKeepAlive';
 
 import history from './history';
 
@@ -27,7 +27,10 @@ const AppRoutes = () => {
   const { featureFlags } = useFeatureFlags();
 
   const status = auth.useStatus();
-  const loaded = !token || status === 'error' || status === 'success';
+  // Routes stay unrendered while a fresh tab asks other tabs for a session, so the login page
+  // cannot flash and then flip to the dashboard once one is adopted.
+  const isAdopting = useSessionAdoption();
+  const loaded = (!token || status === 'error' || status === 'success') && !isAdopting;
 
   useEffect(() => {
     if (!isAuthorized && token) {

--- a/src/shared/api/api.utils.test.ts
+++ b/src/shared/api/api.utils.test.ts
@@ -2,6 +2,15 @@ import axios, { AxiosError } from 'axios';
 
 import { authStorage } from 'shared/utils/authStorage';
 import { getRotatedAt } from 'shared/hooks/useSessionKeepAlive/sessionSync.utils';
+import {
+  closeSessionSync,
+  subscribeSessionSync,
+} from 'shared/hooks/useSessionKeepAlive/sessionSync';
+import { SESSION_CHANNEL_NAME } from 'shared/hooks/useSessionKeepAlive/sessionSync.const';
+import {
+  InMemoryBroadcastChannel,
+  resetInMemoryBroadcastChannels,
+} from 'shared/tests/InMemoryBroadcastChannel';
 
 import { refreshTokenAndReattemptRequest, refreshTokens, shouldNotSkipRoute } from './api.utils';
 import { signInRefreshTokenApi } from './api';
@@ -108,6 +117,86 @@ describe('refreshTokens', () => {
     await expect(refreshTokens()).rejects.toThrow('network down');
 
     expect(getRotatedAt()).toBeNull();
+  });
+});
+
+const tokenWithClaims = (claims: Record<string, string>) =>
+  `header.${btoa(JSON.stringify(claims))}.signature`;
+
+describe('refreshTokens broadcast', () => {
+  let onSiblingMessage: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    vi.stubGlobal('BroadcastChannel', InMemoryBroadcastChannel);
+    // Stands in for this tab's engine, without which nothing is broadcast at all.
+    subscribeSessionSync(vi.fn());
+
+    const sibling = new InMemoryBroadcastChannel(SESSION_CHANNEL_NAME);
+    onSiblingMessage = vi.fn();
+    sibling.onmessage = onSiblingMessage;
+  });
+
+  afterEach(() => {
+    closeSessionSync();
+    resetInMemoryBroadcastChannels();
+    vi.unstubAllGlobals();
+  });
+
+  test('announces the new tokens to sibling tabs', async () => {
+    authStorage.setRefreshToken(tokenWithClaims({ family: 'family-1' }));
+    resolveWith(tokens);
+
+    await refreshTokens();
+
+    expect(onSiblingMessage).toHaveBeenCalledWith({
+      data: {
+        type: 'TOKENS_UPDATED',
+        payload: {
+          sessionId: 'family-1',
+          accessToken: 'new-access',
+          refreshToken: 'new-refresh',
+        },
+      },
+    });
+  });
+
+  test('announces the id siblings still hold, not the incoming one', async () => {
+    authStorage.setRefreshToken(tokenWithClaims({ jti: 'jti-old' }));
+    resolveWith({
+      accessToken: 'new-access',
+      refreshToken: tokenWithClaims({ jti: 'jti-new' }),
+      tokenType: 'Bearer',
+    });
+
+    await refreshTokens();
+
+    expect(onSiblingMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          payload: expect.objectContaining({ sessionId: 'jti-old' }),
+        }),
+      }),
+    );
+  });
+
+  test('announces nothing when the refresh fails', async () => {
+    authStorage.setRefreshToken(tokenWithClaims({ family: 'family-1' }));
+    mockedSignInRefreshTokenApi.mockRejectedValue(new Error('network down'));
+
+    await expect(refreshTokens()).rejects.toThrow('network down');
+
+    expect(onSiblingMessage).not.toHaveBeenCalled();
+  });
+
+  test('announces nothing when the token carries no session id', async () => {
+    authStorage.setRefreshToken('opaque-token');
+    resolveWith(tokens);
+
+    await refreshTokens();
+
+    expect(onSiblingMessage).not.toHaveBeenCalled();
   });
 });
 

--- a/src/shared/api/api.utils.test.ts
+++ b/src/shared/api/api.utils.test.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosError } from 'axios';
 
 import { authStorage } from 'shared/utils/authStorage';
+import { getRotatedAt } from 'shared/hooks/useSessionKeepAlive/sessionSync.utils';
 
 import { refreshTokenAndReattemptRequest, refreshTokens, shouldNotSkipRoute } from './api.utils';
 import { signInRefreshTokenApi } from './api';
@@ -24,6 +25,7 @@ const resolveWith = (result: typeof tokens | undefined, delayMs = 0) =>
 describe('refreshTokens', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    sessionStorage.clear();
     authStorage.setAccessToken('old-access');
     authStorage.setRefreshToken('old-refresh');
   });
@@ -89,6 +91,23 @@ describe('refreshTokens', () => {
 
     await expect(refreshTokens()).rejects.toThrow('Access token refresh failed.');
     expect(authStorage.getAccessToken()).toBe('old-access');
+  });
+
+  test('stamps the rotation time once the tokens are stored', async () => {
+    resolveWith(tokens);
+    const before = Date.now();
+
+    await refreshTokens();
+
+    expect(getRotatedAt()).toBeGreaterThanOrEqual(before);
+  });
+
+  test('leaves the rotation time alone when the request fails', async () => {
+    mockedSignInRefreshTokenApi.mockRejectedValue(new Error('network down'));
+
+    await expect(refreshTokens()).rejects.toThrow('network down');
+
+    expect(getRotatedAt()).toBeNull();
   });
 });
 

--- a/src/shared/api/api.utils.ts
+++ b/src/shared/api/api.utils.ts
@@ -3,7 +3,8 @@ import axios, { AxiosError, InternalAxiosRequestConfig } from 'axios';
 import { authStorage } from 'shared/utils/authStorage';
 import { LocalStorageKeys, storage } from 'shared/utils/storage';
 import { UiLanguages, regionalLangFormats } from 'shared/ui';
-import { stampRotatedAt } from 'shared/hooks/useSessionKeepAlive/sessionSync.utils';
+import { getSessionId, stampRotatedAt } from 'shared/hooks/useSessionKeepAlive/sessionSync.utils';
+import { publishSessionMessage } from 'shared/hooks/useSessionKeepAlive/sessionSync';
 
 import { apiRoutesToSkip, BASE_API_URL } from './api.const';
 import { signInRefreshTokenApi } from './api';
@@ -39,9 +40,19 @@ const requestNewTokens = async () => {
     throw new Error('Access token refresh failed.');
   }
 
+  // Read before the tokens change, since siblings identify by the one they still hold.
+  const sessionId = getSessionId();
+
   authStorage.setAccessToken(accessToken);
   authStorage.setRefreshToken(refreshToken);
   stampRotatedAt();
+
+  if (sessionId) {
+    publishSessionMessage({
+      type: 'TOKENS_UPDATED',
+      payload: { sessionId, accessToken, refreshToken },
+    });
+  }
 
   return { accessToken, refreshToken };
 };

--- a/src/shared/api/api.utils.ts
+++ b/src/shared/api/api.utils.ts
@@ -3,6 +3,7 @@ import axios, { AxiosError, InternalAxiosRequestConfig } from 'axios';
 import { authStorage } from 'shared/utils/authStorage';
 import { LocalStorageKeys, storage } from 'shared/utils/storage';
 import { UiLanguages, regionalLangFormats } from 'shared/ui';
+import { stampRotatedAt } from 'shared/hooks/useSessionKeepAlive/sessionSync.utils';
 
 import { apiRoutesToSkip, BASE_API_URL } from './api.const';
 import { signInRefreshTokenApi } from './api';
@@ -40,6 +41,7 @@ const requestNewTokens = async () => {
 
   authStorage.setAccessToken(accessToken);
   authStorage.setRefreshToken(refreshToken);
+  stampRotatedAt();
 
   return { accessToken, refreshToken };
 };

--- a/src/shared/hooks/useLogout.test.ts
+++ b/src/shared/hooks/useLogout.test.ts
@@ -5,8 +5,15 @@ import { page } from 'resources';
 import { ApiResponseCodes } from 'api';
 import { renderHookWithProviders } from 'shared/utils/renderHookWithProviders';
 import { getPreloadedState } from 'shared/tests/getPreloadedState';
+import {
+  InMemoryBroadcastChannel,
+  resetInMemoryBroadcastChannels,
+} from 'shared/tests/InMemoryBroadcastChannel';
+import { authStorage } from 'shared/utils/authStorage';
 
 import { useLogout } from './useLogout';
+import { closeSessionSync, subscribeSessionSync } from './useSessionKeepAlive/sessionSync';
+import { SESSION_CHANNEL_NAME } from './useSessionKeepAlive/sessionSync.const';
 
 const clearWorkspacePayload = {
   payload: null,
@@ -87,6 +94,78 @@ describe('useLogout', () => {
 
     await waitFor(() => {
       result.current();
+    });
+
+    expect(mockedUseAppDispatch).nthCalledWith(1, clearWorkspacePayload);
+    expect(mockedUseAppDispatch).nthCalledWith(2, resetAlertsPayload);
+    expect(mockedUseAppDispatch).nthCalledWith(3, resetAuthorizationPayload);
+    expect(mockedUseNavigate).toBeCalledWith(page.login);
+  });
+});
+
+describe('useLogout session sync', () => {
+  let onSiblingMessage: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    vi.stubGlobal('BroadcastChannel', InMemoryBroadcastChannel);
+    // Stands in for this tab's engine, without which nothing is broadcast at all.
+    subscribeSessionSync(vi.fn());
+    authStorage.setRefreshToken(`header.${btoa(JSON.stringify({ family: 'family-1' }))}.signature`);
+
+    const sibling = new InMemoryBroadcastChannel(SESSION_CHANNEL_NAME);
+    onSiblingMessage = vi.fn();
+    sibling.onmessage = onSiblingMessage;
+  });
+
+  afterEach(() => {
+    closeSessionSync();
+    resetInMemoryBroadcastChannels();
+    vi.unstubAllGlobals();
+  });
+
+  const renderLogout = () =>
+    renderHookWithProviders(useLogout, { preloadedState: getPreloadedState() });
+
+  test('announces the logout to sibling tabs', async () => {
+    const { result } = renderLogout();
+    vi.mocked(axios.post).mockResolvedValueOnce(null);
+
+    await waitFor(() => {
+      result.current({ reason: 'idle' });
+    });
+
+    expect(onSiblingMessage).toHaveBeenCalledWith({
+      data: { type: 'LOGOUT', payload: { sessionId: 'family-1', reason: 'idle' } },
+    });
+  });
+
+  test('a remote logout announces nothing, so it cannot cascade', async () => {
+    const { result } = renderLogout();
+
+    await waitFor(() => {
+      result.current({ isRemote: true });
+    });
+
+    expect(onSiblingMessage).not.toHaveBeenCalled();
+  });
+
+  test('a remote logout does not revoke the session a second time', async () => {
+    const { result } = renderLogout();
+
+    await waitFor(() => {
+      result.current({ isRemote: true });
+    });
+
+    expect(axios.post).not.toHaveBeenCalled();
+  });
+
+  test('a remote logout still tears this tab down', async () => {
+    const { result } = renderLogout();
+
+    await waitFor(() => {
+      result.current({ isRemote: true });
     });
 
     expect(mockedUseAppDispatch).nthCalledWith(1, clearWorkspacePayload);

--- a/src/shared/hooks/useLogout.ts
+++ b/src/shared/hooks/useLogout.ts
@@ -9,6 +9,15 @@ import { alerts, auth, workspaces } from 'redux/modules';
 import { deleteAccessTokenApi, deleteRefreshTokenApi } from 'modules/Auth/api';
 import { Mixpanel, MixpanelEventType } from 'shared/utils/mixpanel';
 import { FeatureFlags } from 'shared/utils/featureFlags';
+import { publishSessionMessage } from 'shared/hooks/useSessionKeepAlive/sessionSync';
+import { LogoutReason } from 'shared/hooks/useSessionKeepAlive/sessionSync.types';
+import { getSessionId } from 'shared/hooks/useSessionKeepAlive/sessionSync.utils';
+
+type LogoutOptions = {
+  shouldSoftLock?: boolean;
+  reason?: LogoutReason;
+  isRemote?: boolean;
+};
 
 export const useLogout = () => {
   const dispatch = useAppDispatch();
@@ -20,9 +29,21 @@ export const useLogout = () => {
 
   // TODO: rewrite to reset the global state data besides the data needed in LockForm (if
   // completing LockForm implementation still planned, now that auth soft-lock is present).
-  return async ({ shouldSoftLock = false } = {}) => {
+  return async ({
+    shouldSoftLock = false,
+    reason = 'manual',
+    isRemote = false,
+  }: LogoutOptions = {}) => {
+    // Sent first: teardown clears the token the session id is read from, and siblings that hear
+    // late spend the gap making requests the revoked session can only answer with a 401.
+    if (!isRemote) {
+      const sessionId = getSessionId();
+      if (sessionId) publishSessionMessage({ type: 'LOGOUT', payload: { sessionId, reason } });
+    }
+
     try {
-      await deleteAccessTokenApi();
+      // A remote logout follows the tab that already revoked the family, so asking again only 401s.
+      if (!isRemote) await deleteAccessTokenApi();
     } catch (e) {
       if ((e as AxiosError).response?.status === ApiResponseCodes.Unauthorized)
         await deleteRefreshTokenApi();

--- a/src/shared/hooks/useSessionKeepAlive/activityTracker.test.ts
+++ b/src/shared/hooks/useSessionKeepAlive/activityTracker.test.ts
@@ -1,6 +1,18 @@
 import { SessionStorageKeys } from 'shared/utils/storage';
+import { authStorage } from 'shared/utils/authStorage';
+import {
+  InMemoryBroadcastChannel,
+  resetInMemoryBroadcastChannels,
+} from 'shared/tests/InMemoryBroadcastChannel';
 
-import { getLastActivityAt, startActivityTracking, stopActivityTracking } from './activityTracker';
+import {
+  adoptActivityAt,
+  getLastActivityAt,
+  startActivityTracking,
+  stopActivityTracking,
+} from './activityTracker';
+import { closeSessionSync, subscribeSessionSync } from './sessionSync';
+import { SESSION_CHANNEL_NAME } from './sessionSync.const';
 import { ACTIVITY_EVENTS, ACTIVITY_THROTTLE_MS } from './useSessionKeepAlive.const';
 
 const storedActivity = () => sessionStorage.getItem(SessionStorageKeys.LastActivityAt);
@@ -105,5 +117,77 @@ describe('activityTracker', () => {
     sessionStorage.setItem(SessionStorageKeys.LastActivityAt, 'not-a-number');
 
     expect(getLastActivityAt()).toBeNull();
+  });
+
+  test('adopts a later timestamp but never an earlier one', () => {
+    startActivityTracking();
+    const seeded = Number(storedActivity());
+
+    adoptActivityAt(seeded - ACTIVITY_THROTTLE_MS);
+    expect(getLastActivityAt()).toBe(seeded);
+
+    adoptActivityAt(seeded + ACTIVITY_THROTTLE_MS);
+    expect(getLastActivityAt()).toBe(seeded + ACTIVITY_THROTTLE_MS);
+  });
+});
+
+describe('activityTracker broadcast', () => {
+  let onSiblingMessage: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-30T10:00:00Z'));
+    sessionStorage.clear();
+    vi.stubGlobal('BroadcastChannel', InMemoryBroadcastChannel);
+    // Stands in for this tab's engine, without which nothing is broadcast at all.
+    subscribeSessionSync(vi.fn());
+    authStorage.setRefreshToken(`header.${btoa(JSON.stringify({ family: 'family-1' }))}.signature`);
+
+    const sibling = new InMemoryBroadcastChannel(SESSION_CHANNEL_NAME);
+    onSiblingMessage = vi.fn();
+    sibling.onmessage = onSiblingMessage;
+  });
+
+  afterEach(() => {
+    stopActivityTracking();
+    closeSessionSync();
+    resetInMemoryBroadcastChannels();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  test('announces activity to sibling tabs', () => {
+    startActivityTracking();
+
+    vi.advanceTimersByTime(ACTIVITY_THROTTLE_MS + 1);
+    window.dispatchEvent(new Event('keydown'));
+
+    expect(onSiblingMessage).toHaveBeenCalledWith({
+      data: {
+        type: 'ACTIVITY',
+        payload: { sessionId: 'family-1', lastActivityAt: Date.now() },
+      },
+    });
+  });
+
+  test('announces once per throttle window, not once per event', () => {
+    startActivityTracking();
+
+    vi.advanceTimersByTime(ACTIVITY_THROTTLE_MS + 1);
+    window.dispatchEvent(new Event('mousemove'));
+    window.dispatchEvent(new Event('mousemove'));
+    window.dispatchEvent(new Event('mousemove'));
+
+    expect(onSiblingMessage).toHaveBeenCalledTimes(1);
+  });
+
+  test('announces nothing when the token carries no session id', () => {
+    authStorage.setRefreshToken('opaque-token');
+    startActivityTracking();
+
+    vi.advanceTimersByTime(ACTIVITY_THROTTLE_MS + 1);
+    window.dispatchEvent(new Event('keydown'));
+
+    expect(onSiblingMessage).not.toHaveBeenCalled();
   });
 });

--- a/src/shared/hooks/useSessionKeepAlive/activityTracker.ts
+++ b/src/shared/hooks/useSessionKeepAlive/activityTracker.ts
@@ -1,5 +1,7 @@
 import { SessionStorageKeys } from 'shared/utils/storage';
 
+import { publishSessionMessage } from './sessionSync';
+import { getSessionId } from './sessionSync.utils';
 import { ACTIVITY_EVENTS, ACTIVITY_THROTTLE_MS } from './useSessionKeepAlive.const';
 
 // Persisted rather than held in memory so a reload or a duplicated tab inherits the idle clock
@@ -12,6 +14,12 @@ export const getLastActivityAt = (): number | null => {
 
 const setLastActivityAt = (at: number) => {
   sessionStorage.setItem(SessionStorageKeys.LastActivityAt, String(at));
+};
+
+// Keeps the later of the two timestamps, so a message delayed in transit or sent by a tab whose
+// clock runs behind cannot drag the idle deadline backwards and cut the session short.
+export const adoptActivityAt = (at: number) => {
+  if (at > (getLastActivityAt() ?? 0)) setLastActivityAt(at);
 };
 
 let stopTracking: (() => void) | null = null;
@@ -28,6 +36,13 @@ export const startActivityTracking = (onActivity?: () => void) => {
 
     lastWriteAt = now;
     setLastActivityAt(now);
+
+    // Inside the throttle, so a moving mouse costs one message every few seconds, not hundreds.
+    const sessionId = getSessionId();
+    if (sessionId) {
+      publishSessionMessage({ type: 'ACTIVITY', payload: { sessionId, lastActivityAt: now } });
+    }
+
     onActivity?.();
   };
 

--- a/src/shared/hooks/useSessionKeepAlive/activityTracker.ts
+++ b/src/shared/hooks/useSessionKeepAlive/activityTracker.ts
@@ -22,6 +22,16 @@ export const adoptActivityAt = (at: number) => {
   if (at > (getLastActivityAt() ?? 0)) setLastActivityAt(at);
 };
 
+// Records activity here and announces it, so every tab of the session extends together.
+export const recordActivity = (at: number = Date.now()) => {
+  setLastActivityAt(at);
+
+  const sessionId = getSessionId();
+  if (sessionId) {
+    publishSessionMessage({ type: 'ACTIVITY', payload: { sessionId, lastActivityAt: at } });
+  }
+};
+
 let stopTracking: (() => void) | null = null;
 
 export const startActivityTracking = (onActivity?: () => void) => {
@@ -35,14 +45,8 @@ export const startActivityTracking = (onActivity?: () => void) => {
     if (now - lastWriteAt < ACTIVITY_THROTTLE_MS) return;
 
     lastWriteAt = now;
-    setLastActivityAt(now);
-
     // Inside the throttle, so a moving mouse costs one message every few seconds, not hundreds.
-    const sessionId = getSessionId();
-    if (sessionId) {
-      publishSessionMessage({ type: 'ACTIVITY', payload: { sessionId, lastActivityAt: now } });
-    }
-
+    recordActivity(now);
     onActivity?.();
   };
 

--- a/src/shared/hooks/useSessionKeepAlive/index.ts
+++ b/src/shared/hooks/useSessionKeepAlive/index.ts
@@ -3,6 +3,8 @@ export * from './sessionSync.const';
 export * from './sessionSync.types';
 export * from './sessionSync.utils';
 export * from './SessionKeepAlive';
+export * from './useSessionAdoption';
+export * from './useSessionAdoption.utils';
 export * from './useSessionKeepAlive';
 export * from './useSessionKeepAlive.const';
 export * from './useSessionKeepAlive.types';

--- a/src/shared/hooks/useSessionKeepAlive/index.ts
+++ b/src/shared/hooks/useSessionKeepAlive/index.ts
@@ -1,3 +1,7 @@
+export * from './sessionSync';
+export * from './sessionSync.const';
+export * from './sessionSync.types';
+export * from './sessionSync.utils';
 export * from './SessionKeepAlive';
 export * from './useSessionKeepAlive';
 export * from './useSessionKeepAlive.const';

--- a/src/shared/hooks/useSessionKeepAlive/sessionSync.const.ts
+++ b/src/shared/hooks/useSessionKeepAlive/sessionSync.const.ts
@@ -1,0 +1,2 @@
+// Tabs opening this name on the same origin hear each other.
+export const SESSION_CHANNEL_NAME = 'curious-admin-session';

--- a/src/shared/hooks/useSessionKeepAlive/sessionSync.const.ts
+++ b/src/shared/hooks/useSessionKeepAlive/sessionSync.const.ts
@@ -1,2 +1,5 @@
 // Tabs opening this name on the same origin hear each other.
 export const SESSION_CHANNEL_NAME = 'curious-admin-session';
+
+// How long a booting tab waits for sessions to answer before giving up and showing the login page.
+export const SESSION_REQUEST_WINDOW_MS = 300;

--- a/src/shared/hooks/useSessionKeepAlive/sessionSync.test.ts
+++ b/src/shared/hooks/useSessionKeepAlive/sessionSync.test.ts
@@ -1,0 +1,98 @@
+import {
+  InMemoryBroadcastChannel,
+  resetInMemoryBroadcastChannels,
+} from 'shared/tests/InMemoryBroadcastChannel';
+
+import { closeSessionSync, publishSessionMessage, subscribeSessionSync } from './sessionSync';
+import { SESSION_CHANNEL_NAME } from './sessionSync.const';
+import { SessionMessage } from './sessionSync.types';
+
+const message: SessionMessage = { type: 'SESSION_REQUEST' };
+
+// The module under test acts as this tab; a raw channel stands in for a second one.
+const openSiblingTab = () => new InMemoryBroadcastChannel(SESSION_CHANNEL_NAME);
+
+describe('sessionSync', () => {
+  beforeEach(() => {
+    vi.stubGlobal('BroadcastChannel', InMemoryBroadcastChannel);
+  });
+
+  afterEach(() => {
+    closeSessionSync();
+    resetInMemoryBroadcastChannels();
+    vi.unstubAllGlobals();
+  });
+
+  test('delivers a published message to another tab', () => {
+    subscribeSessionSync(vi.fn());
+    const sibling = openSiblingTab();
+    const onSiblingMessage = vi.fn();
+    sibling.onmessage = onSiblingMessage;
+
+    publishSessionMessage(message);
+
+    expect(onSiblingMessage).toHaveBeenCalledWith({ data: message });
+  });
+
+  test('stays silent while nothing in this tab is listening', () => {
+    const sibling = openSiblingTab();
+    const onSiblingMessage = vi.fn();
+    sibling.onmessage = onSiblingMessage;
+
+    publishSessionMessage(message);
+
+    expect(onSiblingMessage).not.toHaveBeenCalled();
+  });
+
+  test('does not deliver a published message back to the publisher', () => {
+    const handler = vi.fn();
+    subscribeSessionSync(handler);
+
+    publishSessionMessage(message);
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test('delivers a message from another tab to every subscriber', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    subscribeSessionSync(first);
+    subscribeSessionSync(second);
+
+    openSiblingTab().postMessage(message);
+
+    expect(first).toHaveBeenCalledWith(message);
+    expect(second).toHaveBeenCalledWith(message);
+  });
+
+  test('stops delivering once unsubscribed', () => {
+    const handler = vi.fn();
+    const unsubscribe = subscribeSessionSync(handler);
+    const sibling = openSiblingTab();
+
+    unsubscribe();
+    sibling.postMessage(message);
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test('ignores a payload that is not a session message', () => {
+    const handler = vi.fn();
+    subscribeSessionSync(handler);
+
+    openSiblingTab().postMessage({ unrelated: true });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test('does nothing when BroadcastChannel is unavailable', () => {
+    vi.stubGlobal('BroadcastChannel', undefined);
+    const handler = vi.fn();
+
+    const unsubscribe = subscribeSessionSync(handler);
+    publishSessionMessage(message);
+    unsubscribe();
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/src/shared/hooks/useSessionKeepAlive/sessionSync.ts
+++ b/src/shared/hooks/useSessionKeepAlive/sessionSync.ts
@@ -1,0 +1,44 @@
+import { SESSION_CHANNEL_NAME } from './sessionSync.const';
+import { SessionMessage, SessionMessageHandler } from './sessionSync.types';
+
+const handlers = new Set<SessionMessageHandler>();
+let channel: BroadcastChannel | null = null;
+
+// Opened on first use, so a tab that never syncs never creates one.
+const openChannel = () => {
+  if (typeof BroadcastChannel === 'undefined') return null;
+
+  if (!channel) {
+    channel = new BroadcastChannel(SESSION_CHANNEL_NAME);
+    // One onmessage slot fans out, so subscribers cannot overwrite each other.
+    channel.onmessage = ({ data }: MessageEvent<SessionMessage>) => {
+      if (!data?.type) return;
+
+      handlers.forEach((handler) => handler(data));
+    };
+  }
+
+  return channel;
+};
+
+// A tab only speaks while it is listening, so the flag-gated subscribers gate sending too.
+export const publishSessionMessage = (message: SessionMessage) => {
+  if (!handlers.size) return;
+
+  openChannel()?.postMessage(message);
+};
+
+export const subscribeSessionSync = (handler: SessionMessageHandler) => {
+  handlers.add(handler);
+  openChannel();
+
+  return () => {
+    handlers.delete(handler);
+  };
+};
+
+export const closeSessionSync = () => {
+  channel?.close();
+  channel = null;
+  handlers.clear();
+};

--- a/src/shared/hooks/useSessionKeepAlive/sessionSync.types.ts
+++ b/src/shared/hooks/useSessionKeepAlive/sessionSync.types.ts
@@ -5,11 +5,13 @@ type TokenPair = {
   refreshToken: string;
 };
 
-// Everything a tab needs to take over a session it was not signed in to itself.
+// Everything a tab needs to take over a session it was not signed in to itself, or to fall back
+// in step with one it slept through: tokens, the ordering stamps, and the true activity clock.
 export type SessionState = TokenPair & {
   sessionId: string;
   loginAt: number | null;
   rotatedAt: number | null;
+  lastActivityAt: number | null;
 };
 
 // sessionId lets a tab ignore messages belonging to another account.

--- a/src/shared/hooks/useSessionKeepAlive/sessionSync.types.ts
+++ b/src/shared/hooks/useSessionKeepAlive/sessionSync.types.ts
@@ -5,13 +5,17 @@ type TokenPair = {
   refreshToken: string;
 };
 
+// Everything a tab needs to take over a session it was not signed in to itself.
+export type SessionState = TokenPair & {
+  sessionId: string;
+  loginAt: number | null;
+  rotatedAt: number | null;
+};
+
 // sessionId lets a tab ignore messages belonging to another account.
 export type SessionMessage =
   | { type: 'SESSION_REQUEST' }
-  | {
-      type: 'SESSION_STATE';
-      payload: TokenPair & { sessionId: string; loginAt: number | null; rotatedAt: number | null };
-    }
+  | { type: 'SESSION_STATE'; payload: SessionState }
   | { type: 'TOKENS_UPDATED'; payload: TokenPair & { sessionId: string } }
   | { type: 'ACTIVITY'; payload: { sessionId: string; lastActivityAt: number } }
   | { type: 'LOGOUT'; payload: { sessionId: string; reason: LogoutReason } };

--- a/src/shared/hooks/useSessionKeepAlive/sessionSync.types.ts
+++ b/src/shared/hooks/useSessionKeepAlive/sessionSync.types.ts
@@ -1,0 +1,19 @@
+export type LogoutReason = 'manual' | 'idle' | 'refresh-failed';
+
+type TokenPair = {
+  accessToken: string;
+  refreshToken: string;
+};
+
+// sessionId lets a tab ignore messages belonging to another account.
+export type SessionMessage =
+  | { type: 'SESSION_REQUEST' }
+  | {
+      type: 'SESSION_STATE';
+      payload: TokenPair & { sessionId: string; loginAt: number | null; rotatedAt: number | null };
+    }
+  | { type: 'TOKENS_UPDATED'; payload: TokenPair & { sessionId: string } }
+  | { type: 'ACTIVITY'; payload: { sessionId: string; lastActivityAt: number } }
+  | { type: 'LOGOUT'; payload: { sessionId: string; reason: LogoutReason } };
+
+export type SessionMessageHandler = (message: SessionMessage) => void;

--- a/src/shared/hooks/useSessionKeepAlive/sessionSync.utils.test.ts
+++ b/src/shared/hooks/useSessionKeepAlive/sessionSync.utils.test.ts
@@ -1,0 +1,76 @@
+import { authStorage } from 'shared/utils/authStorage';
+
+import {
+  getLoginAt,
+  getRotatedAt,
+  getSessionId,
+  stampLoginAt,
+  stampRotatedAt,
+} from './sessionSync.utils';
+import { MS_IN_MIN } from './useSessionKeepAlive.const';
+
+const tokenWithClaims = (claims: Record<string, unknown>) =>
+  `header.${btoa(JSON.stringify(claims))}.signature`;
+
+describe('sessionSync.utils', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-30T10:00:00Z'));
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('getSessionId', () => {
+    test('prefers the family claim, which survives rotation', () => {
+      authStorage.setRefreshToken(tokenWithClaims({ family: 'family-1', jti: 'jti-1' }));
+
+      expect(getSessionId()).toBe('family-1');
+    });
+
+    test('falls back to jti when family is missing', () => {
+      authStorage.setRefreshToken(tokenWithClaims({ jti: 'jti-1' }));
+
+      expect(getSessionId()).toBe('jti-1');
+    });
+
+    test('returns null when neither claim is present', () => {
+      authStorage.setRefreshToken(tokenWithClaims({ sub: 'user-1' }));
+
+      expect(getSessionId()).toBeNull();
+    });
+
+    test('returns null without a refresh token', () => {
+      expect(getSessionId()).toBeNull();
+    });
+  });
+
+  describe('timestamps', () => {
+    test('stamps loginAt at the current time', () => {
+      stampLoginAt();
+
+      expect(getLoginAt()).toBe(Date.now());
+    });
+
+    test('stamps loginAt at an inherited time', () => {
+      const earlier = Date.now() - 20 * MS_IN_MIN;
+
+      stampLoginAt(earlier);
+
+      expect(getLoginAt()).toBe(earlier);
+    });
+
+    test('stamps rotatedAt at the current time', () => {
+      stampRotatedAt();
+
+      expect(getRotatedAt()).toBe(Date.now());
+    });
+
+    test('reads null when nothing is stamped', () => {
+      expect(getLoginAt()).toBeNull();
+      expect(getRotatedAt()).toBeNull();
+    });
+  });
+});

--- a/src/shared/hooks/useSessionKeepAlive/sessionSync.utils.ts
+++ b/src/shared/hooks/useSessionKeepAlive/sessionSync.utils.ts
@@ -1,0 +1,29 @@
+import { authStorage } from 'shared/utils/authStorage';
+import { parseJwtClaims } from 'shared/utils/jwt';
+import { SessionStorageKeys } from 'shared/utils/storage';
+
+// Rotation preserves family across refreshes; jti is the fallback until it ships.
+export const getSessionId = (): string | null => {
+  const { family, jti } = parseJwtClaims(authStorage.getRefreshToken()) ?? {};
+
+  if (typeof family === 'string' && family) return family;
+  if (typeof jti === 'string' && jti) return jti;
+
+  return null;
+};
+
+const readTimestamp = (key: SessionStorageKeys) => {
+  const stored = Number(sessionStorage.getItem(key));
+
+  return Number.isFinite(stored) && stored > 0 ? stored : null;
+};
+
+// Stamped once per sign-in, so sessions stay orderable after rotation replaces their tokens.
+export const getLoginAt = () => readTimestamp(SessionStorageKeys.LoginAt);
+export const stampLoginAt = (at: number = Date.now()) =>
+  sessionStorage.setItem(SessionStorageKeys.LoginAt, String(at));
+
+// Bumped on every rotation, so a tab can tell whether a sibling is holding fresher tokens.
+export const getRotatedAt = () => readTimestamp(SessionStorageKeys.TokensRotatedAt);
+export const stampRotatedAt = (at: number = Date.now()) =>
+  sessionStorage.setItem(SessionStorageKeys.TokensRotatedAt, String(at));

--- a/src/shared/hooks/useSessionKeepAlive/useSessionAdoption.test.ts
+++ b/src/shared/hooks/useSessionKeepAlive/useSessionAdoption.test.ts
@@ -13,6 +13,12 @@ import { SessionMessage, SessionState } from './sessionSync.types';
 import { useSessionAdoption } from './useSessionAdoption';
 import { MS_IN_MIN } from './useSessionKeepAlive.const';
 
+const refreshTokenFor = (sessionId: string) =>
+  `header.${btoa(JSON.stringify({ family: sessionId }))}.signature`;
+
+const tokenExpiringIn = (ms: number) =>
+  `header.${btoa(JSON.stringify({ exp: Math.floor((Date.now() + ms) / 1000) }))}.signature`;
+
 const session = (sessionId: string, loginAt: number): SessionState => ({
   sessionId,
   loginAt,
@@ -105,6 +111,48 @@ describe('useSessionAdoption', () => {
     expect(result.current).toBe(false);
     expect(heard).toHaveLength(0);
     expect(authStorage.getRefreshToken()).toBe('inherited-refresh');
+  });
+
+  test('a tab reloading with expired tokens takes fresher ones from its own session', () => {
+    authStorage.setRefreshToken(refreshTokenFor('family-1'));
+    authStorage.setAccessToken(tokenExpiringIn(-MS_IN_MIN));
+    const fresher = { ...session('family-1', Date.now()), rotatedAt: Date.now() };
+    openSignedInTab(fresher);
+
+    const { result } = renderHook(useSessionAdoption);
+    expect(result.current).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(SESSION_REQUEST_WINDOW_MS);
+    });
+
+    expect(result.current).toBe(false);
+    expect(authStorage.getAccessToken()).toBe('access-family-1');
+  });
+
+  test('a tab reloading with expired tokens is never switched to another account', () => {
+    authStorage.setRefreshToken(refreshTokenFor('family-1'));
+    authStorage.setAccessToken(tokenExpiringIn(-MS_IN_MIN));
+    openSignedInTab({ ...session('family-2', Date.now()), rotatedAt: Date.now() });
+
+    renderHook(useSessionAdoption);
+
+    act(() => {
+      vi.advanceTimersByTime(SESSION_REQUEST_WINDOW_MS);
+    });
+
+    expect(authStorage.getRefreshToken()).toBe(refreshTokenFor('family-1'));
+  });
+
+  test('a healthy reload never asks and is not delayed', () => {
+    authStorage.setRefreshToken(refreshTokenFor('family-1'));
+    authStorage.setAccessToken(tokenExpiringIn(MS_IN_MIN));
+    const heard = openSignedInTab(session('family-2', Date.now()));
+
+    const { result } = renderHook(useSessionAdoption);
+
+    expect(result.current).toBe(false);
+    expect(heard).toHaveLength(0);
   });
 
   test('does nothing when the flag is off', () => {

--- a/src/shared/hooks/useSessionKeepAlive/useSessionAdoption.test.ts
+++ b/src/shared/hooks/useSessionKeepAlive/useSessionAdoption.test.ts
@@ -17,6 +17,7 @@ const session = (sessionId: string, loginAt: number): SessionState => ({
   sessionId,
   loginAt,
   rotatedAt: loginAt,
+  lastActivityAt: loginAt,
   accessToken: `access-${sessionId}`,
   refreshToken: `header.${btoa(JSON.stringify({ family: sessionId }))}.signature`,
 });

--- a/src/shared/hooks/useSessionKeepAlive/useSessionAdoption.test.ts
+++ b/src/shared/hooks/useSessionKeepAlive/useSessionAdoption.test.ts
@@ -1,0 +1,118 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { authStorage } from 'shared/utils/authStorage';
+import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
+import {
+  InMemoryBroadcastChannel,
+  resetInMemoryBroadcastChannels,
+} from 'shared/tests/InMemoryBroadcastChannel';
+
+import { closeSessionSync } from './sessionSync';
+import { SESSION_CHANNEL_NAME, SESSION_REQUEST_WINDOW_MS } from './sessionSync.const';
+import { SessionMessage, SessionState } from './sessionSync.types';
+import { useSessionAdoption } from './useSessionAdoption';
+import { MS_IN_MIN } from './useSessionKeepAlive.const';
+
+const session = (sessionId: string, loginAt: number): SessionState => ({
+  sessionId,
+  loginAt,
+  rotatedAt: loginAt,
+  accessToken: `access-${sessionId}`,
+  refreshToken: `header.${btoa(JSON.stringify({ family: sessionId }))}.signature`,
+});
+
+// A signed-in tab: answers SESSION_REQUEST with its session, collects everything it hears.
+const openSignedInTab = (state: SessionState) => {
+  const channel = new InMemoryBroadcastChannel(SESSION_CHANNEL_NAME);
+  const heard: SessionMessage[] = [];
+  channel.onmessage = ({ data }) => {
+    const message = data as SessionMessage;
+    heard.push(message);
+    if (message.type === 'SESSION_REQUEST') {
+      channel.postMessage({ type: 'SESSION_STATE', payload: state });
+    }
+  };
+
+  return heard;
+};
+
+const setFlag = (enableSessionKeepAlive: boolean) =>
+  vi.mocked(useFeatureFlags).mockReturnValue({
+    featureFlags: { enableSessionKeepAlive },
+    resetLDContext: vi.fn(),
+  } as never);
+
+describe('useSessionAdoption', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-30T10:00:00Z'));
+    sessionStorage.clear();
+    vi.stubGlobal('BroadcastChannel', InMemoryBroadcastChannel);
+    setFlag(true);
+  });
+
+  afterEach(() => {
+    closeSessionSync();
+    resetInMemoryBroadcastChannels();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  test('adopts the newest of the offered sessions and announces the activity', () => {
+    openSignedInTab(session('family-1', Date.now() - 20 * MS_IN_MIN));
+    const newerTabHeard = openSignedInTab(session('family-2', Date.now()));
+
+    const { result } = renderHook(useSessionAdoption);
+    expect(result.current).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(SESSION_REQUEST_WINDOW_MS);
+    });
+
+    expect(result.current).toBe(false);
+    expect(authStorage.getAccessToken()).toBe('access-family-2');
+    expect(newerTabHeard).toContainEqual({
+      type: 'ACTIVITY',
+      payload: { sessionId: 'family-2', lastActivityAt: Date.now() },
+    });
+  });
+
+  test('settles on the login page when nobody answers, and never asks again', () => {
+    const { result } = renderHook(useSessionAdoption);
+
+    act(() => {
+      vi.advanceTimersByTime(SESSION_REQUEST_WINDOW_MS + 1);
+    });
+    expect(result.current).toBe(false);
+    expect(authStorage.getAccessToken()).toBeNull();
+
+    // A session starting later must not be adopted by a tab already sitting on the login page.
+    const heard = openSignedInTab(session('family-1', Date.now()));
+    act(() => {
+      vi.advanceTimersByTime(SESSION_REQUEST_WINDOW_MS + 1);
+    });
+    expect(heard).toHaveLength(0);
+    expect(authStorage.getAccessToken()).toBeNull();
+  });
+
+  test('a tab that already has a session never asks', () => {
+    authStorage.setRefreshToken('inherited-refresh');
+    const heard = openSignedInTab(session('family-1', Date.now()));
+
+    const { result } = renderHook(useSessionAdoption);
+
+    expect(result.current).toBe(false);
+    expect(heard).toHaveLength(0);
+    expect(authStorage.getRefreshToken()).toBe('inherited-refresh');
+  });
+
+  test('does nothing when the flag is off', () => {
+    setFlag(false);
+    const heard = openSignedInTab(session('family-1', Date.now()));
+
+    const { result } = renderHook(useSessionAdoption);
+
+    expect(result.current).toBe(false);
+    expect(heard).toHaveLength(0);
+  });
+});

--- a/src/shared/hooks/useSessionKeepAlive/useSessionAdoption.ts
+++ b/src/shared/hooks/useSessionKeepAlive/useSessionAdoption.ts
@@ -1,12 +1,32 @@
 import { useEffect, useState } from 'react';
 
 import { authStorage } from 'shared/utils/authStorage';
+import { getTokenExpiration } from 'shared/utils/jwt';
 import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 
 import { publishSessionMessage, subscribeSessionSync } from './sessionSync';
 import { SESSION_REQUEST_WINDOW_MS } from './sessionSync.const';
 import { SessionState } from './sessionSync.types';
-import { adoptSession, pickNewestSession } from './useSessionAdoption.utils';
+import {
+  adoptSession,
+  catchUpSession,
+  pickFresherSibling,
+  pickNewestSession,
+} from './useSessionAdoption.utils';
+
+// 'fresh' joins a session this tab never had; 'catch-up' rejoins one it slept through.
+type AdoptionMode = 'fresh' | 'catch-up';
+
+const resolveMode = (isEnabled: boolean): AdoptionMode | null => {
+  if (!isEnabled) return null;
+  if (!authStorage.getRefreshToken()) return 'fresh';
+
+  // A tab discarded mid-session reloads holding tokens that expired while it was gone. Asking
+  // beats letting boot spend a retired refresh token and get the whole session revoked.
+  const expiresAt = getTokenExpiration(authStorage.getAccessToken());
+
+  return expiresAt !== null && expiresAt <= Date.now() ? 'catch-up' : null;
+};
 
 // Asks the other tabs for a live session on boot and adopts the newest answer, so a fresh tab
 // lands signed in instead of on the login page. Returns true while the answer is still pending.
@@ -14,9 +34,8 @@ export const useSessionAdoption = () => {
   const { featureFlags } = useFeatureFlags();
   // Decided once, at mount: a tab that already asked and heard nothing must not ask again, or a
   // stale login page would silently join a session someone starts later.
-  const [isAdopting, setIsAdopting] = useState(
-    () => !!featureFlags.enableSessionKeepAlive && !authStorage.getRefreshToken(),
-  );
+  const [mode] = useState(() => resolveMode(!!featureFlags.enableSessionKeepAlive));
+  const [isAdopting, setIsAdopting] = useState(mode !== null);
 
   useEffect(() => {
     if (!isAdopting) return;
@@ -30,8 +49,13 @@ export const useSessionAdoption = () => {
     publishSessionMessage({ type: 'SESSION_REQUEST' });
 
     const timer = setTimeout(() => {
-      const newest = pickNewestSession(offered);
-      if (newest) adoptSession(newest);
+      if (mode === 'fresh') {
+        const newest = pickNewestSession(offered);
+        if (newest) adoptSession(newest);
+      } else {
+        const fresher = pickFresherSibling(offered);
+        if (fresher) catchUpSession(fresher);
+      }
       setIsAdopting(false);
     }, SESSION_REQUEST_WINDOW_MS);
 
@@ -39,7 +63,7 @@ export const useSessionAdoption = () => {
       clearTimeout(timer);
       unsubscribe();
     };
-  }, [isAdopting]);
+  }, [isAdopting, mode]);
 
   return isAdopting;
 };

--- a/src/shared/hooks/useSessionKeepAlive/useSessionAdoption.ts
+++ b/src/shared/hooks/useSessionKeepAlive/useSessionAdoption.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+
+import { authStorage } from 'shared/utils/authStorage';
+import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
+
+import { publishSessionMessage, subscribeSessionSync } from './sessionSync';
+import { SESSION_REQUEST_WINDOW_MS } from './sessionSync.const';
+import { SessionState } from './sessionSync.types';
+import { adoptSession, pickNewestSession } from './useSessionAdoption.utils';
+
+// Asks the other tabs for a live session on boot and adopts the newest answer, so a fresh tab
+// lands signed in instead of on the login page. Returns true while the answer is still pending.
+export const useSessionAdoption = () => {
+  const { featureFlags } = useFeatureFlags();
+  // Decided once, at mount: a tab that already asked and heard nothing must not ask again, or a
+  // stale login page would silently join a session someone starts later.
+  const [isAdopting, setIsAdopting] = useState(
+    () => !!featureFlags.enableSessionKeepAlive && !authStorage.getRefreshToken(),
+  );
+
+  useEffect(() => {
+    if (!isAdopting) return;
+
+    const offered: SessionState[] = [];
+    // Subscribing first also opens the channel, without which nothing would be published.
+    const unsubscribe = subscribeSessionSync((message) => {
+      if (message.type === 'SESSION_STATE') offered.push(message.payload);
+    });
+
+    publishSessionMessage({ type: 'SESSION_REQUEST' });
+
+    const timer = setTimeout(() => {
+      const newest = pickNewestSession(offered);
+      if (newest) adoptSession(newest);
+      setIsAdopting(false);
+    }, SESSION_REQUEST_WINDOW_MS);
+
+    return () => {
+      clearTimeout(timer);
+      unsubscribe();
+    };
+  }, [isAdopting]);
+
+  return isAdopting;
+};

--- a/src/shared/hooks/useSessionKeepAlive/useSessionAdoption.utils.test.ts
+++ b/src/shared/hooks/useSessionKeepAlive/useSessionAdoption.utils.test.ts
@@ -10,6 +10,7 @@ const session = (overrides: Partial<SessionState> = {}): SessionState => ({
   sessionId: 'family-1',
   loginAt: Date.now(),
   rotatedAt: Date.now(),
+  lastActivityAt: Date.now(),
   accessToken: 'access-1',
   refreshToken: `header.${btoa(JSON.stringify({ family: 'family-1' }))}.signature`,
   ...overrides,

--- a/src/shared/hooks/useSessionKeepAlive/useSessionAdoption.utils.test.ts
+++ b/src/shared/hooks/useSessionKeepAlive/useSessionAdoption.utils.test.ts
@@ -1,0 +1,50 @@
+import { authStorage } from 'shared/utils/authStorage';
+
+import { getLastActivityAt } from './activityTracker';
+import { SessionState } from './sessionSync.types';
+import { getLoginAt, getRotatedAt } from './sessionSync.utils';
+import { adoptSession, pickNewestSession } from './useSessionAdoption.utils';
+import { MS_IN_MIN } from './useSessionKeepAlive.const';
+
+const session = (overrides: Partial<SessionState> = {}): SessionState => ({
+  sessionId: 'family-1',
+  loginAt: Date.now(),
+  rotatedAt: Date.now(),
+  accessToken: 'access-1',
+  refreshToken: `header.${btoa(JSON.stringify({ family: 'family-1' }))}.signature`,
+  ...overrides,
+});
+
+describe('useSessionAdoption.utils', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-30T10:00:00Z'));
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('picks the most recent login, sorting undated sessions oldest', () => {
+    const undated = session({ sessionId: 'family-1', loginAt: null });
+    const older = session({ sessionId: 'family-2', loginAt: Date.now() - 20 * MS_IN_MIN });
+    const newest = session({ sessionId: 'family-3', loginAt: Date.now() });
+
+    expect(pickNewestSession([newest, undated, older])).toBe(newest);
+    expect(pickNewestSession([undated, older])).toBe(older);
+    expect(pickNewestSession([])).toBeNull();
+  });
+
+  test('stores the tokens, inherits the stamps, and counts the adoption as activity', () => {
+    const loginAt = Date.now() - 20 * MS_IN_MIN;
+    const rotatedAt = Date.now() - 5 * MS_IN_MIN;
+
+    adoptSession(session({ loginAt, rotatedAt }));
+
+    expect(authStorage.getAccessToken()).toBe('access-1');
+    expect(getLoginAt()).toBe(loginAt);
+    expect(getRotatedAt()).toBe(rotatedAt);
+    expect(getLastActivityAt()).toBe(Date.now());
+  });
+});

--- a/src/shared/hooks/useSessionKeepAlive/useSessionAdoption.utils.ts
+++ b/src/shared/hooks/useSessionKeepAlive/useSessionAdoption.utils.ts
@@ -1,0 +1,23 @@
+import { authStorage } from 'shared/utils/authStorage';
+
+import { recordActivity } from './activityTracker';
+import { SessionState } from './sessionSync.types';
+import { stampLoginAt, stampRotatedAt } from './sessionSync.utils';
+
+// Sessions that began before the flag was switched on have no stamp, so they sort oldest.
+export const pickNewestSession = (sessions: SessionState[]) =>
+  sessions.reduce<SessionState | null>(
+    (newest, session) =>
+      !newest || (session.loginAt ?? 0) > (newest.loginAt ?? 0) ? session : newest,
+    null,
+  );
+
+// loginAt is inherited, not re-stamped: the tab joins an existing session, it does not start one.
+// The tokens must land before recordActivity, which reads the session id from them.
+export const adoptSession = ({ accessToken, refreshToken, loginAt, rotatedAt }: SessionState) => {
+  authStorage.setAccessToken(accessToken);
+  authStorage.setRefreshToken(refreshToken);
+  if (loginAt) stampLoginAt(loginAt);
+  if (rotatedAt) stampRotatedAt(rotatedAt);
+  recordActivity();
+};

--- a/src/shared/hooks/useSessionKeepAlive/useSessionAdoption.utils.ts
+++ b/src/shared/hooks/useSessionKeepAlive/useSessionAdoption.utils.ts
@@ -1,8 +1,8 @@
 import { authStorage } from 'shared/utils/authStorage';
 
-import { recordActivity } from './activityTracker';
+import { adoptActivityAt, recordActivity } from './activityTracker';
 import { SessionState } from './sessionSync.types';
-import { stampLoginAt, stampRotatedAt } from './sessionSync.utils';
+import { getRotatedAt, getSessionId, stampLoginAt, stampRotatedAt } from './sessionSync.utils';
 
 // Sessions that began before the flag was switched on have no stamp, so they sort oldest.
 export const pickNewestSession = (sessions: SessionState[]) =>
@@ -20,4 +20,32 @@ export const adoptSession = ({ accessToken, refreshToken, loginAt, rotatedAt }: 
   if (loginAt) stampLoginAt(loginAt);
   if (rotatedAt) stampRotatedAt(rotatedAt);
   recordActivity();
+};
+
+// Only fresher tokens for the session this tab already belongs to. Someone else's newer login is
+// not ours to join, so a tab that has a session of its own is never switched to another.
+export const pickFresherSibling = (sessions: SessionState[]) => {
+  const mine = getSessionId();
+  const rotatedAt = getRotatedAt() ?? 0;
+
+  return (
+    sessions.find(
+      (session) => session.sessionId === mine && (session.rotatedAt ?? 0) > rotatedAt,
+    ) ?? null
+  );
+};
+
+// Rejoining a session this tab already belonged to. Unlike adoptSession it takes the sibling's
+// activity clock rather than recording new activity: coming back to a tab is not itself activity,
+// so a session that idled out while the tab was gone still ends.
+export const catchUpSession = ({
+  accessToken,
+  refreshToken,
+  rotatedAt,
+  lastActivityAt,
+}: SessionState) => {
+  authStorage.setAccessToken(accessToken);
+  authStorage.setRefreshToken(refreshToken);
+  if (rotatedAt) stampRotatedAt(rotatedAt);
+  if (lastActivityAt) adoptActivityAt(lastActivityAt);
 };

--- a/src/shared/hooks/useSessionKeepAlive/useSessionKeepAlive.test.ts
+++ b/src/shared/hooks/useSessionKeepAlive/useSessionKeepAlive.test.ts
@@ -204,6 +204,62 @@ describe('useSessionKeepAlive', () => {
     expect(authStorage.getAccessToken()).toBe(mine);
   });
 
+  test('a sibling reporting activity holds off this tab logout', () => {
+    renderEngine();
+    const sibling = new InMemoryBroadcastChannel(SESSION_CHANNEL_NAME);
+
+    act(() => {
+      vi.advanceTimersByTime(IDLE_TIMEOUT_MS - MS_IN_MIN);
+    });
+    act(() => {
+      sibling.postMessage({
+        type: 'ACTIVITY',
+        payload: { sessionId: SESSION_ID, lastActivityAt: Date.now() },
+      });
+    });
+    act(() => {
+      vi.advanceTimersByTime(2 * MS_IN_MIN);
+    });
+
+    expect(mockedLogout).not.toHaveBeenCalled();
+  });
+
+  test('ignores activity reported by another account session', () => {
+    renderEngine();
+    const sibling = new InMemoryBroadcastChannel(SESSION_CHANNEL_NAME);
+
+    act(() => {
+      vi.advanceTimersByTime(IDLE_TIMEOUT_MS - MS_IN_MIN);
+    });
+    act(() => {
+      sibling.postMessage({
+        type: 'ACTIVITY',
+        payload: { sessionId: 'family-2', lastActivityAt: Date.now() },
+      });
+    });
+    act(() => {
+      vi.advanceTimersByTime(2 * MS_IN_MIN);
+    });
+
+    expect(mockedLogout).toHaveBeenCalledWith({ shouldSoftLock: true });
+  });
+
+  test('does not rebroadcast the activity it adopted', () => {
+    renderEngine();
+    const sibling = new InMemoryBroadcastChannel(SESSION_CHANNEL_NAME);
+    const onSiblingMessage = vi.fn();
+    sibling.onmessage = onSiblingMessage;
+
+    act(() => {
+      sibling.postMessage({
+        type: 'ACTIVITY',
+        payload: { sessionId: SESSION_ID, lastActivityAt: Date.now() },
+      });
+    });
+
+    expect(onSiblingMessage).not.toHaveBeenCalled();
+  });
+
   test('does not rebroadcast the tokens it adopted', () => {
     renderEngine();
     const sibling = new InMemoryBroadcastChannel(SESSION_CHANNEL_NAME);

--- a/src/shared/hooks/useSessionKeepAlive/useSessionKeepAlive.test.ts
+++ b/src/shared/hooks/useSessionKeepAlive/useSessionKeepAlive.test.ts
@@ -292,6 +292,31 @@ describe('useSessionKeepAlive', () => {
     expect(onSiblingMessage).not.toHaveBeenCalled();
   });
 
+  test('answers a session request with its own session', () => {
+    renderEngine();
+    sessionStorage.setItem(SessionStorageKeys.LoginAt, String(Date.now() - 10 * MS_IN_MIN));
+    const sibling = new InMemoryBroadcastChannel(SESSION_CHANNEL_NAME);
+    const onSiblingMessage = vi.fn();
+    sibling.onmessage = onSiblingMessage;
+
+    act(() => {
+      sibling.postMessage({ type: 'SESSION_REQUEST' });
+    });
+
+    expect(onSiblingMessage).toHaveBeenCalledWith({
+      data: {
+        type: 'SESSION_STATE',
+        payload: {
+          sessionId: SESSION_ID,
+          loginAt: Date.now() - 10 * MS_IN_MIN,
+          rotatedAt: null,
+          accessToken: authStorage.getAccessToken(),
+          refreshToken: authStorage.getRefreshToken(),
+        },
+      },
+    });
+  });
+
   test('logs out when a sibling ends the session', () => {
     renderEngine();
     const sibling = new InMemoryBroadcastChannel(SESSION_CHANNEL_NAME);

--- a/src/shared/hooks/useSessionKeepAlive/useSessionKeepAlive.test.ts
+++ b/src/shared/hooks/useSessionKeepAlive/useSessionKeepAlive.test.ts
@@ -7,9 +7,15 @@ import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 import { useLogout } from 'shared/hooks/useLogout';
 import { renderHookWithProviders } from 'shared/utils/renderHookWithProviders';
 import { getPreloadedState } from 'shared/tests/getPreloadedState';
+import {
+  InMemoryBroadcastChannel,
+  resetInMemoryBroadcastChannels,
+} from 'shared/tests/InMemoryBroadcastChannel';
 import { state as authState } from 'modules/Auth/state/Auth.state';
 
 import { useSessionKeepAlive } from './useSessionKeepAlive';
+import { closeSessionSync, publishSessionMessage } from './sessionSync';
+import { SESSION_CHANNEL_NAME } from './sessionSync.const';
 import { MS_IN_MIN, MS_IN_SEC } from './useSessionKeepAlive.const';
 
 vi.mock('shared/api', () => ({ refreshTokens: vi.fn() }));
@@ -26,8 +32,13 @@ const IDLE_TIMEOUT_MS = 30 * MS_IN_MIN;
 const TOKEN_LIFETIME_MS = 15 * MS_IN_MIN;
 const REFRESH_LEAD_MS = 90 * MS_IN_SEC;
 
+const SESSION_ID = 'family-1';
+
 const tokenExpiringIn = (ms: number) =>
   `header.${btoa(JSON.stringify({ exp: Math.floor((Date.now() + ms) / 1000) }))}.signature`;
+
+const refreshTokenFor = (sessionId: string) =>
+  `header.${btoa(JSON.stringify({ family: sessionId }))}.signature`;
 
 const setFlag = (enableSessionKeepAlive: boolean) =>
   vi.mocked(useFeatureFlags).mockReturnValue({
@@ -47,13 +58,19 @@ describe('useSessionKeepAlive', () => {
     vi.setSystemTime(new Date('2026-07-30T10:00:00Z'));
     sessionStorage.clear();
 
+    vi.stubGlobal('BroadcastChannel', InMemoryBroadcastChannel);
+
     vi.mocked(useLogout).mockReturnValue(mockedLogout);
     mockedRefreshTokens.mockResolvedValue({ accessToken: 'a', refreshToken: 'r' });
     setFlag(true);
     authStorage.setAccessToken(tokenExpiringIn(TOKEN_LIFETIME_MS));
+    authStorage.setRefreshToken(refreshTokenFor(SESSION_ID));
   });
 
   afterEach(() => {
+    closeSessionSync();
+    resetInMemoryBroadcastChannels();
+    vi.unstubAllGlobals();
     vi.useRealTimers();
   });
 
@@ -143,17 +160,97 @@ describe('useSessionKeepAlive', () => {
     expect(mockedRefreshTokens).toHaveBeenCalledTimes(1);
   });
 
+  test('adopts tokens a sibling rotated and re-arms from them', () => {
+    renderEngine();
+    const sibling = new InMemoryBroadcastChannel(SESSION_CHANNEL_NAME);
+    const rotated = tokenExpiringIn(2 * TOKEN_LIFETIME_MS);
+
+    act(() => {
+      sibling.postMessage({
+        type: 'TOKENS_UPDATED',
+        payload: {
+          sessionId: SESSION_ID,
+          accessToken: rotated,
+          refreshToken: refreshTokenFor(SESSION_ID),
+        },
+      });
+    });
+    expect(authStorage.getAccessToken()).toBe(rotated);
+
+    // The replaced token's refresh moment passes without this tab rotating again.
+    act(() => {
+      vi.advanceTimersByTime(TOKEN_LIFETIME_MS - REFRESH_LEAD_MS + MS_IN_SEC);
+    });
+
+    expect(mockedRefreshTokens).not.toHaveBeenCalled();
+  });
+
+  test('ignores tokens rotated in another account session', () => {
+    renderEngine();
+    const sibling = new InMemoryBroadcastChannel(SESSION_CHANNEL_NAME);
+    const mine = authStorage.getAccessToken();
+
+    act(() => {
+      sibling.postMessage({
+        type: 'TOKENS_UPDATED',
+        payload: {
+          sessionId: 'family-2',
+          accessToken: 'their-access',
+          refreshToken: 'their-refresh',
+        },
+      });
+    });
+
+    expect(authStorage.getAccessToken()).toBe(mine);
+  });
+
+  test('does not rebroadcast the tokens it adopted', () => {
+    renderEngine();
+    const sibling = new InMemoryBroadcastChannel(SESSION_CHANNEL_NAME);
+    const onSiblingMessage = vi.fn();
+    sibling.onmessage = onSiblingMessage;
+
+    act(() => {
+      sibling.postMessage({
+        type: 'TOKENS_UPDATED',
+        payload: {
+          sessionId: SESSION_ID,
+          accessToken: tokenExpiringIn(TOKEN_LIFETIME_MS),
+          refreshToken: refreshTokenFor(SESSION_ID),
+        },
+      });
+    });
+
+    expect(onSiblingMessage).not.toHaveBeenCalled();
+  });
+
   test('does nothing at all when the flag is off', () => {
     setFlag(false);
     renderEngine();
+    const sibling = new InMemoryBroadcastChannel(SESSION_CHANNEL_NAME);
+    const onSiblingMessage = vi.fn();
+    sibling.onmessage = onSiblingMessage;
+    const mine = authStorage.getAccessToken();
 
     act(() => {
       vi.advanceTimersByTime(IDLE_TIMEOUT_MS * 2);
       window.dispatchEvent(new Event('keydown'));
+      publishSessionMessage({ type: 'SESSION_REQUEST' });
+      sibling.postMessage({
+        type: 'TOKENS_UPDATED',
+        payload: {
+          sessionId: SESSION_ID,
+          accessToken: 'sibling-access',
+          refreshToken: 'sibling-refresh',
+        },
+      });
     });
 
     expect(mockedRefreshTokens).not.toHaveBeenCalled();
     expect(mockedLogout).not.toHaveBeenCalled();
     expect(sessionStorage.getItem(SessionStorageKeys.LastActivityAt)).toBeNull();
+    // Neither direction: nothing published, and a sibling's message is not acted on.
+    expect(onSiblingMessage).not.toHaveBeenCalled();
+    expect(authStorage.getAccessToken()).toBe(mine);
   });
 });

--- a/src/shared/hooks/useSessionKeepAlive/useSessionKeepAlive.test.ts
+++ b/src/shared/hooks/useSessionKeepAlive/useSessionKeepAlive.test.ts
@@ -117,7 +117,11 @@ describe('useSessionKeepAlive', () => {
     act(() => {
       vi.advanceTimersByTime(2 * MS_IN_SEC);
     });
-    expect(mockedLogout).toHaveBeenCalledWith({ shouldSoftLock: true });
+    expect(mockedLogout).toHaveBeenCalledWith({
+      shouldSoftLock: true,
+      reason: 'idle',
+      isRemote: false,
+    });
   });
 
   test('activity pushes the logout deadline out', () => {
@@ -142,7 +146,11 @@ describe('useSessionKeepAlive', () => {
       vi.advanceTimersByTime(TOKEN_LIFETIME_MS - REFRESH_LEAD_MS);
     });
 
-    expect(mockedLogout).toHaveBeenCalledWith({ shouldSoftLock: true });
+    expect(mockedLogout).toHaveBeenCalledWith({
+      shouldSoftLock: true,
+      reason: 'refresh-failed',
+      isRemote: false,
+    });
   });
 
   test('caps the lead so a short-lived token does not refresh on every tick', () => {
@@ -241,7 +249,11 @@ describe('useSessionKeepAlive', () => {
       vi.advanceTimersByTime(2 * MS_IN_MIN);
     });
 
-    expect(mockedLogout).toHaveBeenCalledWith({ shouldSoftLock: true });
+    expect(mockedLogout).toHaveBeenCalledWith({
+      shouldSoftLock: true,
+      reason: 'idle',
+      isRemote: false,
+    });
   });
 
   test('does not rebroadcast the activity it adopted', () => {
@@ -278,6 +290,56 @@ describe('useSessionKeepAlive', () => {
     });
 
     expect(onSiblingMessage).not.toHaveBeenCalled();
+  });
+
+  test('logs out when a sibling ends the session', () => {
+    renderEngine();
+    const sibling = new InMemoryBroadcastChannel(SESSION_CHANNEL_NAME);
+
+    act(() => {
+      sibling.postMessage({
+        type: 'LOGOUT',
+        payload: { sessionId: SESSION_ID, reason: 'manual' },
+      });
+    });
+
+    expect(mockedLogout).toHaveBeenCalledWith({
+      shouldSoftLock: false,
+      reason: 'manual',
+      isRemote: true,
+    });
+  });
+
+  test('stays logged in when another account session ends', () => {
+    renderEngine();
+    const sibling = new InMemoryBroadcastChannel(SESSION_CHANNEL_NAME);
+
+    act(() => {
+      sibling.postMessage({
+        type: 'LOGOUT',
+        payload: { sessionId: 'family-2', reason: 'manual' },
+      });
+    });
+
+    expect(mockedLogout).not.toHaveBeenCalled();
+  });
+
+  test('soft locks when a sibling ended the session involuntarily', () => {
+    renderEngine();
+    const sibling = new InMemoryBroadcastChannel(SESSION_CHANNEL_NAME);
+
+    act(() => {
+      sibling.postMessage({
+        type: 'LOGOUT',
+        payload: { sessionId: SESSION_ID, reason: 'idle' },
+      });
+    });
+
+    expect(mockedLogout).toHaveBeenCalledWith({
+      shouldSoftLock: true,
+      reason: 'idle',
+      isRemote: true,
+    });
   });
 
   test('does nothing at all when the flag is off', () => {

--- a/src/shared/hooks/useSessionKeepAlive/useSessionKeepAlive.test.ts
+++ b/src/shared/hooks/useSessionKeepAlive/useSessionKeepAlive.test.ts
@@ -15,7 +15,8 @@ import { state as authState } from 'modules/Auth/state/Auth.state';
 
 import { useSessionKeepAlive } from './useSessionKeepAlive';
 import { closeSessionSync, publishSessionMessage } from './sessionSync';
-import { SESSION_CHANNEL_NAME } from './sessionSync.const';
+import { SESSION_CHANNEL_NAME, SESSION_REQUEST_WINDOW_MS } from './sessionSync.const';
+import { SessionMessage, SessionState } from './sessionSync.types';
 import { MS_IN_MIN, MS_IN_SEC } from './useSessionKeepAlive.const';
 
 vi.mock('shared/api', () => ({ refreshTokens: vi.fn() }));
@@ -45,6 +46,27 @@ const setFlag = (enableSessionKeepAlive: boolean) =>
     featureFlags: { enableSessionKeepAlive },
     resetLDContext: vi.fn(),
   } as never);
+
+// A sibling tab that replies to every session request with the state it is given.
+const answerSessionRequests = (state: Partial<SessionState>) => {
+  const sibling = new InMemoryBroadcastChannel(SESSION_CHANNEL_NAME);
+  sibling.onmessage = ({ data }) => {
+    if ((data as SessionMessage).type !== 'SESSION_REQUEST') return;
+
+    sibling.postMessage({
+      type: 'SESSION_STATE',
+      payload: {
+        sessionId: SESSION_ID,
+        loginAt: Date.now(),
+        rotatedAt: null,
+        lastActivityAt: null,
+        accessToken: authStorage.getAccessToken(),
+        refreshToken: authStorage.getRefreshToken(),
+        ...state,
+      },
+    });
+  };
+};
 
 const renderEngine = () =>
   renderHookWithProviders(useSessionKeepAlive, {
@@ -310,6 +332,7 @@ describe('useSessionKeepAlive', () => {
           sessionId: SESSION_ID,
           loginAt: Date.now() - 10 * MS_IN_MIN,
           rotatedAt: null,
+          lastActivityAt: Date.now(),
           accessToken: authStorage.getAccessToken(),
           refreshToken: authStorage.getRefreshToken(),
         },
@@ -364,6 +387,69 @@ describe('useSessionKeepAlive', () => {
       shouldSoftLock: true,
       reason: 'idle',
       isRemote: true,
+    });
+  });
+
+  test('adopts a sibling fresher tokens on wake instead of spending its own', () => {
+    renderEngine();
+    const rotated = tokenExpiringIn(2 * TOKEN_LIFETIME_MS);
+    answerSessionRequests({ rotatedAt: Date.now(), accessToken: rotated });
+
+    // The tab slept: the token it still holds was replaced long ago.
+    authStorage.setAccessToken(tokenExpiringIn(-MS_IN_MIN));
+    mockedRefreshTokens.mockClear();
+
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    expect(authStorage.getAccessToken()).toBe(rotated);
+
+    act(() => {
+      vi.advanceTimersByTime(SESSION_REQUEST_WINDOW_MS);
+    });
+    expect(mockedRefreshTokens).not.toHaveBeenCalled();
+  });
+
+  test('a sibling vouching for recent activity stops a stale idle logout', () => {
+    renderEngine();
+    answerSessionRequests({ lastActivityAt: Date.now() });
+
+    // The tab slept through the idle window, hearing none of the activity elsewhere.
+    sessionStorage.setItem(
+      SessionStorageKeys.LastActivityAt,
+      String(Date.now() - 2 * IDLE_TIMEOUT_MS),
+    );
+
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    act(() => {
+      vi.advanceTimersByTime(SESSION_REQUEST_WINDOW_MS);
+    });
+
+    expect(mockedLogout).not.toHaveBeenCalled();
+  });
+
+  test('waits for an answer on wake, then logs out when no sibling vouches', () => {
+    renderEngine();
+    sessionStorage.setItem(
+      SessionStorageKeys.LastActivityAt,
+      String(Date.now() - 2 * IDLE_TIMEOUT_MS),
+    );
+
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    expect(mockedLogout).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(SESSION_REQUEST_WINDOW_MS);
+    });
+
+    expect(mockedLogout).toHaveBeenCalledWith({
+      shouldSoftLock: true,
+      reason: 'idle',
+      isRemote: false,
     });
   });
 

--- a/src/shared/hooks/useSessionKeepAlive/useSessionKeepAlive.ts
+++ b/src/shared/hooks/useSessionKeepAlive/useSessionKeepAlive.ts
@@ -13,6 +13,7 @@ import {
   stopActivityTracking,
 } from './activityTracker';
 import { publishSessionMessage, subscribeSessionSync } from './sessionSync';
+import { SESSION_REQUEST_WINDOW_MS } from './sessionSync.const';
 import { LogoutReason, SessionMessage } from './sessionSync.types';
 import { getLoginAt, getRotatedAt, getSessionId, stampRotatedAt } from './sessionSync.utils';
 import { resolveSessionConfig } from './useSessionKeepAlive.utils';
@@ -34,6 +35,7 @@ export const useSessionKeepAlive = () => {
     const { idleTimeoutMs, refreshLeadMs } = resolveSessionConfig();
     let refreshTimer: ReturnType<typeof setTimeout>;
     let logoutTimer: ReturnType<typeof setTimeout>;
+    let catchUpTimer: ReturnType<typeof setTimeout>;
     let hasEnded = false;
 
     // Soft lock only for logouts nobody asked for, so a deliberate one is not undone on return.
@@ -73,7 +75,13 @@ export const useSessionKeepAlive = () => {
     };
 
     const handleVisibilityChange = () => {
-      if (document.visibilityState === 'visible') schedule();
+      if (document.visibilityState !== 'visible') return;
+
+      // Ask first and give the answer a beat: a token gone stale during sleep would otherwise
+      // refresh at zero delay, losing the race against a sibling handing over fresher ones.
+      publishSessionMessage({ type: 'SESSION_REQUEST' });
+      clearTimeout(catchUpTimer);
+      catchUpTimer = setTimeout(schedule, SESSION_REQUEST_WINDOW_MS);
     };
 
     const handleSyncMessage = (message: SessionMessage) => {
@@ -88,10 +96,30 @@ export const useSessionKeepAlive = () => {
             sessionId,
             loginAt: getLoginAt(),
             rotatedAt: getRotatedAt(),
+            lastActivityAt: getLastActivityAt(),
             accessToken: authStorage.getAccessToken(),
             refreshToken: authStorage.getRefreshToken(),
           },
         });
+
+        return;
+      }
+
+      // A sibling's answer vouches for the session: its true activity clock, and tokens that may
+      // have been replaced while this tab slept.
+      if (message.type === 'SESSION_STATE') {
+        const { sessionId, rotatedAt, lastActivityAt, accessToken, refreshToken } = message.payload;
+        if (sessionId !== getSessionId()) return;
+
+        if (lastActivityAt) adoptActivityAt(lastActivityAt);
+
+        if (rotatedAt && rotatedAt > (getRotatedAt() ?? 0)) {
+          authStorage.setAccessToken(accessToken);
+          authStorage.setRefreshToken(refreshToken);
+          stampRotatedAt(rotatedAt);
+        }
+
+        schedule();
 
         return;
       }
@@ -131,10 +159,13 @@ export const useSessionKeepAlive = () => {
     startActivityTracking(schedule);
     document.addEventListener('visibilitychange', handleVisibilityChange);
     schedule();
+    // A tab frozen past a rotation falls back in step the moment it starts, not at its next refresh.
+    publishSessionMessage({ type: 'SESSION_REQUEST' });
 
     return () => {
       clearTimeout(refreshTimer);
       clearTimeout(logoutTimer);
+      clearTimeout(catchUpTimer);
       stopActivityTracking();
       document.removeEventListener('visibilitychange', handleVisibilityChange);
       unsubscribe();

--- a/src/shared/hooks/useSessionKeepAlive/useSessionKeepAlive.ts
+++ b/src/shared/hooks/useSessionKeepAlive/useSessionKeepAlive.ts
@@ -7,6 +7,9 @@ import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 import { useLogout } from 'shared/hooks/useLogout';
 
 import { getLastActivityAt, startActivityTracking, stopActivityTracking } from './activityTracker';
+import { subscribeSessionSync } from './sessionSync';
+import { SessionMessage } from './sessionSync.types';
+import { getSessionId, stampRotatedAt } from './sessionSync.utils';
 import { resolveSessionConfig } from './useSessionKeepAlive.utils';
 
 export const useSessionKeepAlive = () => {
@@ -67,6 +70,20 @@ export const useSessionKeepAlive = () => {
       if (document.visibilityState === 'visible') schedule();
     };
 
+    // Adopting a sibling's rotation keeps this tab from spending an already-replaced token.
+    const handleSyncMessage = (message: SessionMessage) => {
+      if (message.type !== 'TOKENS_UPDATED') return;
+
+      const { sessionId, accessToken, refreshToken } = message.payload;
+      if (sessionId !== getSessionId()) return;
+
+      authStorage.setAccessToken(accessToken);
+      authStorage.setRefreshToken(refreshToken);
+      stampRotatedAt();
+      schedule();
+    };
+
+    const unsubscribe = subscribeSessionSync(handleSyncMessage);
     startActivityTracking(schedule);
     document.addEventListener('visibilitychange', handleVisibilityChange);
     schedule();
@@ -76,6 +93,7 @@ export const useSessionKeepAlive = () => {
       clearTimeout(logoutTimer);
       stopActivityTracking();
       document.removeEventListener('visibilitychange', handleVisibilityChange);
+      unsubscribe();
     };
   }, [isEnabled]);
 };

--- a/src/shared/hooks/useSessionKeepAlive/useSessionKeepAlive.ts
+++ b/src/shared/hooks/useSessionKeepAlive/useSessionKeepAlive.ts
@@ -12,9 +12,9 @@ import {
   startActivityTracking,
   stopActivityTracking,
 } from './activityTracker';
-import { subscribeSessionSync } from './sessionSync';
+import { publishSessionMessage, subscribeSessionSync } from './sessionSync';
 import { LogoutReason, SessionMessage } from './sessionSync.types';
-import { getSessionId, stampRotatedAt } from './sessionSync.utils';
+import { getLoginAt, getRotatedAt, getSessionId, stampRotatedAt } from './sessionSync.utils';
 import { resolveSessionConfig } from './useSessionKeepAlive.utils';
 
 export const useSessionKeepAlive = () => {
@@ -77,6 +77,25 @@ export const useSessionKeepAlive = () => {
     };
 
     const handleSyncMessage = (message: SessionMessage) => {
+      // Only tabs with a live session answer, which is what keeps a logged-out one silent.
+      if (message.type === 'SESSION_REQUEST') {
+        const sessionId = getSessionId();
+        if (!sessionId) return;
+
+        publishSessionMessage({
+          type: 'SESSION_STATE',
+          payload: {
+            sessionId,
+            loginAt: getLoginAt(),
+            rotatedAt: getRotatedAt(),
+            accessToken: authStorage.getAccessToken(),
+            refreshToken: authStorage.getRefreshToken(),
+          },
+        });
+
+        return;
+      }
+
       // A sibling ended the session for all of us, so tear down without revoking it again.
       if (message.type === 'LOGOUT') {
         if (message.payload.sessionId !== getSessionId()) return;

--- a/src/shared/hooks/useSessionKeepAlive/useSessionKeepAlive.ts
+++ b/src/shared/hooks/useSessionKeepAlive/useSessionKeepAlive.ts
@@ -13,7 +13,7 @@ import {
   stopActivityTracking,
 } from './activityTracker';
 import { subscribeSessionSync } from './sessionSync';
-import { SessionMessage } from './sessionSync.types';
+import { LogoutReason, SessionMessage } from './sessionSync.types';
 import { getSessionId, stampRotatedAt } from './sessionSync.utils';
 import { resolveSessionConfig } from './useSessionKeepAlive.utils';
 
@@ -36,10 +36,11 @@ export const useSessionKeepAlive = () => {
     let logoutTimer: ReturnType<typeof setTimeout>;
     let hasEnded = false;
 
-    const endSession = () => {
+    // Soft lock only for logouts nobody asked for, so a deliberate one is not undone on return.
+    const endSession = (reason: LogoutReason, isRemote = false) => {
       if (hasEnded) return;
       hasEnded = true;
-      logoutRef.current({ shouldSoftLock: true });
+      logoutRef.current({ shouldSoftLock: reason !== 'manual', reason, isRemote });
     };
 
     const schedule = () => {
@@ -49,9 +50,9 @@ export const useSessionKeepAlive = () => {
 
       const idleDeadline = (getLastActivityAt() ?? Date.now()) + idleTimeoutMs;
       const msUntilLogout = idleDeadline - Date.now();
-      if (msUntilLogout <= 0) return endSession();
+      if (msUntilLogout <= 0) return endSession('idle');
 
-      logoutTimer = setTimeout(endSession, msUntilLogout);
+      logoutTimer = setTimeout(() => endSession('idle'), msUntilLogout);
 
       // Read at decision time: another tab or an earlier refresh may have replaced the token.
       const expiresAt = getTokenExpiration(authStorage.getAccessToken());
@@ -67,7 +68,7 @@ export const useSessionKeepAlive = () => {
         await refreshTokens();
         schedule();
       } catch {
-        endSession();
+        endSession('refresh-failed');
       }
     };
 
@@ -76,6 +77,15 @@ export const useSessionKeepAlive = () => {
     };
 
     const handleSyncMessage = (message: SessionMessage) => {
+      // A sibling ended the session for all of us, so tear down without revoking it again.
+      if (message.type === 'LOGOUT') {
+        if (message.payload.sessionId !== getSessionId()) return;
+
+        endSession(message.payload.reason, true);
+
+        return;
+      }
+
       // Someone working in any tab of this session keeps every other tab from idling out.
       if (message.type === 'ACTIVITY') {
         if (message.payload.sessionId !== getSessionId()) return;

--- a/src/shared/hooks/useSessionKeepAlive/useSessionKeepAlive.ts
+++ b/src/shared/hooks/useSessionKeepAlive/useSessionKeepAlive.ts
@@ -6,7 +6,12 @@ import { authStorage, getTokenExpiration } from 'shared/utils';
 import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 import { useLogout } from 'shared/hooks/useLogout';
 
-import { getLastActivityAt, startActivityTracking, stopActivityTracking } from './activityTracker';
+import {
+  adoptActivityAt,
+  getLastActivityAt,
+  startActivityTracking,
+  stopActivityTracking,
+} from './activityTracker';
 import { subscribeSessionSync } from './sessionSync';
 import { SessionMessage } from './sessionSync.types';
 import { getSessionId, stampRotatedAt } from './sessionSync.utils';
@@ -70,8 +75,18 @@ export const useSessionKeepAlive = () => {
       if (document.visibilityState === 'visible') schedule();
     };
 
-    // Adopting a sibling's rotation keeps this tab from spending an already-replaced token.
     const handleSyncMessage = (message: SessionMessage) => {
+      // Someone working in any tab of this session keeps every other tab from idling out.
+      if (message.type === 'ACTIVITY') {
+        if (message.payload.sessionId !== getSessionId()) return;
+
+        adoptActivityAt(message.payload.lastActivityAt);
+        schedule();
+
+        return;
+      }
+
+      // Adopting a sibling's rotation keeps this tab from spending an already-replaced token.
       if (message.type !== 'TOKENS_UPDATED') return;
 
       const { sessionId, accessToken, refreshToken } = message.payload;

--- a/src/shared/tests/InMemoryBroadcastChannel.ts
+++ b/src/shared/tests/InMemoryBroadcastChannel.ts
@@ -1,0 +1,32 @@
+type MessageListener = (event: { data: unknown }) => void;
+
+const openChannels = new Map<string, Set<InMemoryBroadcastChannel>>();
+
+// Stands in for BroadcastChannel, which jsdom does not implement. Delivery is synchronous so tests
+// can assert without awaiting, and never reaches the sender, as in the real API.
+export class InMemoryBroadcastChannel {
+  onmessage: MessageListener | null = null;
+
+  private isClosed = false;
+
+  constructor(readonly name: string) {
+    const peers = openChannels.get(name) ?? new Set<InMemoryBroadcastChannel>();
+    peers.add(this);
+    openChannels.set(name, peers);
+  }
+
+  postMessage(data: unknown) {
+    if (this.isClosed) throw new Error('postMessage on a closed InMemoryBroadcastChannel');
+
+    openChannels.get(this.name)?.forEach((peer) => {
+      if (peer !== this) peer.onmessage?.({ data });
+    });
+  }
+
+  close() {
+    this.isClosed = true;
+    openChannels.get(this.name)?.delete(this);
+  }
+}
+
+export const resetInMemoryBroadcastChannels = () => openChannels.clear();

--- a/src/shared/utils/storage.ts
+++ b/src/shared/utils/storage.ts
@@ -14,6 +14,8 @@ export const enum SessionStorageKeys {
   DebugMode = 'debugMode',
   DatavizHideSkipped = 'datavizHideSkipped',
   LastActivityAt = 'lastActivityAt',
+  LoginAt = 'loginAt',
+  TokensRotatedAt = 'tokensRotatedAt',
 }
 
 export { secureLocalStorage as storage };


### PR DESCRIPTION
- [x] Tests for the changes have been added
- [ ] Delivered the `fix` or `feature` branches into `develop` or `release` branches via `Squash and Merge` (to keep clean history)

### 📝 Description

🔗 [Jira Ticket M2-11052](https://mindlogger.atlassian.net/browse/M2-11052)

Follow-up to (#2246). Each tab currently runs its own keep-alive engine and knows nothing about the others, so a backgrounded tab hits its own idle deadline and logs out and under token rotation that revokes the whole family, killing the tab actually in use. A new tab also always shows the login page even when a session is live next door.

This makes tabs of the same session talk to each other over a `BroadcastChannel`.

Changes include:

- New `sessionSync` module - one channel, and a message protocol scoped by session id (the refresh token's `family` claim, falling back to `jti`)
- Rotated tokens, activity and logout are shared between tabs of the same session
- A new tab asks for live sessions on boot and adopts the most recent one; tabs that already have a session are never switched
- A tab that was frozen or discarded catches up on wake/reload instead of spending a stale refresh token

Behaviour is unchanged while `enableSessionKeepAlive` is off - nothing is sent or received.

### 🪤 Peer Testing

**Requires the `enableSessionKeepAlive` flag on, and a backend with token rotation.**

- Sign in, then **open a second tab**

    **Expected:** lands on the dashboard, no login page

- Leave two tabs on the login page, **sign in as User 1 in one and User 2 in the other, then open a third tab**

    **Expected:** third tab is User 2; the first two are untouched and keep working as their own user

- **Log out User 2, then open a new tab**

    **Expected:** new tab is User 1 - only live sessions are offered

- **Duplicate a tab, background the duplicate, keep working in the original past the idle timeout**

    **Expected:** neither tab logs out, and only one refresh call per cycle

- **Log out manually in one tab**

    **Expected:** other tabs of that session log out too

- **Leave every tab idle past the timeout**

    **Expected:** soft-locked login page with the email pre-filled

- **Turn the flag off**

    **Expected:** new tabs show the login page, no channel traffic in either direction

### ✏️ Notes

- Stacked on `session-keep-alive`- please review with that as the base. Will rebase onto `develop` once #2246 merges.
- The flag stays off until this lands; keep-alive without tab sync is what causes the cross-tab logout.

