### PR TITLE
feat: Response options layout banner (M2-11051)

### DIFF
--- a/src/resources/app-en.json
+++ b/src/resources/app-en.json
@@ -230,7 +230,7 @@
   "alwaysAvailableWarning": "Once you set this event to always available, all scheduled events for this activity will be removed.",
   "any": "Any",
   "and": "and",
-  "announcementBanner": "<0>Two Factor Authentication is here! </0> <1>Protect your account with an extra layer of security. Enable it in your account settings. </1><2>Click to learn more.</2>",
+  "announcementBanner": "<0>Change in response options layout: </0><1>Starting September 16, response options for single and multiple select items will always display as a vertical list for all screen sizes. Please note, this change does not affect the grid arrangement for responses when the Use Portrait Layout item setting is turned on.</1>",
   "applet_one": "Applet",
   "applet_other": "Applets",
   "appletActivities": "Applet activities",

--- a/src/resources/app-fr.json
+++ b/src/resources/app-fr.json
@@ -230,7 +230,7 @@
   "alwaysAvailableWarning": "Si vous définissez cet événement comme toujours disponible, tous les événements programmés pour cette activité seront supprimés.",
   "any": "N'importe lequel",
   "and": "et",
-  "announcementBanner": "<0>L'authentification multifacteur est disponible! </0> <1>Protégez votre compte avec une couche de sécurité supplémentaire. Configurez-la dans les paramètres de votre compte. </1><2>Cliquez pour en savoir plus.</2>",
+  "announcementBanner": "<0>Changement de la disposition des options de réponse : </0><1>À partir du 16 septembre, les options de réponse des items à choix unique et à choix multiples s'afficheront toujours sous forme de liste verticale, quelle que soit la taille de l'écran. Veuillez noter que ce changement n'affecte pas la disposition en grille des réponses lorsque le paramètre d'item « Utiliser la disposition en mode portrait » est activé.</1>",
   "applet_one": "Applet",
   "applet_other": "Applets",
   "appletActivities": "Activités de l'applet",

--- a/src/shared/components/Banners/AnnouncementBanner/AnnouncementBanner.tsx
+++ b/src/shared/components/Banners/AnnouncementBanner/AnnouncementBanner.tsx
@@ -11,6 +11,9 @@ import { variables } from 'shared/styles';
 import { Banner, BannerProps } from '../Banner';
 import { StyledImg /*, StyledLink */ } from './AnnouncementBanner.styles';
 
+// Update when announcement changes, so users who dismissed previous announcement are shown the new one
+const ANNOUNCEMENT_ID = 'response-options-layout';
+
 // Update when announcement links to an article
 // const ANNOUNCEMENT_URL = 'https://...';
 
@@ -18,10 +21,11 @@ import { StyledImg /*, StyledLink */ } from './AnnouncementBanner.styles';
  * Returns a unique key for the announcement banner dismiss state
  * It creates a user-only key for use on the auth screen
  */
-export const getDismissedKey = (userId: string) => `announcement-banner-dismissed-${userId}`;
+export const getDismissedKey = (userId: string) =>
+  `announcement-banner-dismissed-${userId}-${ANNOUNCEMENT_ID}`;
 
 // Global key for anonymous users (e.g., on the login screen)
-export const GLOBAL_DISMISSED_KEY = 'announcement-banner-dismissed-global';
+export const GLOBAL_DISMISSED_KEY = `announcement-banner-dismissed-global-${ANNOUNCEMENT_ID}`;
 
 const DISPLAY_ROUTES = [/^\/auth(?:\/|$)/, /^\/dashboard\/(applets|managers|respondents)$/];
 

