### PR TITLE
feat: Move tokens to local storage (M2-11055)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,6 @@ REACT_APP_DD_TRACING_URLS=http://localhost:3000
 # Session keep-alive
 REACT_APP_IDLE_TIMEOUT_MIN=30
 REACT_APP_REFRESH_LEAD_SEC=90
+
+# Encrypts local storage. Any non-empty value; changing it logs every user out.
+REACT_APP_SECURE_LOCAL_STORAGE_HASH_KEY=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,4 +75,6 @@ jobs:
       - name: Build admin app
         env:
           CI: false
+          # Compile check only, never deployed. Deploys take the real key from Secrets Manager.
+          REACT_APP_SECURE_LOCAL_STORAGE_HASH_KEY: ci-build-not-a-real-key
         run: yarn build

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ import { datadogLogs } from '@datadog/browser-logs';
 import { Mixpanel } from 'shared/utils/mixpanel';
 import { patchDOMForGoogleTranslate } from 'shared/utils/patchDOMForGoogleTranslate';
 import { migrateLegacySession } from 'shared/utils/migrateLegacySession';
+import { clearStaleSession } from 'shared/hooks/useSessionKeepAlive/clearStaleSession';
 
 import App from './App';
 import './i18n';
@@ -57,9 +58,10 @@ const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 
 Mixpanel.init();
 
-// Before render: the routes read the token while rendering, so a session still in the old store
-// has to be adopted first or the tab shows the login page and the tokens are lost on the reload.
+// Both run before render, because the routes read the token as they render.
 migrateLegacySession();
+// After the migration, so a session that just moved across is checked on its own clock.
+clearStaleSession();
 
 patchDOMForGoogleTranslate();
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@ import { datadogLogs } from '@datadog/browser-logs';
 
 import { Mixpanel } from 'shared/utils/mixpanel';
 import { patchDOMForGoogleTranslate } from 'shared/utils/patchDOMForGoogleTranslate';
+import { migrateLegacySession } from 'shared/utils/migrateLegacySession';
 
 import App from './App';
 import './i18n';
@@ -55,6 +56,10 @@ if (
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 
 Mixpanel.init();
+
+// Before render: the routes read the token while rendering, so a session still in the old store
+// has to be adopted first or the tab shows the login page and the tokens are lost on the reload.
+migrateLegacySession();
 
 patchDOMForGoogleTranslate();
 

--- a/src/modules/Auth/state/Auth.reducer.test.ts
+++ b/src/modules/Auth/state/Auth.reducer.test.ts
@@ -1,0 +1,41 @@
+import { authStorage } from 'shared/utils/authStorage';
+import {
+  getLastActivityAt,
+  setLastActivityAt,
+} from 'shared/hooks/useSessionKeepAlive/sessionStore';
+import { LocalStorageKeys, storage } from 'shared/utils/storage';
+
+import { reducers } from './Auth.reducer';
+import { state as initialState } from './Auth.state';
+import { AuthSchema } from './Auth.schema';
+
+const appletKey = 'pwd/owner-id/applet-id';
+
+describe('resetAuthorization', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  test('clears the session from every store it is spread across', () => {
+    authStorage.setAccessToken('access-token');
+    authStorage.setRefreshToken('refresh-token');
+    setLastActivityAt(Date.now());
+    sessionStorage.setItem(appletKey, 'private-key');
+
+    reducers.resetAuthorization({ ...initialState, isAuthorized: true } as AuthSchema);
+
+    expect(authStorage.getAccessToken()).toBeNull();
+    expect(authStorage.getRefreshToken()).toBeNull();
+    expect(getLastActivityAt()).toBeNull();
+    expect(sessionStorage.getItem(appletKey)).toBeNull();
+  });
+
+  test('leaves storage that is not part of the session alone', () => {
+    storage.setItem(LocalStorageKeys.Language, 'fr');
+
+    reducers.resetAuthorization({ ...initialState } as AuthSchema);
+
+    expect(storage.getItem(LocalStorageKeys.Language)).toBe('fr');
+  });
+});

--- a/src/modules/Auth/state/Auth.reducer.ts
+++ b/src/modules/Auth/state/Auth.reducer.ts
@@ -1,6 +1,8 @@
 import { ActionReducerMapBuilder, PayloadAction } from '@reduxjs/toolkit';
 
 import { ApiErrorReturn } from 'shared/state/Base';
+import { authStorage } from 'shared/utils/authStorage';
+import { clearSessionState } from 'shared/hooks/useSessionKeepAlive/sessionStore';
 
 import { AuthSchema, SoftLockData, MFASession } from './Auth.schema';
 import { signIn, getUserDetails, verifyMFATOTP, verifyMFARecoveryCode } from './Auth.thunk';