--- a/src/shared/components/Banners/AnnouncementBanner/AnnouncementBanner.tsx
+++ b/src/shared/components/Banners/AnnouncementBanner/AnnouncementBanner.tsx
@@ -110,8 +110,13 @@ export const AnnouncementBanner = (props: BannerProps) => {
             {...props}
           >
             <Trans i18nKey="announcementBanner">
-              <strong>We are rebranding! </strong>
-              <>Design updates are on the way — same great app, fresh new look. Curious? </>
+              <strong>Change in response options layout: </strong>
+              <>
+                Starting September 16, response options for single and multiple select items will
+                always display as a vertical list for all screen sizes. Please note, this change
+                does not affect the grid arrangement for responses when the Use Portrait Layout item
+                setting is turned on.
+              </>
               <StyledLink href={ANNOUNCEMENT_URL} target="_blank">
                 Click to learn more.
               </StyledLink>

--- a/src/shared/components/Banners/AnnouncementBanner/AnnouncementBanner.tsx
+++ b/src/shared/components/Banners/AnnouncementBanner/AnnouncementBanner.tsx
@@ -11,6 +11,9 @@ import { variables } from 'shared/styles';
 import { Banner, BannerProps } from '../Banner';
 import { StyledImg /*, StyledLink */ } from './AnnouncementBanner.styles';
 
+// Constant prefix for localStorage key
+const ANNOUNCEMENT_PREFIX = 'announcement-banner-dismissed';
+
 // Update when announcement changes, so users who dismissed previous announcement are shown the new one
 const ANNOUNCEMENT_ID = 'response-options-layout';
 
@@ -22,10 +25,19 @@ const ANNOUNCEMENT_ID = 'response-options-layout';
  * It creates a user-only key for use on the auth screen
  */
 export const getDismissedKey = (userId: string) =>
-  `announcement-banner-dismissed-${userId}-${ANNOUNCEMENT_ID}`;
+  `${ANNOUNCEMENT_PREFIX}-${userId}-${ANNOUNCEMENT_ID}`;
 
 // Global key for anonymous users (e.g., on the login screen)
-export const GLOBAL_DISMISSED_KEY = `announcement-banner-dismissed-global-${ANNOUNCEMENT_ID}`;
+export const GLOBAL_DISMISSED_KEY = `${ANNOUNCEMENT_PREFIX}-global-${ANNOUNCEMENT_ID}`;
+
+// Discards dismiss state left behind by previous announcements
+const clearStaleDismissedKeys = () => {
+  Object.keys(localStorage)
+    .filter(
+      (key) => key.startsWith(`${ANNOUNCEMENT_PREFIX}-`) && !key.endsWith(`-${ANNOUNCEMENT_ID}`),
+    )
+    .forEach((key) => localStorage.removeItem(key));
+};
 
 const DISPLAY_ROUTES = [/^\/auth(?:\/|$)/, /^\/dashboard\/(applets|managers|respondents)$/];
 
@@ -47,6 +59,8 @@ export const AnnouncementBanner = (props: BannerProps) => {
 
   useEffect(() => {
     if (!featureFlags.enableAdminAnnouncementBanner) return;
+
+    clearStaleDismissedKeys();
 
     // For auth screen or when user is not logged in yet
     if (!userId) {

--- a/src/shared/components/Banners/AnnouncementBanner/AnnouncementBanner.tsx
+++ b/src/shared/components/Banners/AnnouncementBanner/AnnouncementBanner.tsx
@@ -9,12 +9,10 @@ import { useFeatureFlags } from 'shared/hooks/useFeatureFlags';
 import { variables } from 'shared/styles';
 
 import { Banner, BannerProps } from '../Banner';
-import { StyledImg, StyledLink } from './AnnouncementBanner.styles';
+import { StyledImg /*, StyledLink */ } from './AnnouncementBanner.styles';
 
-// ─── Update this URL when the announcement changes ────────────────────────────
-const ANNOUNCEMENT_URL =
-  'https://mindlogger.atlassian.net/servicedesk/customer/portal/3/topic/ca0a323b-b88d-4b32-8f4f-4e6b0157f8f6/article/1545404417';
-// ─────────────────────────────────────────────────────────────────────────────
+// Update when announcement links to an article
+// const ANNOUNCEMENT_URL = 'https://...';
 
 /**
  * Returns a unique key for the announcement banner dismiss state
@@ -117,9 +115,9 @@ export const AnnouncementBanner = (props: BannerProps) => {
                 does not affect the grid arrangement for responses when the Use Portrait Layout item
                 setting is turned on.
               </>
-              <StyledLink href={ANNOUNCEMENT_URL} target="_blank">
+              {/* <StyledLink href={ANNOUNCEMENT_URL} target="_blank">
                 Click to learn more.
-              </StyledLink>
+              </StyledLink> */}
             </Trans>
           </Banner>
         )}


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-11051](https://mindlogger.atlassian.net/browse/M2-11051)

Changes include:

- Update announcement for response options layout
- Add `ANNOUNCEMENT_ID` to undismiss updated banner
- Comment out temporarily unused `ANNOUNCEMENT_URL`
- Clear stale announcement keys from `localStorage`

Related to ChildMindInstitute/mindlogger-web-refactor#758.

### 📸 Screenshots

#### Announcement Banner Displayed

<img width="2740" height="2060" alt="M2-11051 Response Options Layout Banner" src="https://github.com/user-attachments/assets/b109b99b-2fc4-4576-a943-5370b2d154bf" />

#### Announcement Banner Dismissed

<img width="2730" height="2050" alt="M2-11051 Response Options Layout Dismissed" src="https://github.com/user-attachments/assets/4e915347-2310-40ed-86ba-039d65865766" />

### ✅ Checklist

### Functionality

- [x] The feature behaves correctly in practice and fulfills the intended business purpose
- [x] The implementation accounts for edge cases, avoids subtle logical errors, and handles somewhat rare failure states (e.g. offline mode for mobile, 3rd party being down, etc)

### Testing

- [x] Verify there are automated tests added that meaningfully cover critical behavior and failure cases
- [x] Code coverage does not go down as result of this change
- [x] Test suite passes

### Security & Data Privacy

- [x] Verify there is no chance we would accidentally log PII to application logs
- [x] Verify this addition does not materially affect our security attack surface, and if so it has undergone security review
- [x] All inputs are sanitized
- [x] New dependencies are well maintained, have significant justification for being added to the project, and are documented in the Curious [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### Logging/Monitoring

- [x] Logging is implemented for this change such that you could troubleshoot this feature in production
- [x] The change/feature is able to be monitored in production

### Performance

- [x] This change does not introduce n+1 queries or other performance issues within our expected scale (e.g. missing indexes on frequently queried columns, frequently updating tables that are accessed often)

### Readability

- [x] All commented out code is removed
- [x] Debugging code including extraneous log lines are removed
- [x] Code is easy to understand through naming and structure; comments explain intent or non‑obvious decisions

### Change Safety

- [x] ~~Backend changes are backwards compatible with old clients, or it is well known they are not and a deployment/rollout plan is in place. This include backend changes being compatible with old mobile app versions, as well as applet versioning within Curious.~~
- [x] ~~Destructive database migrations are rolled out in stages. For example, renaming a column means adding a new column and migrating the existing data to that columns in one deployment. Then monitoring to ensure that field isn’t used, and finally removing that old column in a separate deployment.~~