@@ -20,6 +22,10 @@ export const reducers = {
     state.isLogoutInProgress = false;
   },
   resetAuthorization: (state: AuthSchema): void => {
+    // Tokens and the idle clock now outlive the tab, so clearing sessionStorage alone would leave
+    // a signed-in session behind. sessionStorage still holds the applet private keys.
+    authStorage.clear();
+    clearSessionState();
     sessionStorage.clear();
     state.authentication = initialState.authentication;
     state.isAuthorized = false;

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,15 +1,25 @@
 import 'mock-local-storage';
 import '@testing-library/jest-dom';
-import { vi } from 'vitest';
+import { beforeEach, vi } from 'vitest';
+
+// Hoisted alongside vi.mock, which runs before this file's imports are evaluated.
+const { inMemorySecureStorage, resetInMemorySecureStorage } = await vi.hoisted(
+  () => import('./shared/tests/InMemorySecureStorage'),
+);
 
 vi.mock('react-secure-storage', () => ({
   default: {
-    setItem: vi.fn(() => Promise.resolve()),
-    getItem: vi.fn(() => Promise.resolve('')),
-    removeItem: vi.fn(() => Promise.resolve()),
-    clear: vi.fn(() => Promise.resolve()),
+    setItem: vi.fn(inMemorySecureStorage.setItem),
+    getItem: vi.fn(inMemorySecureStorage.getItem),
+    removeItem: vi.fn(inMemorySecureStorage.removeItem),
+    clear: vi.fn(inMemorySecureStorage.clear),
   },
 }));
+
+// Stored values are shared by every test in a file, so each one starts from an empty store.
+beforeEach(() => {
+  resetInMemorySecureStorage();
+});
 
 vi.mock('shared/utils/encryption', async () => ({
   __esModule: true,

--- a/src/shared/hooks/useSessionKeepAlive/activityTracker.test.ts
+++ b/src/shared/hooks/useSessionKeepAlive/activityTracker.test.ts
@@ -1,16 +1,16 @@
-import { SessionStorageKeys } from 'shared/utils/storage';
+import { PlainStorageKeys } from 'shared/utils/storage';
 
 import { startActivityTracking, stopActivityTracking } from './activityTracker';
 import { getLastActivityAt } from './sessionStore';
 import { ACTIVITY_EVENTS, ACTIVITY_THROTTLE_MS } from './useSessionKeepAlive.const';
 
-const storedActivity = () => sessionStorage.getItem(SessionStorageKeys.LastActivityAt);
+const storedActivity = () => localStorage.getItem(PlainStorageKeys.LastActivityAt);
 
 describe('activityTracker', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-07-30T10:00:00Z'));
-    sessionStorage.clear();
+    localStorage.clear();
   });
 
   afterEach(() => {
@@ -26,7 +26,7 @@ describe('activityTracker', () => {
 
   test('adopts an existing timestamp instead of resetting it', () => {
     const earlier = Date.now() - 600000;
-    sessionStorage.setItem(SessionStorageKeys.LastActivityAt, String(earlier));
+    localStorage.setItem(PlainStorageKeys.LastActivityAt, String(earlier));
 
     startActivityTracking();
 
@@ -103,7 +103,7 @@ describe('activityTracker', () => {
   });
 
   test('ignores a corrupt stored value', () => {
-    sessionStorage.setItem(SessionStorageKeys.LastActivityAt, 'not-a-number');
+    localStorage.setItem(PlainStorageKeys.LastActivityAt, 'not-a-number');
 
     expect(getLastActivityAt()).toBeNull();
   });

--- a/src/shared/hooks/useSessionKeepAlive/activityTracker.test.ts
+++ b/src/shared/hooks/useSessionKeepAlive/activityTracker.test.ts
@@ -1,6 +1,7 @@
 import { SessionStorageKeys } from 'shared/utils/storage';
 
-import { getLastActivityAt, startActivityTracking, stopActivityTracking } from './activityTracker';
+import { startActivityTracking, stopActivityTracking } from './activityTracker';
+import { getLastActivityAt } from './sessionStore';
 import { ACTIVITY_EVENTS, ACTIVITY_THROTTLE_MS } from './useSessionKeepAlive.const';
 
 const storedActivity = () => sessionStorage.getItem(SessionStorageKeys.LastActivityAt);

--- a/src/shared/hooks/useSessionKeepAlive/activityTracker.ts
+++ b/src/shared/hooks/useSessionKeepAlive/activityTracker.ts
@@ -1,18 +1,5 @@
-import { SessionStorageKeys } from 'shared/utils/storage';
-
+import { getLastActivityAt, setLastActivityAt } from './sessionStore';
 import { ACTIVITY_EVENTS, ACTIVITY_THROTTLE_MS } from './useSessionKeepAlive.const';
-
-// Persisted rather than held in memory so a reload or a duplicated tab inherits the idle clock
-// instead of being handed a fresh timeout.
-export const getLastActivityAt = (): number | null => {
-  const stored = Number(sessionStorage.getItem(SessionStorageKeys.LastActivityAt));
-
-  return Number.isFinite(stored) && stored > 0 ? stored : null;
-};
-
-const setLastActivityAt = (at: number) => {
-  sessionStorage.setItem(SessionStorageKeys.LastActivityAt, String(at));
-};
 
 let stopTracking: (() => void) | null = null;
 

--- a/src/shared/hooks/useSessionKeepAlive/clearStaleSession.test.ts
+++ b/src/shared/hooks/useSessionKeepAlive/clearStaleSession.test.ts
@@ -1,0 +1,43 @@
+import { authStorage } from 'shared/utils';
+
+import { clearStaleSession } from './clearStaleSession';
+import { getLastActivityAt, setLastActivityAt } from './sessionStore';
+import { MS_IN_MIN } from './useSessionKeepAlive.const';
+
+// Pinned so the suite does not depend on the .env a developer happens to have locally.
+vi.mock('./useSessionKeepAlive.utils', () => ({
+  resolveSessionConfig: () => ({ idleTimeoutMs: 30 * 60 * 1000, refreshLeadMs: 90 * 1000 }),
+}));
+
+const IDLE_TIMEOUT_MS = 30 * MS_IN_MIN;
+
+describe('clearStaleSession', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    authStorage.setAccessToken('access-token');
+    authStorage.setRefreshToken('refresh-token');
+  });
+
+  test('clears a session left idle past its deadline', () => {
+    setLastActivityAt(Date.now() - IDLE_TIMEOUT_MS - 1);
+
+    clearStaleSession();
+
+    expect(authStorage.getRefreshToken()).toBeNull();
+    expect(getLastActivityAt()).toBeNull();
+  });
+
+  test('keeps a session still inside the idle window', () => {
+    setLastActivityAt(Date.now() - IDLE_TIMEOUT_MS + MS_IN_MIN);
+
+    clearStaleSession();
+
+    expect(authStorage.getRefreshToken()).toBe('refresh-token');
+  });
+
+  test('leaves a session with no activity clock to the usual 401 path', () => {
+    clearStaleSession();
+
+    expect(authStorage.getRefreshToken()).toBe('refresh-token');
+  });
+});

--- a/src/shared/hooks/useSessionKeepAlive/clearStaleSession.ts
+++ b/src/shared/hooks/useSessionKeepAlive/clearStaleSession.ts
@@ -1,0 +1,18 @@
+import { authStorage } from 'shared/utils/authStorage';
+
+import { clearSessionState, getLastActivityAt } from './sessionStore';
+import { resolveSessionConfig } from './useSessionKeepAlive.utils';
+
+// A session outlives its tab now, so closing the browser no longer ends one. Without this, a
+// session left idle too long comes back on the next visit and only fails once it makes a request.
+export const clearStaleSession = () => {
+  const lastActivityAt = getLastActivityAt();
+  // No clock means the session predates this check. Leave it to the usual 401 path.
+  if (!lastActivityAt) return;
+
+  const { idleTimeoutMs } = resolveSessionConfig();
+  if (Date.now() - lastActivityAt < idleTimeoutMs) return;
+
+  authStorage.clear();
+  clearSessionState();
+};

--- a/src/shared/hooks/useSessionKeepAlive/sessionStore.ts
+++ b/src/shared/hooks/useSessionKeepAlive/sessionStore.ts
@@ -1,0 +1,18 @@
+import { SessionStorageKeys } from 'shared/utils/storage';
+
+// Persisted rather than held in memory so a reload or a duplicated tab inherits the idle clock
+// instead of being handed a fresh timeout.
+const readTimestamp = (key: SessionStorageKeys): number | null => {
+  const stored = Number(sessionStorage.getItem(key));
+
+  return Number.isFinite(stored) && stored > 0 ? stored : null;
+};
+
+const writeTimestamp = (key: SessionStorageKeys, at: number) => {
+  sessionStorage.setItem(key, String(at));
+};
+
+export const getLastActivityAt = () => readTimestamp(SessionStorageKeys.LastActivityAt);
+
+export const setLastActivityAt = (at: number) =>
+  writeTimestamp(SessionStorageKeys.LastActivityAt, at);

--- a/src/shared/hooks/useSessionKeepAlive/sessionStore.ts
+++ b/src/shared/hooks/useSessionKeepAlive/sessionStore.ts
@@ -1,18 +1,20 @@
-import { SessionStorageKeys } from 'shared/utils/storage';
+import { PlainStorageKeys } from 'shared/utils/storage';
 
-// Persisted rather than held in memory so a reload or a duplicated tab inherits the idle clock
-// instead of being handed a fresh timeout.
-const readTimestamp = (key: SessionStorageKeys): number | null => {
-  const stored = Number(sessionStorage.getItem(key));
+// Plain localStorage, not the encrypted store: a timestamp is not a secret, and every tab has to
+// be able to read the current value rather than the one it loaded with.
+const readTimestamp = (key: PlainStorageKeys): number | null => {
+  const stored = Number(localStorage.getItem(key));
 
   return Number.isFinite(stored) && stored > 0 ? stored : null;
 };
 
-const writeTimestamp = (key: SessionStorageKeys, at: number) => {
-  sessionStorage.setItem(key, String(at));
+const writeTimestamp = (key: PlainStorageKeys, at: number) => {
+  localStorage.setItem(key, String(at));
 };
 
-export const getLastActivityAt = () => readTimestamp(SessionStorageKeys.LastActivityAt);
+export const getLastActivityAt = () => readTimestamp(PlainStorageKeys.LastActivityAt);
 
 export const setLastActivityAt = (at: number) =>
-  writeTimestamp(SessionStorageKeys.LastActivityAt, at);
+  writeTimestamp(PlainStorageKeys.LastActivityAt, at);
+
+export const clearSessionState = () => localStorage.removeItem(PlainStorageKeys.LastActivityAt);

--- a/src/shared/hooks/useSessionKeepAlive/useSessionKeepAlive.test.ts
+++ b/src/shared/hooks/useSessionKeepAlive/useSessionKeepAlive.test.ts
@@ -143,7 +143,7 @@ describe('useSessionKeepAlive', () => {
     expect(mockedRefreshTokens).toHaveBeenCalledTimes(1);
   });
 
-  test('does nothing at all when the flag is off', () => {
+  test('neither refreshes nor logs out when the flag is off', () => {
     setFlag(false);
     renderEngine();
 
@@ -154,6 +154,12 @@ describe('useSessionKeepAlive', () => {
 
     expect(mockedRefreshTokens).not.toHaveBeenCalled();
     expect(mockedLogout).not.toHaveBeenCalled();
-    expect(localStorage.getItem(PlainStorageKeys.LastActivityAt)).toBeNull();
+  });
+
+  test('still records activity when the flag is off, so the boot check has a clock to read', () => {
+    setFlag(false);
+    renderEngine();
+
+    expect(localStorage.getItem(PlainStorageKeys.LastActivityAt)).toBe(String(Date.now()));
   });
 });

--- a/src/shared/hooks/useSessionKeepAlive/useSessionKeepAlive.test.ts
+++ b/src/shared/hooks/useSessionKeepAlive/useSessionKeepAlive.test.ts
@@ -2,7 +2,7 @@ import { act } from '@testing-library/react';
 
 import { refreshTokens } from 'shared/api';
 import { authStorage } from 'shared/utils';
-import { SessionStorageKeys } from 'shared/utils/storage';
+import { PlainStorageKeys } from 'shared/utils/storage';
 import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 import { useLogout } from 'shared/hooks/useLogout';
 import { renderHookWithProviders } from 'shared/utils/renderHookWithProviders';
@@ -45,7 +45,7 @@ describe('useSessionKeepAlive', () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-07-30T10:00:00Z'));
-    sessionStorage.clear();
+    localStorage.clear();
 
     vi.mocked(useLogout).mockReturnValue(mockedLogout);
     mockedRefreshTokens.mockResolvedValue({ accessToken: 'a', refreshToken: 'r' });
@@ -154,6 +154,6 @@ describe('useSessionKeepAlive', () => {
 
     expect(mockedRefreshTokens).not.toHaveBeenCalled();
     expect(mockedLogout).not.toHaveBeenCalled();
-    expect(sessionStorage.getItem(SessionStorageKeys.LastActivityAt)).toBeNull();
+    expect(localStorage.getItem(PlainStorageKeys.LastActivityAt)).toBeNull();
   });
 });

--- a/src/shared/hooks/useSessionKeepAlive/useSessionKeepAlive.ts
+++ b/src/shared/hooks/useSessionKeepAlive/useSessionKeepAlive.ts
@@ -20,6 +20,18 @@ export const useSessionKeepAlive = () => {
   logoutRef.current = logout;
 
   const isEnabled = !!featureFlags.enableSessionKeepAlive && isAuthorized;
+  // Set by the engine below, so tracking can re-arm the timers without owning them.
+  const scheduleRef = useRef<(() => void) | null>(null);
+
+  // Runs with the flag off too: a session outlives its tab now, and the boot check reads this
+  // clock to decide whether one left behind may carry on.
+  useEffect(() => {
+    if (!isAuthorized) return;
+
+    startActivityTracking(() => scheduleRef.current?.());
+
+    return stopActivityTracking;
+  }, [isAuthorized]);
 
   useEffect(() => {
     if (!isEnabled) return;
@@ -68,14 +80,14 @@ export const useSessionKeepAlive = () => {
       if (document.visibilityState === 'visible') schedule();
     };
 
-    startActivityTracking(schedule);
+    scheduleRef.current = schedule;
     document.addEventListener('visibilitychange', handleVisibilityChange);
     schedule();
 
     return () => {
       clearTimeout(refreshTimer);
       clearTimeout(logoutTimer);
-      stopActivityTracking();
+      scheduleRef.current = null;
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
   }, [isEnabled]);

--- a/src/shared/hooks/useSessionKeepAlive/useSessionKeepAlive.ts
+++ b/src/shared/hooks/useSessionKeepAlive/useSessionKeepAlive.ts
@@ -6,7 +6,8 @@ import { authStorage, getTokenExpiration } from 'shared/utils';
 import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 import { useLogout } from 'shared/hooks/useLogout';
 
-import { getLastActivityAt, startActivityTracking, stopActivityTracking } from './activityTracker';
+import { startActivityTracking, stopActivityTracking } from './activityTracker';
+import { getLastActivityAt } from './sessionStore';
 import { resolveSessionConfig } from './useSessionKeepAlive.utils';
 
 export const useSessionKeepAlive = () => {

--- a/src/shared/tests/InMemorySecureStorage.ts
+++ b/src/shared/tests/InMemorySecureStorage.ts
@@ -1,0 +1,29 @@
+type SecureStorageValue = string | number | boolean | object;
+
+const store = new Map<string, SecureStorageValue>();
+
+// Replica of react-secure-storage: reads return straight away, and values keep the type they were
+// written as. A stub that returns promises cannot stand in for that.
+export const inMemorySecureStorage = {
+  getItem: (key: string): SecureStorageValue | null => store.get(key) ?? null,
+
+  setItem: (key: string, value: SecureStorageValue | null | undefined) => {
+    if (value === null || value === undefined) {
+      store.delete(key);
+
+      return;
+    }
+
+    store.set(key, value);
+  },
+
+  removeItem: (key: string) => {
+    store.delete(key);
+  },
+
+  clear: () => {
+    store.clear();
+  },
+};
+
+export const resetInMemorySecureStorage = () => store.clear();

--- a/src/shared/utils/authStorage.ts
+++ b/src/shared/utils/authStorage.ts
@@ -1,27 +1,26 @@
 import { Workspace } from 'shared/state';
 
-import { SessionStorageKeys } from './storage';
+import { LocalStorageKeys, storage } from './storage';
 
-const set = (key: string, data: unknown) => sessionStorage.setItem(key, JSON.stringify(data));
-const get = (key: string) => {
-  const data = sessionStorage.getItem(key);
-
-  try {
-    return data ? JSON.parse(data) : null;
-  } catch {
-    return data;
-  }
-};
-const remove = (key: string) => sessionStorage.removeItem(key);
+// The secure store keeps values in the type they were written as, so nothing is stringified here.
+const getString = (key: LocalStorageKeys) => (storage.getItem(key) as string | null) ?? null;
 
 export const authStorage = {
-  getRefreshToken: () => get(SessionStorageKeys.RefreshToken),
-  getAccessToken: () => get(SessionStorageKeys.AccessToken),
-  getWorkspace: () => get(SessionStorageKeys.Workspace),
-  setRefreshToken: (token: string) => set(SessionStorageKeys.RefreshToken, token),
-  setAccessToken: (token: string) => set(SessionStorageKeys.AccessToken, token),
-  setWorkspace: (workspace: Workspace | null) => set(SessionStorageKeys.Workspace, workspace),
-  removeRefreshToken: () => remove(SessionStorageKeys.RefreshToken),
-  removeAccessToken: () => remove(SessionStorageKeys.AccessToken),
-  removeWorkspace: () => remove(SessionStorageKeys.Workspace),
+  getRefreshToken: () => getString(LocalStorageKeys.RefreshToken),
+  getAccessToken: () => getString(LocalStorageKeys.AccessToken),
+  getWorkspace: () => storage.getItem(LocalStorageKeys.Workspace) as Workspace | null,
+  setRefreshToken: (token: string) => storage.setItem(LocalStorageKeys.RefreshToken, token),
+  setAccessToken: (token: string) => storage.setItem(LocalStorageKeys.AccessToken, token),
+  setWorkspace: (workspace: Workspace | null) =>
+    storage.setItem(LocalStorageKeys.Workspace, workspace as object),
+  removeRefreshToken: () => storage.removeItem(LocalStorageKeys.RefreshToken),
+  removeAccessToken: () => storage.removeItem(LocalStorageKeys.AccessToken),
+  removeWorkspace: () => storage.removeItem(LocalStorageKeys.Workspace),
+  // Named removals rather than the store's own clear(), which wipes unrelated keys such as the
+  // chosen language and the library return path.
+  clear: () => {
+    storage.removeItem(LocalStorageKeys.RefreshToken);
+    storage.removeItem(LocalStorageKeys.AccessToken);
+    storage.removeItem(LocalStorageKeys.Workspace);
+  },
 };

--- a/src/shared/utils/migrateLegacySession.test.ts
+++ b/src/shared/utils/migrateLegacySession.test.ts
@@ -1,0 +1,53 @@
+import { getLastActivityAt } from 'shared/hooks/useSessionKeepAlive/sessionStore';
+
+import { authStorage } from './authStorage';
+import { migrateLegacySession } from './migrateLegacySession';
+
+const seedLegacySession = () => {
+  sessionStorage.setItem('accessToken', JSON.stringify('legacy-access'));
+  sessionStorage.setItem('refreshToken', JSON.stringify('legacy-refresh'));
+};
+
+describe('migrateLegacySession', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  test('adopts a session left in the old store and clears the old keys', () => {
+    seedLegacySession();
+
+    migrateLegacySession();
+
+    expect(authStorage.getAccessToken()).toBe('legacy-access');
+    expect(authStorage.getRefreshToken()).toBe('legacy-refresh');
+    expect(sessionStorage.getItem('accessToken')).toBeNull();
+    expect(sessionStorage.getItem('refreshToken')).toBeNull();
+  });
+
+  test('carries the idle clock across so the session keeps its deadline', () => {
+    const lastActivityAt = Date.now() - 60000;
+    seedLegacySession();
+    sessionStorage.setItem('lastActivityAt', String(lastActivityAt));
+
+    migrateLegacySession();
+
+    expect(getLastActivityAt()).toBe(lastActivityAt);
+  });
+
+  test('leaves a session already in the new store alone', () => {
+    authStorage.setAccessToken('current-access');
+    authStorage.setRefreshToken('current-refresh');
+    seedLegacySession();
+
+    migrateLegacySession();
+
+    expect(authStorage.getRefreshToken()).toBe('current-refresh');
+  });
+
+  test('does nothing when there is no session to migrate', () => {
+    migrateLegacySession();
+
+    expect(authStorage.getRefreshToken()).toBeNull();
+  });
+});

--- a/src/shared/utils/migrateLegacySession.ts
+++ b/src/shared/utils/migrateLegacySession.ts
@@ -1,0 +1,47 @@
+import { Workspace } from 'shared/state';
+import { setLastActivityAt } from 'shared/hooks/useSessionKeepAlive/sessionStore';
+
+import { authStorage } from './authStorage';
+
+// Sessions signed in before tokens moved to local storage sit under these keys. Without this, the
+// deploy looks like a logout to anyone who was signed in at the time.
+// Temporary: delete this file one release after shipping.
+const LEGACY_KEYS = {
+  refreshToken: 'refreshToken',
+  accessToken: 'accessToken',
+  workspace: 'workspace',
+  lastActivityAt: 'lastActivityAt',
+} as const;
+
+// The old authStorage stringified on write, so values come back wrapped and have to be unwrapped.
+const readLegacy = (key: string): unknown => {
+  const stored = sessionStorage.getItem(key);
+  if (!stored) return null;
+
+  try {
+    return JSON.parse(stored);
+  } catch {
+    return null;
+  }
+};
+
+export const migrateLegacySession = () => {
+  // A session already in the new store is by definition the newer one.
+  if (authStorage.getRefreshToken()) return;
+
+  const refreshToken = readLegacy(LEGACY_KEYS.refreshToken);
+  const accessToken = readLegacy(LEGACY_KEYS.accessToken);
+  if (typeof refreshToken !== 'string' || typeof accessToken !== 'string') return;
+
+  authStorage.setRefreshToken(refreshToken);
+  authStorage.setAccessToken(accessToken);
+
+  const workspace = readLegacy(LEGACY_KEYS.workspace);
+  if (workspace) authStorage.setWorkspace(workspace as Workspace);
+
+  // The tracker wrote this one as a bare number, never through JSON, so it is read differently.
+  const lastActivityAt = Number(sessionStorage.getItem(LEGACY_KEYS.lastActivityAt));
+  if (Number.isFinite(lastActivityAt) && lastActivityAt > 0) setLastActivityAt(lastActivityAt);
+
+  Object.values(LEGACY_KEYS).forEach((key) => sessionStorage.removeItem(key));
+};

--- a/src/shared/utils/storage.ts
+++ b/src/shared/utils/storage.ts
@@ -1,19 +1,25 @@
 import secureLocalStorage from 'react-secure-storage';
 
+// Encrypted, and shared by every tab. Reads come from a snapshot taken when the tab loaded.
 export const enum LocalStorageKeys {
   Language = 'lang',
   LibraryPreparedData = 'libraryPreparedData',
   IsFromLibrary = 'isFromLibrary',
   LibraryUrl = 'libraryPath',
-}
-
-export const enum SessionStorageKeys {
   RefreshToken = 'refreshToken',
   AccessToken = 'accessToken',
   Workspace = 'workspace',
+}
+
+// Left unencrypted on purpose: not secrets, and a tab has to read them live rather than from the
+// snapshot above.
+export const enum PlainStorageKeys {
+  LastActivityAt = 'lastActivityAt',
+}
+
+export const enum SessionStorageKeys {
   DebugMode = 'debugMode',
   DatavizHideSkipped = 'datavizHideSkipped',
-  LastActivityAt = 'lastActivityAt',
 }
 
 export { secureLocalStorage as storage };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,71 +1,90 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import react from '@vitejs/plugin-react';
 import svgr from 'vite-plugin-svgr';
 import { nodePolyfills } from 'vite-plugin-node-polyfills';
 import sourcemaps from 'rollup-plugin-sourcemaps';
 
+const SECURE_STORAGE_HASH_KEY = 'REACT_APP_SECURE_LOCAL_STORAGE_HASH_KEY';
+
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [
-    react({
-      babel: {
-        plugins: ['babel-plugin-macros'],
-      },
-    }),
-    tsconfigPaths(),
-    svgr(),
-    nodePolyfills({
-      // Whether to polyfill `node:` protocol imports.
-      protocolImports: true,
-      globals: {
-        Buffer: true,
-        process: true,
-      },
-    }),
-  ],
-  // Add custom env variable prefix configuration
-  envPrefix: 'REACT_APP_',
-  build: {
-    sourcemap: true,
-    rollupOptions: {
-      output: {
-        sourcemap: true,
-        sourcemapExcludeSources: false,
-      },
-      plugins: [sourcemaps()], // enable if deps ship external maps that aren’t picked up
-    },
-  },
-  server: {
-    port: 3000, // Match CRA's default port
-    open: true,
-  },
-  resolve: {
-    // Use tsconfig paths for module resolution
-    alias: {
-      // Add polyfill aliases
-      stream: 'stream-browserify',
-      crypto: 'crypto-browserify',
-    },
-    dedupe: ['react', 'react-dom', 'redux', '@reduxjs/toolkit'],
-  },
-  optimizeDeps: {
-    include: [
-      'react',
-      'react-dom',
-      '@reduxjs/toolkit',
-      'react-window',
-      'react-virtualized-auto-sizer',
+export default defineConfig(({ command, mode }) => {
+  const env = loadEnv(mode, process.cwd(), 'REACT_APP_');
+
+  // Left unset, react-secure-storage encrypts with a constant published inside its own npm package,
+  // identical for every application using the library.
+  if (command === 'build' && !env[SECURE_STORAGE_HASH_KEY]) {
+    throw new Error(`Missing required environment variable ${SECURE_STORAGE_HASH_KEY}`);
+  }
+
+  return {
+    plugins: [
+      react({
+        babel: {
+          plugins: ['babel-plugin-macros'],
+        },
+      }),
+      tsconfigPaths(),
+      svgr(),
+      nodePolyfills({
+        // Whether to polyfill `node:` protocol imports.
+        protocolImports: true,
+        globals: {
+          Buffer: true,
+          process: true,
+        },
+      }),
     ],
-    exclude: [],
-    esbuildOptions: {
-      // Node.js global to browser globalThis
-      define: {
-        global: 'globalThis',
+    // Add custom env variable prefix configuration
+    envPrefix: 'REACT_APP_',
+    // The library reads its key off process.env, which the browser does not have. Inlined here
+    // rather than left to the polyfill above, whose process.env is empty.
+    define: {
+      [`process.env.${SECURE_STORAGE_HASH_KEY}`]: JSON.stringify(
+        env[SECURE_STORAGE_HASH_KEY] ?? '',
+      ),
+    },
+    build: {
+      sourcemap: true,
+      rollupOptions: {
+        output: {
+          sourcemap: true,
+          sourcemapExcludeSources: false,
+        },
+        plugins: [sourcemaps()], // enable if deps ship external maps that aren’t picked up
       },
     },
-  },
-  ssr: {
-    noExternal: ['react-window', 'react-virtualized-auto-sizer'],
-  },
+    server: {
+      port: 3000, // Match CRA's default port
+      open: true,
+    },
+    resolve: {
+      // Use tsconfig paths for module resolution
+      alias: {
+        // Add polyfill aliases
+        stream: 'stream-browserify',
+        crypto: 'crypto-browserify',
+      },
+      dedupe: ['react', 'react-dom', 'redux', '@reduxjs/toolkit'],
+    },
+    optimizeDeps: {
+      include: [
+        'react',
+        'react-dom',
+        '@reduxjs/toolkit',
+        'react-window',
+        'react-virtualized-auto-sizer',
+      ],
+      exclude: [],
+      esbuildOptions: {
+        // Node.js global to browser globalThis
+        define: {
+          global: 'globalThis',
+        },
+      },
+    },
+    ssr: {
+      noExternal: ['react-window', 'react-virtualized-auto-sizer'],
+    },
+  };
 });


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-11055](https://mindlogger.atlassian.net/browse/M2-11055)

Tokens live in `sessionStorage`, which is per tab. So a new tab always shows the login page even when a session is live next door, closing the tab ends the session, and the tokens sit in DevTools as readable JWTs.

This moves them to `react-secure-storage` already a dependency, already used for language and library paths. One session per browser, shared by every tab, encrypted at rest.

Changes include:

- Tokens and workspace move to the encrypted store
- `lastActivityAt` moves to plain localStorage . it is a timestamp, not a secret, and it has to stay readable live because the encrypted store answers reads from a snapshot taken at page load
- Applet private keys stay in `sessionStorage`
- Logout clears the new locations. Today's `sessionStorage.clear()` no longer reaches the tokens, so leaving it alone would leave a signed-in session behind
- A session signed in before this ships is carried over, so the deploy is not a logout
- The idle deadline is checked at boot, because closing the browser no longer ends a session
- Activity is now tracked with the feature flag off, so that boot check has a clock to read

### 🪤 Peer Testing

- **Sign in, then open a new tab**

    **Expected outcome:** already signed in, no login page

- **Log out, check Application → Storage, then open a new tab**

    **Expected outcome:** no tokens in either store, and the new tab shows the login page

- **Change the language, log out, log back in**

    **Expected outcome:** language is preserved

- **Sign in on `develop`, switch to this branch, reload**

    **Expected outcome:** still signed in, and the old `accessToken` / `refreshToken` keys are gone from sessionStorage

- **Set `REACT_APP_IDLE_TIMEOUT_MIN=1`, quit the browser, reopen straight away**

    **Expected outcome:** still signed in

- **Let the access token expire, then click something**

    **Expected outcome:** the 401 refresh still works transparently

- **Log out from the account menu with unsaved changes in the builder**

    **Expected outcome:** the save/discard prompt still appears and the logout completes

- **Open two tabs and sign in as a different user in each**

    **Expected outcome:** they converge on one user. This is the intended change, not a bug — see Notes

### ✏️ Notes

- **Base branch is `session-keep-alive`
- **Not behind `enableSessionKeepAlive`.**- **Rolling back logs users out once.** Their tokens would be in the new store and the reverted code looks in the old one. Rolling forward is covered by the migration; rolling back is not.


### ✅ Checklist

### Functionality

- [x] The feature behaves correctly in practice and fulfills the intended business purpose
- [x] The implementation accounts for edge cases, avoids subtle logical errors, and handles somewhat rare failure states (e.g. offline mode for mobile, 3rd party being down, etc)

### Testing

- [x] Verify there are automated tests added that meaningfully cover critical behavior and failure cases
- [x] Code coverage does not go down as result of this change
- [x] Test suite passes

### Security & Data Privacy

- [x] Verify there is no chance we would accidentally log PII to application logs
- [x] Verify this addition does not materially affect our security attack surface, and if so it has undergone security review  
- [x] All inputs are sanitized
- [x] New dependencies are well maintained, have significant justification for being added to the project, and are documented in the Curious open source credit page - **no new dependencies.** `react-secure-storage` was already in use.

### Logging/Monitoring

- [ ] Logging is implemented for this change such that you could troubleshoot this feature in production - **no logging added.** Failures surface as the login page. If we want to see how often the boot check clears a session, that would need adding.
- [ ] The change/feature is able to be monitored in production - as above.

### Performance

- [x] This change does not introduce n+1 queries or other performance issues within our expected scale (e.g. missing indexes on frequently queried columns, frequently updating tables that are accessed often)

### Readability

- [x] All commented out code is removed
- [x] Debugging code including extraneous log lines are removed
- [x] Code is easy to understand through naming and structure; comments explain intent or non‑obvious decisions

### Change Safety

- [x] ~~Backend changes are backwards compatible with old clients, or it is well known they are not and a deployment/rollout plan is in place. This include backend changes being compatible with old mobile app versions, as well as applet versioning within Curious.~~
- [x] ~~Destructive database migrations are rolled out in stages. For example, renaming a column means adding a new column and migrating the existing data to that columns in one deployment. Then monitoring to ensure that field isn’t used, and finally removing that old column in a separate deployment.~~
